### PR TITLE
feat: Session Runtime MVP — claude/codex wrapper + wallet-encrypted sync + VSCode chat

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,3 +1,12 @@
 .idea/
 .DS_Store
 examples/
+
+# deps & build output
+node_modules/
+dist/
+*.tsbuildinfo
+
+# local runtime state (sessions, tokens, config live in ~/.agentnet)
+.agentnet/
+HANDOFF.md

--- a/package.json
+++ b/package.json
@@ -1,0 +1,23 @@
+{
+  "name": "@iqlabs-official/agent-sdk",
+  "version": "0.0.1",
+  "type": "module",
+  "private": true,
+  "scripts": {
+    "build": "tsup",
+    "test:run": "tsx scripts/test-runtime.ts"
+  },
+  "peerDependencies": {
+    "@iqlabs-official/solana-sdk": "^0.1.27",
+    "@solana/web3.js": "^1.98.0"
+  },
+  "devDependencies": {
+    "@iqlabs-official/solana-sdk": "^0.1.27",
+    "@solana/web3.js": "^1.98.0",
+    "@types/node": "^20.0.0",
+    "tsup": "^8.0.0",
+    "tsx": "^4.19.2",
+    "tweetnacl": "^1.0.3",
+    "typescript": "^5.6.0"
+  }
+}

--- a/plans/STATUS.md
+++ b/plans/STATUS.md
@@ -1,0 +1,132 @@
+# AgentNet — 진행 상황 (Status Map)
+
+> 다음 개발자를 위한 정직한 현황. **검증된 것 / 만들었지만 안 꽂은 것 / 아직 없는 것**을
+> 구분해서 적는다. 과장 없음. 코드가 실제로 무엇을 하는지 파일 단위로 설명한다.
+
+마지막 갱신: 첫 코드 PR 시점. 모든 `src/` 코드는 이 PR이 첫 커밋(이전엔 plans만 있었음).
+
+---
+
+## 1. 한눈에 — 무엇이 진짜 되나
+
+```mermaid
+flowchart TB
+    subgraph DONE["검증됨 (테스트 PASS)"]
+        ENGINE["runtime 엔진<br/>claude + codex spawn·capture·resume"]
+        CRYPTO["세션 암호화<br/>지갑서명→키, append-only 로그"]
+        STORE["저장소 4종<br/>local·icloud·custom·gdrive"]
+        UICHAT["VSCode 채팅 UI<br/>대화·세션목록·삭제·모델선택"]
+    end
+    subgraph WIRED_NOT["만들었지만 UI에 안 꽂음"]
+        ONBOARD["온보딩 플로우<br/>(login·detectCli·STORAGE_OPTIONS 다 있음)"]
+        CLOUDPICK["저장소 선택<br/>(gdrive OAuth 완성, 호출만 안 함)"]
+    end
+    subgraph MISSING["아직 없음 (부품도 없음)"]
+        PHANTOM["진짜 Phantom 지갑<br/>(지금은 가짜 키페어)"]
+        ONCHAIN["온체인 레이어<br/>스킬 NFT·평판·세션 인덱스"]
+        OTHERAPPS["다른 앱<br/>모바일·CLI 단독·웹"]
+    end
+
+    UICHAT -->|"진짜 호출"| ENGINE
+    ENGINE --> CRYPTO --> STORE
+    UICHAT -.->|"아직 가짜 지갑"| PHANTOM
+    UICHAT -.->|"안 부름"| ONBOARD
+    ONBOARD -.-> CLOUDPICK
+
+    style DONE fill:#e6ffe6,stroke:#3a3
+    style WIRED_NOT fill:#fff8e0,stroke:#cc3
+    style MISSING fill:#ffe6e6,stroke:#c33
+```
+
+**한 줄 요약:** 엔진·암호화·저장소·채팅 UI는 **진짜로 작동**한다. 빠진 건 "**진짜 신원(Phantom) + 온보딩 연결**" 한 덩어리, 그리고 그 다음의 **온체인 레이어**.
+
+---
+
+## 2. 무엇이 무엇을 하나 — 파일별 정직한 설명
+
+### 2.1 엔진 (`src/runtime/`) — 전부 작동, 스텁 없음
+
+| 파일 | 하는 일 | 상태 |
+|---|---|---|
+| `contract.ts` | 계약(인터페이스). 엔진과 모든 UI가 이것만 import. AgentRuntime, Wallet, StorageAdapter, ChatMessage 등 정의. 여기 안 바뀌면 UI/엔진 따로 작업 가능. | OK |
+| `index.ts` | createRuntime(wallet, storage) — 엔진 본체. spawn→파싱→메시지 emit→턴끝에 자동 암호화 저장. sessionId 도착 전 메시지는 큐에 쌓았다 flush. | OK |
+| `spawn.ts` | claude/codex를 각각 다른 방식으로 띄움. claude=긴 1프로세스(stdin stream-json), codex=턴마다 exec, 재개는 exec resume threadId. | OK 둘 다 |
+| `convert/claude.ts` | claude stream-json 줄 → ChatMessage. system/init=sessionId, assistant=텍스트, result=턴끝. | OK |
+| `convert/codex.ts` | codex exec --json 줄 → ChatMessage. thread.started=sessionId, item.completed=메시지, turn.completed=턴끝. | OK |
+| `convert/types.ts` | 두 파서 공통 출력형 ParseResult. | OK |
+| `detect.ts` | detectCli() — codex/claude 설치+로그인 상태 체크. 온보딩용인데 아직 UI가 안 부름. | OK(미사용) |
+
+### 2.2 신원·암호화 (`src/core/`) — 작동
+
+| 파일 | 하는 일 | 상태 |
+|---|---|---|
+| `crypto.ts` | 지갑 signMessage로 X25519 키 파생(결정적 — 같은 지갑=같은 키=어느 기기서나 복호화) → 세션 blob 암복호화. iqlabs-sdk 사용. | OK |
+| `paths.ts` | ~/.agentnet/ 로컬 경로 단일 출처. AGENTNET_HOME으로 override(테스트 격리). | OK |
+
+### 2.3 저장·세션 (`src/account/`) — 작동 (gdrive만 설정 필요)
+
+| 파일 | 하는 일 | 상태 |
+|---|---|---|
+| `sessionLog.ts` | 저장 포맷의 단일 출처. 메시지 한 개 = 암호화된 한 줄(JSONL). append-only. | OK |
+| `store.ts` | SessionStore — appendMessage(한 줄 추가)/load(복호화 재조립)/listMine/remove. | OK |
+| `login.ts` | initialize(첫 설정), login(config 읽어 storage 복원), switchStorage, logout, getStorageInfo. | OK |
+| `storage/adapter.ts` | 저장소 레지스트리. kind(local/gdrive/icloud/custom)→빌더. STORAGE_OPTIONS. | OK |
+| `storage/manual.ts` | 로컬 파일. 진짜 append. | OK |
+| `storage/icloud.ts` | iCloud Drive 폴더. 진짜 append. macOS 전용. | OK |
+| `storage/custom.ts` | 유저 HTTP 엔드포인트(S3/WebDAV). PUT/GET/DELETE. | OK |
+| `storage/gdrive.ts` | Google Drive appDataFolder. | OK 단 GOOGLE_CLIENT_ID 필요 |
+| `storage/oauth.ts` | 구글 OAuth(PKCE+자동 refresh). 토큰은 로컬만(~/.agentnet/tokens/). | OK 완성 |
+
+### 2.4 UI (`surfaces/vscode/`) — 채팅 완성, 온보딩 없음
+
+| 파일 | 하는 일 | 상태 |
+|---|---|---|
+| `extension.ts` | webview↔runtime 브릿지. 진짜 createRuntime 호출(mock 아님). 단 지갑=가짜 키페어, 저장소=로컬 고정. | 부분 |
+| `webview.ts` | 채팅 HTML/JS. 대화·세션목록·삭제·모델드롭다운·claude/codex 탭·IME·시간표시. | OK |
+
+---
+
+## 3. "UI는 됐지만 안 꽂은" 것 — 정확히 무엇
+
+부품은 다 만들어졌는데 extension.ts가 아직 안 부르는 것들:
+
+```mermaid
+flowchart LR
+    EXT["extension.ts<br/>(현재)"] -->|"지금"| FAKE["가짜 지갑 + manualStorage()"]
+    EXT -.->|"꽂아야 함"| READY["이미 만든 부품들"]
+    subgraph READY["만들어진 부품 (호출만 하면 됨)"]
+        L["login() / initialize()"]
+        D["detectCli()"]
+        S["STORAGE_OPTIONS / switchStorage()"]
+        G["gdrive OAuth (googleLogin)"]
+    end
+    style FAKE fill:#ffe6e6,stroke:#c33
+    style READY fill:#fff8e0,stroke:#cc3
+```
+
+즉 **"구현이 없다"가 아니라 "만든 걸 화면에 연결만 안 했다".** 온보딩 화면(지갑→CLI체크→저장소선택)을 짜서 위 부품을 부르면 된다.
+
+---
+
+## 4. 아직 진짜로 없는 것
+
+1. **진짜 Phantom 지갑** — 유일하게 부품조차 없음. 지금은 nacl 가짜 키페어(seed=7).
+   - 주의: 지금 저장된 세션은 가짜 키로 암호화됨. 진짜 지갑 붙이면 복호화 안 됨(키가 다름). 전환 시 테스트 세션은 버려야 함.
+2. **온체인 레이어** — 스킬 NFT, 평판(notes), mysessions 온체인 인덱스. 설계 문서(plans/)만 있고 코드 0.
+3. **다른 앱** — 모바일/CLI 단독/웹. VSCode 하나만 있음.
+4. **로컬↔클라우드 세션 중복 관리** — 지금은 한 저장소만. 병렬 사용 시 충돌 정책 미정.
+
+---
+
+## 5. 검증 방법 (직접 확인용)
+
+```bash
+pnpm install
+pnpm test:run          # 엔진: claude+codex 캡처→암호화→append→복구. PASS 떠야 정상.
+# VSCode: surfaces/vscode 열고 F5 → 채팅·세션목록·삭제 동작 확인
+```
+
+- 테스트는 임시 AGENTNET_HOME을 써서 실제 ~/.agentnet을 오염시키지 않는다.
+- gdrive 실연결만 GOOGLE_CLIENT_ID(Desktop-app) 필요. local/icloud/custom은 설정 없이 동작.
+
+다음 할 일은 [`roadmap-2tracks.md`](roadmap-2tracks.md) 참고.

--- a/plans/onboarding-ux.md
+++ b/plans/onboarding-ux.md
@@ -1,0 +1,88 @@
+# Onboarding + Model-Select + Storage UX (설계)
+
+이 세션(runtime/설계)이 정한 그림. no2(UI) / no3(storage/oauth)가 이걸 기준으로 작업.
+계약은 contract.ts (../src/runtime/contract.ts) — 새 API 필요하면 여기 먼저 합의.
+
+## 1. 첫 진입 (init/onboarding) — 순서
+```
+A. 지갑 연결 (Phantom)
+B. CLI 체크: codex / claude 설치+로그인 됐나?
+   - 둘 다 없음 -> "설치 안내" (codex/claude 설치 링크/명령)
+   - 설치됐는데 미로그인 -> "로그인 안내" (claude login / codex login)
+   - 기본 선호 = codex (없으면 claude)
+C. 저장소 선택 (init): "세션을 어디에 저장할까요?"
+   - 기기 감지: macOS면 애플(iCloud) 추천 디폴트 제시
+   - 옵션: iCloud / Google Drive / 로컬 / 커스텀
+   - 선택 -> OAuth/폴더설정 -> config.json 저장
+D. 이후 진입: config 읽어 자동 login -> 세션 목록 (다시 안 물음)
+```
+
+## 2. claude/codex = 모델 선택 (세션은 하나처럼)
+- 대화 화면 상단에 모델 드롭다운: [codex] / [claude]. 기본 codex.
+- 전환해도 같은 sessionId 유지 -> 한 대화에 codex/claude 섞여 이어짐 (런타임 이미 공유 지원).
+- startSession({cli})의 cli만 바뀜. UI가 현재 선택된 cli를 send마다 넘김.
+- 즉 "모델 고르듯" 전환, 로그는 하나.
+
+## 3. 저장소 보기 / 바꾸기
+- 내 저장소 보기: 현재 config.kind 표시 ("Google Drive에 저장 중" 등) + 실제 위치.
+- 저장소 바꾸기: 애플->구글 등. 새 kind로 initialize 재실행 -> config 교체.
+  - 기존 세션 이전? v1은 "새 저장소부터 적용"(과거는 옛 저장소). 마이그레이션은 나중.
+
+## 4. CLI 없을 때 정책 (정하기)
+- codex/claude 미설치: 앱에서 깔라고 강제 못 함 -> 안내만 (설치 명령/링크 + 설치 후 재시도 버튼).
+- 미로그인: 마찬가지로 claude/codex login 안내.
+- 둘 중 하나만 있으면 그걸 기본으로.
+
+## 5. OAuth "이미 로그인됨" 의심 → **조사 완료: 버그 아님** (no3)
+조사 결과 (`~/.agentnet/` 실제 상태):
+- `tokens/` = **없음** (OAuth 토큰 0). `config.json` = **없음** (저장소 미설정). `sessions/`만 존재.
+- 즉 OAuth는 실제로 안 돼있음. `isInitialized()`도 config 없으면 `false` 반환 — 정상.
+
+**원인:** vscode가 지금 `manualStorage()`(로컬, OAuth 불필요)로 돌아가서 "로그인 없이 바로 됨"
+처럼 보인 것. 진짜 구글 연결은 `initialize({kind:"gdrive"})`를 골라야만 토큰이 생김.
+→ 첫 사용자가 gdrive를 고르면 그때 consent가 뜸. 지금 안 뜨는 건 manual이라서지 버그 아님.
+
+## 6. 새로 필요한 contract API
+- detectCli(): { codex: "ok"|"no-login"|"missing", claude: ... } -- onboarding B단계용 (런타임 세션 담당)
+- **getStorageInfo(): { kind, location?, connected } -- ✅ 완료 (no3, src/index.ts에서 export)**
+  - "내 저장소 보기" 패널용. gdrive면 connected=토큰 유무, 나머진 설정되면 true. null=미설정.
+  - 관련 export (전부 src/index.ts): isInitialized, initialize, login/connect, switchStorage,
+    logout, currentStorageKind, getStorageInfo, STORAGE_OPTIONS. 상세 흐름은 ↓ "Storage API" 절.
+- 모델 전환: startSession이 이미 cli 받으니 추가 API 불필요 (UI가 cli 토글)
+
+---
+
+## Storage API (no3) — 화면이 호출하는 함수들
+
+자세한 흐름/머메이드는 이 절 기준. 모두 `import { ... } from "../src/index.js"`.
+
+```ts
+// 첫 진입
+if (!(await isInitialized())) {
+  const cfg = await showPicker(STORAGE_OPTIONS);     // {kind,label,needs}[]
+  await initialize(cfg, (url) => openBrowser(url));  // gdrive면 consent 뜸
+}
+const runtime = await connect(wallet);               // = login()+createRuntime()
+
+// 내 저장소 보기 (설정 패널)
+const info = await getStorageInfo();   // { kind, location?, connected } | null
+
+// 저장소 바꾸기
+const next = await switchStorage(wallet, newCfg, openBrowser);
+const runtime2 = createRuntime(next.wallet, next.storage);
+
+// 연결 해제 (이 기기의 config+구글토큰만 삭제, 원격 데이터는 그대로)
+await logout();
+```
+
+`StorageConfig = { kind:"local"|"gdrive"|"icloud"|"custom", location?, authHeader? }`
+- icloud: location=폴더(없으면 iCloud Drive/AgentNet). custom: location=base URL(+authHeader).
+- gdrive 실연결은 env `GOOGLE_CLIENT_ID`(Desktop-app) 필요. icloud/custom/local은 불필요.
+
+검증: `scripts/test-storage.ts` PASS (icloud·custom·login 저장/복구/append/중복방지).
+
+## 분담
+- 이 세션(설계/runtime): 위 contract API 추가 + 말풍선2개 버그 + onboarding 상태머신 골격.
+- no3(storage/oauth): ✅ 5번 OAuth 조사(버그 아님) + getStorageInfo + switchStorage/logout +
+  STORAGE_OPTIONS 모두 완료, src/index.ts에서 export. UI는 위 "Storage API" 절대로 호출하면 됨.
+- no2(UI): onboarding 화면(A~C) + 모델 드롭다운 + 저장소 보기/바꾸기 패널.

--- a/plans/roadmap-2tracks.md
+++ b/plans/roadmap-2tracks.md
@@ -1,0 +1,106 @@
+# AgentNet 로드맵 — 두 트랙
+
+> 현황은 [`STATUS.md`](STATUS.md). 여기는 **앞으로 할 일**을 두 갈래로 나눈다.
+> 지금까지 한 건 둘 다의 공통 토대(엔진+암호화+저장소). 이제 갈라진다.
+
+```mermaid
+flowchart TB
+    BASE["지금까지 (공통 토대)<br/>runtime 엔진 · 세션 암호화 · 저장소 4종 · VSCode 채팅"]
+    BASE --> T1["트랙 1 — 신원 & 멀티기기 세션<br/>(오프체인, 지갑 기준)"]
+    BASE --> T2["트랙 2 — 온체인 AgentNet<br/>(스킬 NFT · 평판)"]
+    T1 --> CONV["합류: 지갑 = 에이전트<br/>세션 + 스킬 + 평판이 한 지갑에"]
+    T2 --> CONV
+    style BASE fill:#e6ffe6,stroke:#3a3
+    style T1 fill:#e6f0ff,stroke:#36c
+    style T2 fill:#f0e6ff,stroke:#93c
+    style CONV fill:#fff8e0,stroke:#cc3
+```
+
+---
+
+# 트랙 1 — 지갑 신원 & 멀티기기 세션 동기화
+
+**목표:** 지갑을 연결하면, 어느 기기·어느 앱(VSCode/모바일/CLI)에서 열든 **같은 세션이
+암호화된 채로 클라우드에서 동기화**된다. "지갑 = 신원, 세션은 지갑을 따라온다."
+
+```mermaid
+flowchart LR
+    W["Phantom 지갑 연결"] --> KEY["서명 → 암호화 키<br/>(이미 됨: core/crypto)"]
+    KEY --> SESS["세션 암복호화<br/>(이미 됨)"]
+    SESS --> CLOUD["내 클라우드에 동기화<br/>(gdrive/icloud, 이미 됨)"]
+    CLOUD --> MULTI["다른 기기서 같은 지갑 → 복구"]
+    style W fill:#ffe6e6,stroke:#c33
+    style MULTI fill:#e6f0ff,stroke:#36c
+```
+
+### T1 할 일 (순서)
+
+| # | 할 일 | 왜 / 무엇 | 의존 |
+|---|---|---|---|
+| **T1-1** | **진짜 Phantom 지갑 연결** | 지금 가짜 키페어(seed=7) 대신 실제 지갑 서명. VSCode는 딥링크/외부브라우저 콜백, 모바일은 지갑앱 연동. Wallet 인터페이스(contract.ts)만 만족하면 됨 — 엔진은 안 바뀜. | 부품 없음(신규) |
+| **T1-2** | **온보딩 화면 연결** | 만들어둔 login()/detectCli()/STORAGE_OPTIONS를 UI에 꽂기: 지갑연결 → CLI체크 → 저장소선택(애플/구글/로컬/커스텀) → config 저장. | 부품 다 있음 |
+| **T1-3** | **저장소 선택을 진짜로** | 지금 manualStorage 고정 → 유저가 고른 저장소(gdrive 등)로. gdrive는 GOOGLE_CLIENT_ID 발급 필요. | 부품 다 있음 |
+| **T1-4** | **멀티기기 검증** | 기기 A에서 저장 → 기기 B에서 같은 지갑 login → 세션 복구되는지 실측. (같은 지갑=같은 키라 복호화 됨 — 설계상 됨, 실측만) | T1-1,2,3 |
+| **T1-5** | **다른 앱 만들기** | VSCode 같은 앱을 모바일/CLI단독으로. 다 같은 src/(엔진+저장소) 재사용, surface만 새로. | T1-1 |
+| **T1-6** | **로컬↔클라우드 중복 관리** | 로컬 기록 + 클라우드 기록이 겹치면 별로. 어느 게 진실인지(병렬 사용 충돌) 정책: last-write-wins(파일 ts) v1 → 나중 머지. | T1-4 |
+
+**T1 끝 그림:** zo가 폰에서 지갑 연결 → 어제 VSCode에서 한 대화가 그대로 뜨고,
+저장소에 **진짜 암호화된 세션이 이쁘게 동기화**돼 올라가 있다.
+
+---
+
+# 트랙 2 — 온체인 AgentNet (스킬 NFT · 평판)
+
+**목표:** 지갑(=에이전트)이 **스킬을 발행·검색·구매**하고, **평판(notes)**을 남긴다.
+세션이 이미 지갑에 합쳐졌으니, 다음은 **스킬과 평판이 같은 지갑에 붙는 온체인 레이어**.
+
+```mermaid
+flowchart LR
+    AG["지갑 = 에이전트"] --> SK["스킬 NFT<br/>(Token-2022 소울바운드)"]
+    SK --> PUB["발행: code-in 텍스트 + 민트"]
+    SK --> BUY["구매: 결제+민트, supply++ = 인기도"]
+    SK --> SEARCH["검색: 카테고리/해시태그 + supply 정렬"]
+    AG --> NOTE["평판 notes<br/>(온체인 쓰기, 스킬보유 게이트)"]
+    style AG fill:#f0e6ff,stroke:#93c
+    style SK fill:#f0e6ff,stroke:#93c
+```
+
+### T2 할 일 (순서) — 설계는 plans에 이미 있음
+
+| # | 할 일 | 참고 문서 | 상태 |
+|---|---|---|---|
+| **T2-1** | core/ 온체인 부분 — mysessions 등 테이블 시드 + IQLabs chain 래퍼 | [`coding-info.md`](coding-info.md) | 코드 0 |
+| **T2-2** | **스킬 NFT 발행** — code-in 텍스트 + Token-2022 민트(소울바운드) | [`skill-nft-structure.md`](skill-nft-structure.md) | 코드 0 |
+| **T2-3** | **스킬 구매** — 결제 + 민트 + supply++ (인기도) | 〃 | 코드 0 |
+| **T2-4** | **검색** — 카테고리/해시태그(트레잇) 필터 + supply 정렬 | [`search.md`](search.md) | 코드 0 |
+| **T2-5** | **평판 notes** — 온체인 쓰기, 스킬보유 게이트 | [`notes.md`](notes.md) | 코드 0 |
+| **T2-6** | **검증 게이트** — 발행 전 품질/악성 검사 | [`skill-validation-adapter.md`](skill-validation-adapter.md) | 코드 0 |
+| **T2-7** | **워크플로우 NFT** — 스킬 묶음 레시피, requiredSkills 게이트 | [`workflow-nft.md`](workflow-nft.md) | 코드 0 |
+| **T2-8** | (나중) MCP 도구로 노출 — 에이전트 자율 구매 | coding-info Step7 | 코드 0 |
+
+**T2 끝 그림:** 디자이너 에이전트(지갑)가 스킬을 사서 장착하고, 좋은 스킬엔 평판을
+남기고, 인기 스킬은 supply로 정렬돼 보인다. 세션(트랙1)과 같은 지갑에 다 모인다.
+
+---
+
+## 합류점 — 왜 두 트랙인가
+
+```mermaid
+flowchart TB
+    subgraph WALLET["하나의 지갑 = 하나의 에이전트"]
+        S["세션 (트랙1, 오프체인 암호화)"]
+        K["스킬 (트랙2, 온체인 NFT)"]
+        R["평판 (트랙2, 온체인 notes)"]
+    end
+    style WALLET fill:#fff8e0,stroke:#cc3
+```
+
+- **트랙1**(세션)은 **오프체인**(프라이버시 — 대화는 암호화, 지갑만 봄).
+- **트랙2**(스킬·평판)는 **온체인**(공개 — 사고팔고 정렬).
+- 둘 다 **같은 지갑**에 매달린다. 그래서 "지갑 연결 = 내 에이전트(세션+스킬+평판)가 통째로 따라옴".
+
+## 지금 당장의 다음 한 수
+
+**트랙1의 T1-1 (진짜 Phantom 지갑)** 이 다음 큰 갈림길.
+이게 되면 T1-2~4(온보딩·저장소·멀티기기)가 줄줄이 풀린다 (부품 다 있으니).
+트랙2는 트랙1과 **독립**이라 병렬 가능 — 온체인 코드는 세션과 안 겹친다.

--- a/plans/test-plan.md
+++ b/plans/test-plan.md
@@ -1,0 +1,56 @@
+# Integration Test Plan — wallet → claude/codex wrapper → encrypted synced sessions
+
+3개 세션(runtime / vscode UI / storage)이 `contract.ts`로 합쳐진 뒤, 통합 동작을
+레이어별로 검증한다. 각 단계는 **이전 단계가 통과해야** 다음으로 간다 (bottom-up).
+
+## L0 — 이미 통과한 단위 (회귀 확인용)
+- `pnpm test:run` (runtime): claude+codex 캡처 → append 암호화 → 복구, 공유 세션 grow. ✅
+- `pnpm test:storage` (storage): icloud/custom put+append+restore, login 플로우. ✅
+- vscode `pnpm build` + F5(mock 제거 후 real): 패널 오픈, 세션목록, 입력. ✅(빌드)
+
+## L1 — 런타임 통합 (CLI 실물, 로컬 저장)
+| # | 검증 | 방법 | 기대 |
+|---|---|---|---|
+| 1.1 | claude 1턴 캡처+저장 | test:run | assistant 메시지 .log에 암호화 저장 |
+| 1.2 | codex 1턴 캡처+저장 | test:run | 〃 |
+| 1.3 | 같은 세션 append | test:run turn2 | msgs 2→4, 파일 1개 (중복X) |
+| 1.4 | 껐다 켜기 복구 | 새 SessionStore.load | 메시지 순서대로 재조립 |
+
+## L2 — 저장소 교체 (manual → cloud)
+| # | 검증 | 방법 | 기대 |
+|---|---|---|---|
+| 2.1 | icloud 폴더 저장 | initialize({kind:"icloud"}) → 세션 | iCloud Drive 경로에 .log |
+| 2.2 | custom HTTP 저장 | initialize({kind:"custom"}) | 유저 엔드포인트에 PUT |
+| 2.3 | gdrive (ID 발급 후) | GOOGLE_CLIENT_ID + initialize gdrive | appDataFolder 업로드 |
+| 2.4 | 저장소 바꿔도 같은 세션 | config 교체 후 load | 복호화 동일 (지갑키 동일) |
+
+## L3 — VSCode UI 통합 (눈으로)
+| # | 검증 | 방법 | 기대 |
+|---|---|---|---|
+| 3.1 | 패널에서 실제 claude 대화 | F5 → 입력 | 진짜 claude 응답이 버블에 |
+| 3.2 | 세션 목록 = 저장된 것 | 좌측 목록 | listSessions가 .log들 반영 |
+| 3.3 | 세션 클릭 → resume | 목록 클릭 | 그 세션 이어서 대화 |
+| 3.4 | 새 세션 → 별도 파일 | + New | 새 sessionId .log 추가 |
+
+## L4 — 동기화 (끝목표: 기기·CLI 가로질러)
+| # | 검증 | 방법 | 기대 |
+|---|---|---|---|
+| 4.1 | claude→codex 공유 | 같은 sessionId로 codex resume | claude 대화를 codex가 이어봄 |
+| 4.2 | 기기 A→B (클라우드) | A에서 저장 → B에서 같은 지갑 login → load | B에서 세션 복구 |
+| 4.3 | 같은 지갑 = 같은 복호화 | 다른 머신 deriveSessionKey | 동일 키로 복호화 성공 |
+
+## L5 — 보안/엣지 (놓치기 쉬운 것)
+- 다른 지갑으로 복호화 시도 → 실패해야 (남의 세션 못 봄)
+- 동시 2턴 append 레이스 → 순서 안 깨지나
+- CLI 비로그인/크래시 → 깔끔히 에러 (멈춤 X)
+- 큰 세션(수백 메시지) append 성능 / load 시간
+- OAuth 토큰은 로컬만 (우리 서버 0) 재확인
+
+## 실행 순서
+L1(지금 가능) → L3(F5, 지금 가능) → L2 cloud(icloud/custom 지금, gdrive는 ID 후)
+→ L4 동기화 → L5 보안. 각 통과 시 체크.
+
+## 미해결 (테스트가 드러낼 것)
+- claude `--resume`이 우리가 만든 sessionId를 항상 찾나 (claude 내부 세션과 우리 id 매핑)
+- codex `exec resume`의 thread 영속 위치 (CODEX_HOME) 가 우리 저장과 별개로 쌓이는지
+- partial(타이핑 델타)은 아직 미구현 — UI는 완성단위로 받음 (나중 채움)

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -1,0 +1,1752 @@
+lockfileVersion: '9.0'
+
+settings:
+  autoInstallPeers: true
+  excludeLinksFromLockfile: false
+
+importers:
+
+  .:
+    devDependencies:
+      '@iqlabs-official/solana-sdk':
+        specifier: ^0.1.27
+        version: 0.1.27(bufferutil@4.1.0)(typescript@5.9.3)(utf-8-validate@6.0.6)
+      '@solana/web3.js':
+        specifier: ^1.98.0
+        version: 1.98.4(bufferutil@4.1.0)(typescript@5.9.3)(utf-8-validate@6.0.6)
+      '@types/node':
+        specifier: ^20.0.0
+        version: 20.19.42
+      tsup:
+        specifier: ^8.0.0
+        version: 8.5.1(tsx@4.22.4)(typescript@5.9.3)
+      tsx:
+        specifier: ^4.19.2
+        version: 4.22.4
+      tweetnacl:
+        specifier: ^1.0.3
+        version: 1.0.3
+      typescript:
+        specifier: ^5.6.0
+        version: 5.9.3
+
+packages:
+
+  '@babel/runtime@7.29.7':
+    resolution: {integrity: sha512-Nq8OhGWiZIZGV6hLHoyAKLLcJihP/xFeBMGJoUrxTX2psI8dCifzLhZISFb+VWS3wFMRDmCGw5R+dOySCqPLhw==}
+    engines: {node: '>=6.9.0'}
+
+  '@coral-xyz/anchor-errors@0.31.1':
+    resolution: {integrity: sha512-NhNEku4F3zzUSBtrYz84FzYWm48+9OvmT1Hhnwr6GnPQry2dsEqH/ti/7ASjjpoFTWRnPXrjAIT1qM6Isop+LQ==}
+    engines: {node: '>=10'}
+
+  '@coral-xyz/anchor@0.32.1':
+    resolution: {integrity: sha512-zAyxFtfeje2FbMA1wzgcdVs7Hng/MijPKpRijoySPCicnvcTQs/+dnPZ/cR+LcXM9v9UYSyW81uRNYZtN5G4yg==}
+    engines: {node: '>=17'}
+
+  '@coral-xyz/borsh@0.31.1':
+    resolution: {integrity: sha512-9N8AU9F0ubriKfNE3g1WF0/4dtlGXoBN/hd1PvbNBamBNwRgHxH4P+o3Zt7rSEloW1HUs6LfZEchlx9fW7POYw==}
+    engines: {node: '>=10'}
+    peerDependencies:
+      '@solana/web3.js': ^1.69.0
+
+  '@esbuild/aix-ppc64@0.27.7':
+    resolution: {integrity: sha512-EKX3Qwmhz1eMdEJokhALr0YiD0lhQNwDqkPYyPhiSwKrh7/4KRjQc04sZ8db+5DVVnZ1LmbNDI1uAMPEUBnQPg==}
+    engines: {node: '>=18'}
+    cpu: [ppc64]
+    os: [aix]
+
+  '@esbuild/aix-ppc64@0.28.0':
+    resolution: {integrity: sha512-lhRUCeuOyJQURhTxl4WkpFTjIsbDayJHih5kZC1giwE+MhIzAb7mEsQMqMf18rHLsrb5qI1tafG20mLxEWcWlA==}
+    engines: {node: '>=18'}
+    cpu: [ppc64]
+    os: [aix]
+
+  '@esbuild/android-arm64@0.27.7':
+    resolution: {integrity: sha512-62dPZHpIXzvChfvfLJow3q5dDtiNMkwiRzPylSCfriLvZeq0a1bWChrGx/BbUbPwOrsWKMn8idSllklzBy+dgQ==}
+    engines: {node: '>=18'}
+    cpu: [arm64]
+    os: [android]
+
+  '@esbuild/android-arm64@0.28.0':
+    resolution: {integrity: sha512-+WzIXQOSaGs33tLEgYPYe/yQHf0WTU0X42Jca3y8NWMbUVhp7rUnw+vAsRC/QiDrdD31IszMrZy+qwPOPjd+rw==}
+    engines: {node: '>=18'}
+    cpu: [arm64]
+    os: [android]
+
+  '@esbuild/android-arm@0.27.7':
+    resolution: {integrity: sha512-jbPXvB4Yj2yBV7HUfE2KHe4GJX51QplCN1pGbYjvsyCZbQmies29EoJbkEc+vYuU5o45AfQn37vZlyXy4YJ8RQ==}
+    engines: {node: '>=18'}
+    cpu: [arm]
+    os: [android]
+
+  '@esbuild/android-arm@0.28.0':
+    resolution: {integrity: sha512-wqh0ByljabXLKHeWXYLqoJ5jKC4XBaw6Hk08OfMrCRd2nP2ZQ5eleDZC41XHyCNgktBGYMbqnrJKq/K/lzPMSQ==}
+    engines: {node: '>=18'}
+    cpu: [arm]
+    os: [android]
+
+  '@esbuild/android-x64@0.27.7':
+    resolution: {integrity: sha512-x5VpMODneVDb70PYV2VQOmIUUiBtY3D3mPBG8NxVk5CogneYhkR7MmM3yR/uMdITLrC1ml/NV1rj4bMJuy9MCg==}
+    engines: {node: '>=18'}
+    cpu: [x64]
+    os: [android]
+
+  '@esbuild/android-x64@0.28.0':
+    resolution: {integrity: sha512-+VJggoaKhk2VNNqVL7f6S189UzShHC/mR9EE8rDdSkdpN0KflSwWY/gWjDrNxxisg8Fp1ZCD9jLMo4m0OUfeUA==}
+    engines: {node: '>=18'}
+    cpu: [x64]
+    os: [android]
+
+  '@esbuild/darwin-arm64@0.27.7':
+    resolution: {integrity: sha512-5lckdqeuBPlKUwvoCXIgI2D9/ABmPq3Rdp7IfL70393YgaASt7tbju3Ac+ePVi3KDH6N2RqePfHnXkaDtY9fkw==}
+    engines: {node: '>=18'}
+    cpu: [arm64]
+    os: [darwin]
+
+  '@esbuild/darwin-arm64@0.28.0':
+    resolution: {integrity: sha512-0T+A9WZm+bZ84nZBtk1ckYsOvyA3x7e2Acj1KdVfV4/2tdG4fzUp91YHx+GArWLtwqp77pBXVCPn2We7Letr0Q==}
+    engines: {node: '>=18'}
+    cpu: [arm64]
+    os: [darwin]
+
+  '@esbuild/darwin-x64@0.27.7':
+    resolution: {integrity: sha512-rYnXrKcXuT7Z+WL5K980jVFdvVKhCHhUwid+dDYQpH+qu+TefcomiMAJpIiC2EM3Rjtq0sO3StMV/+3w3MyyqQ==}
+    engines: {node: '>=18'}
+    cpu: [x64]
+    os: [darwin]
+
+  '@esbuild/darwin-x64@0.28.0':
+    resolution: {integrity: sha512-fyzLm/DLDl/84OCfp2f/XQ4flmORsjU7VKt8HLjvIXChJoFFOIL6pLJPH4Yhd1n1gGFF9mPwtlN5Wf82DZs+LQ==}
+    engines: {node: '>=18'}
+    cpu: [x64]
+    os: [darwin]
+
+  '@esbuild/freebsd-arm64@0.27.7':
+    resolution: {integrity: sha512-B48PqeCsEgOtzME2GbNM2roU29AMTuOIN91dsMO30t+Ydis3z/3Ngoj5hhnsOSSwNzS+6JppqWsuhTp6E82l2w==}
+    engines: {node: '>=18'}
+    cpu: [arm64]
+    os: [freebsd]
+
+  '@esbuild/freebsd-arm64@0.28.0':
+    resolution: {integrity: sha512-l9GeW5UZBT9k9brBYI+0WDffcRxgHQD8ShN2Ur4xWq/NFzUKm3k5lsH4PdaRgb2w7mI9u61nr2gI2mLI27Nh3Q==}
+    engines: {node: '>=18'}
+    cpu: [arm64]
+    os: [freebsd]
+
+  '@esbuild/freebsd-x64@0.27.7':
+    resolution: {integrity: sha512-jOBDK5XEjA4m5IJK3bpAQF9/Lelu/Z9ZcdhTRLf4cajlB+8VEhFFRjWgfy3M1O4rO2GQ/b2dLwCUGpiF/eATNQ==}
+    engines: {node: '>=18'}
+    cpu: [x64]
+    os: [freebsd]
+
+  '@esbuild/freebsd-x64@0.28.0':
+    resolution: {integrity: sha512-BXoQai/A0wPO6Es3yFJ7APCiKGc1tdAEOgeTNy3SsB491S3aHn4S4r3e976eUnPdU+NbdtmBuLncYir2tMU9Nw==}
+    engines: {node: '>=18'}
+    cpu: [x64]
+    os: [freebsd]
+
+  '@esbuild/linux-arm64@0.27.7':
+    resolution: {integrity: sha512-RZPHBoxXuNnPQO9rvjh5jdkRmVizktkT7TCDkDmQ0W2SwHInKCAV95GRuvdSvA7w4VMwfCjUiPwDi0ZO6Nfe9A==}
+    engines: {node: '>=18'}
+    cpu: [arm64]
+    os: [linux]
+
+  '@esbuild/linux-arm64@0.28.0':
+    resolution: {integrity: sha512-RVyzfb3FWsGA55n6WY0MEIEPURL1FcbhFE6BffZEMEekfCzCIMtB5yyDcFnVbTnwk+CLAgTujmV/Lgvih56W+A==}
+    engines: {node: '>=18'}
+    cpu: [arm64]
+    os: [linux]
+
+  '@esbuild/linux-arm@0.27.7':
+    resolution: {integrity: sha512-RkT/YXYBTSULo3+af8Ib0ykH8u2MBh57o7q/DAs3lTJlyVQkgQvlrPTnjIzzRPQyavxtPtfg0EopvDyIt0j1rA==}
+    engines: {node: '>=18'}
+    cpu: [arm]
+    os: [linux]
+
+  '@esbuild/linux-arm@0.28.0':
+    resolution: {integrity: sha512-CjaaREJagqJp7iTaNQjjidaNbCKYcd4IDkzbwwxtSvjI7NZm79qiHc8HqciMddQ6CKvJT6aBd8lO9kN/ZudLlw==}
+    engines: {node: '>=18'}
+    cpu: [arm]
+    os: [linux]
+
+  '@esbuild/linux-ia32@0.27.7':
+    resolution: {integrity: sha512-GA48aKNkyQDbd3KtkplYWT102C5sn/EZTY4XROkxONgruHPU72l+gW+FfF8tf2cFjeHaRbWpOYa/uRBz/Xq1Pg==}
+    engines: {node: '>=18'}
+    cpu: [ia32]
+    os: [linux]
+
+  '@esbuild/linux-ia32@0.28.0':
+    resolution: {integrity: sha512-KBnSTt1kxl9x70q+ydterVdl+Cn0H18ngRMRCEQfrbqdUuntQQ0LoMZv47uB97NljZFzY6HcfqEZ2SAyIUTQBQ==}
+    engines: {node: '>=18'}
+    cpu: [ia32]
+    os: [linux]
+
+  '@esbuild/linux-loong64@0.27.7':
+    resolution: {integrity: sha512-a4POruNM2oWsD4WKvBSEKGIiWQF8fZOAsycHOt6JBpZ+JN2n2JH9WAv56SOyu9X5IqAjqSIPTaJkqN8F7XOQ5Q==}
+    engines: {node: '>=18'}
+    cpu: [loong64]
+    os: [linux]
+
+  '@esbuild/linux-loong64@0.28.0':
+    resolution: {integrity: sha512-zpSlUce1mnxzgBADvxKXX5sl8aYQHo2ezvMNI8I0lbblJtp8V4odlm3Yzlj7gPyt3T8ReksE6bK+pT3WD+aJRg==}
+    engines: {node: '>=18'}
+    cpu: [loong64]
+    os: [linux]
+
+  '@esbuild/linux-mips64el@0.27.7':
+    resolution: {integrity: sha512-KabT5I6StirGfIz0FMgl1I+R1H73Gp0ofL9A3nG3i/cYFJzKHhouBV5VWK1CSgKvVaG4q1RNpCTR2LuTVB3fIw==}
+    engines: {node: '>=18'}
+    cpu: [mips64el]
+    os: [linux]
+
+  '@esbuild/linux-mips64el@0.28.0':
+    resolution: {integrity: sha512-2jIfP6mmjkdmeTlsX/9vmdmhBmKADrWqN7zcdtHIeNSCH1SqIoNI63cYsjQR8J+wGa4Y5izRcSHSm8K3QWmk3w==}
+    engines: {node: '>=18'}
+    cpu: [mips64el]
+    os: [linux]
+
+  '@esbuild/linux-ppc64@0.27.7':
+    resolution: {integrity: sha512-gRsL4x6wsGHGRqhtI+ifpN/vpOFTQtnbsupUF5R5YTAg+y/lKelYR1hXbnBdzDjGbMYjVJLJTd2OFmMewAgwlQ==}
+    engines: {node: '>=18'}
+    cpu: [ppc64]
+    os: [linux]
+
+  '@esbuild/linux-ppc64@0.28.0':
+    resolution: {integrity: sha512-bc0FE9wWeC0WBm49IQMPSPILRocGTQt3j5KPCA8os6VprfuJ7KD+5PzESSrJ6GmPIPJK965ZJHTUlSA6GNYEhg==}
+    engines: {node: '>=18'}
+    cpu: [ppc64]
+    os: [linux]
+
+  '@esbuild/linux-riscv64@0.27.7':
+    resolution: {integrity: sha512-hL25LbxO1QOngGzu2U5xeXtxXcW+/GvMN3ejANqXkxZ/opySAZMrc+9LY/WyjAan41unrR3YrmtTsUpwT66InQ==}
+    engines: {node: '>=18'}
+    cpu: [riscv64]
+    os: [linux]
+
+  '@esbuild/linux-riscv64@0.28.0':
+    resolution: {integrity: sha512-SQPZOwoTTT/HXFXQJG/vBX8sOFagGqvZyXcgLA3NhIqcBv1BJU1d46c0rGcrij2B56Z2rNiSLaZOYW5cUk7yLQ==}
+    engines: {node: '>=18'}
+    cpu: [riscv64]
+    os: [linux]
+
+  '@esbuild/linux-s390x@0.27.7':
+    resolution: {integrity: sha512-2k8go8Ycu1Kb46vEelhu1vqEP+UeRVj2zY1pSuPdgvbd5ykAw82Lrro28vXUrRmzEsUV0NzCf54yARIK8r0fdw==}
+    engines: {node: '>=18'}
+    cpu: [s390x]
+    os: [linux]
+
+  '@esbuild/linux-s390x@0.28.0':
+    resolution: {integrity: sha512-SCfR0HN8CEEjnYnySJTd2cw0k9OHB/YFzt5zgJEwa+wL/T/raGWYMBqwDNAC6dqFKmJYZoQBRfHjgwLHGSrn3Q==}
+    engines: {node: '>=18'}
+    cpu: [s390x]
+    os: [linux]
+
+  '@esbuild/linux-x64@0.27.7':
+    resolution: {integrity: sha512-hzznmADPt+OmsYzw1EE33ccA+HPdIqiCRq7cQeL1Jlq2gb1+OyWBkMCrYGBJ+sxVzve2ZJEVeePbLM2iEIZSxA==}
+    engines: {node: '>=18'}
+    cpu: [x64]
+    os: [linux]
+
+  '@esbuild/linux-x64@0.28.0':
+    resolution: {integrity: sha512-us0dSb9iFxIi8srnpl931Nvs65it/Jd2a2K3qs7fz2WfGPHqzfzZTfec7oxZJRNPXPnNYZtanmRc4AL/JwVzHQ==}
+    engines: {node: '>=18'}
+    cpu: [x64]
+    os: [linux]
+
+  '@esbuild/netbsd-arm64@0.27.7':
+    resolution: {integrity: sha512-b6pqtrQdigZBwZxAn1UpazEisvwaIDvdbMbmrly7cDTMFnw/+3lVxxCTGOrkPVnsYIosJJXAsILG9XcQS+Yu6w==}
+    engines: {node: '>=18'}
+    cpu: [arm64]
+    os: [netbsd]
+
+  '@esbuild/netbsd-arm64@0.28.0':
+    resolution: {integrity: sha512-CR/RYotgtCKwtftMwJlUU7xCVNg3lMYZ0RzTmAHSfLCXw3NtZtNpswLEj/Kkf6kEL3Gw+BpOekRX0BYCtklhUw==}
+    engines: {node: '>=18'}
+    cpu: [arm64]
+    os: [netbsd]
+
+  '@esbuild/netbsd-x64@0.27.7':
+    resolution: {integrity: sha512-OfatkLojr6U+WN5EDYuoQhtM+1xco+/6FSzJJnuWiUw5eVcicbyK3dq5EeV/QHT1uy6GoDhGbFpprUiHUYggrw==}
+    engines: {node: '>=18'}
+    cpu: [x64]
+    os: [netbsd]
+
+  '@esbuild/netbsd-x64@0.28.0':
+    resolution: {integrity: sha512-nU1yhmYutL+fQ71Kxnhg8uEOdC0pwEW9entHykTgEbna2pw2dkbFSMeqjjyHZoCmt8SBkOSvV+yNmm94aUrrqw==}
+    engines: {node: '>=18'}
+    cpu: [x64]
+    os: [netbsd]
+
+  '@esbuild/openbsd-arm64@0.27.7':
+    resolution: {integrity: sha512-AFuojMQTxAz75Fo8idVcqoQWEHIXFRbOc1TrVcFSgCZtQfSdc1RXgB3tjOn/krRHENUB4j00bfGjyl2mJrU37A==}
+    engines: {node: '>=18'}
+    cpu: [arm64]
+    os: [openbsd]
+
+  '@esbuild/openbsd-arm64@0.28.0':
+    resolution: {integrity: sha512-cXb5vApOsRsxsEl4mcZ1XY3D4DzcoMxR/nnc4IyqYs0rTI8ZKmW6kyyg+11Z8yvgMfAEldKzP7AdP64HnSC/6g==}
+    engines: {node: '>=18'}
+    cpu: [arm64]
+    os: [openbsd]
+
+  '@esbuild/openbsd-x64@0.27.7':
+    resolution: {integrity: sha512-+A1NJmfM8WNDv5CLVQYJ5PshuRm/4cI6WMZRg1by1GwPIQPCTs1GLEUHwiiQGT5zDdyLiRM/l1G0Pv54gvtKIg==}
+    engines: {node: '>=18'}
+    cpu: [x64]
+    os: [openbsd]
+
+  '@esbuild/openbsd-x64@0.28.0':
+    resolution: {integrity: sha512-8wZM2qqtv9UP3mzy7HiGYNH/zjTA355mpeuA+859TyR+e+Tc08IHYpLJuMsfpDJwoLo1ikIJI8jC3GFjnRClzA==}
+    engines: {node: '>=18'}
+    cpu: [x64]
+    os: [openbsd]
+
+  '@esbuild/openharmony-arm64@0.27.7':
+    resolution: {integrity: sha512-+KrvYb/C8zA9CU/g0sR6w2RBw7IGc5J2BPnc3dYc5VJxHCSF1yNMxTV5LQ7GuKteQXZtspjFbiuW5/dOj7H4Yw==}
+    engines: {node: '>=18'}
+    cpu: [arm64]
+    os: [openharmony]
+
+  '@esbuild/openharmony-arm64@0.28.0':
+    resolution: {integrity: sha512-FLGfyizszcef5C3YtoyQDACyg95+dndv79i2EekILBofh5wpCa1KuBqOWKrEHZg3zrL3t5ouE5jgr94vA+Wb2w==}
+    engines: {node: '>=18'}
+    cpu: [arm64]
+    os: [openharmony]
+
+  '@esbuild/sunos-x64@0.27.7':
+    resolution: {integrity: sha512-ikktIhFBzQNt/QDyOL580ti9+5mL/YZeUPKU2ivGtGjdTYoqz6jObj6nOMfhASpS4GU4Q/Clh1QtxWAvcYKamA==}
+    engines: {node: '>=18'}
+    cpu: [x64]
+    os: [sunos]
+
+  '@esbuild/sunos-x64@0.28.0':
+    resolution: {integrity: sha512-1ZgjUoEdHZZl/YlV76TSCz9Hqj9h9YmMGAgAPYd+q4SicWNX3G5GCyx9uhQWSLcbvPW8Ni7lj4gDa1T40akdlw==}
+    engines: {node: '>=18'}
+    cpu: [x64]
+    os: [sunos]
+
+  '@esbuild/win32-arm64@0.27.7':
+    resolution: {integrity: sha512-7yRhbHvPqSpRUV7Q20VuDwbjW5kIMwTHpptuUzV+AA46kiPze5Z7qgt6CLCK3pWFrHeNfDd1VKgyP4O+ng17CA==}
+    engines: {node: '>=18'}
+    cpu: [arm64]
+    os: [win32]
+
+  '@esbuild/win32-arm64@0.28.0':
+    resolution: {integrity: sha512-Q9StnDmQ/enxnpxCCLSg0oo4+34B9TdXpuyPeTedN/6+iXBJ4J+zwfQI28u/Jl40nOYAxGoNi7mFP40RUtkmUA==}
+    engines: {node: '>=18'}
+    cpu: [arm64]
+    os: [win32]
+
+  '@esbuild/win32-ia32@0.27.7':
+    resolution: {integrity: sha512-SmwKXe6VHIyZYbBLJrhOoCJRB/Z1tckzmgTLfFYOfpMAx63BJEaL9ExI8x7v0oAO3Zh6D/Oi1gVxEYr5oUCFhw==}
+    engines: {node: '>=18'}
+    cpu: [ia32]
+    os: [win32]
+
+  '@esbuild/win32-ia32@0.28.0':
+    resolution: {integrity: sha512-zF3ag/gfiCe6U2iczcRzSYJKH1DCI+ByzSENHlM2FcDbEeo5Zd2C86Aq0tKUYAJJ1obRP84ymxIAksZUcdztHA==}
+    engines: {node: '>=18'}
+    cpu: [ia32]
+    os: [win32]
+
+  '@esbuild/win32-x64@0.27.7':
+    resolution: {integrity: sha512-56hiAJPhwQ1R4i+21FVF7V8kSD5zZTdHcVuRFMW0hn753vVfQN8xlx4uOPT4xoGH0Z/oVATuR82AiqSTDIpaHg==}
+    engines: {node: '>=18'}
+    cpu: [x64]
+    os: [win32]
+
+  '@esbuild/win32-x64@0.28.0':
+    resolution: {integrity: sha512-pEl1bO9mfAmIC+tW5btTmrKaujg3zGtUmWNdCw/xs70FBjwAL3o9OEKNHvNmnyylD6ubxUERiEhdsL0xBQ9efw==}
+    engines: {node: '>=18'}
+    cpu: [x64]
+    os: [win32]
+
+  '@iqlabs-official/solana-sdk@0.1.27':
+    resolution: {integrity: sha512-A+//KL2IQe8aCjGZM6sNOnah4srPWWlh/o13INWkmomyvHP3Oa+IbIPgjzync7RbL4Qi46mNK3xAmNC+bjSCVg==}
+
+  '@jridgewell/gen-mapping@0.3.13':
+    resolution: {integrity: sha512-2kkt/7niJ6MgEPxF0bYdQ6etZaA+fQvDcLKckhy1yIQOzaoKjBBjSj63/aLVjYE3qhRt5dvM+uUyfCg6UKCBbA==}
+
+  '@jridgewell/resolve-uri@3.1.2':
+    resolution: {integrity: sha512-bRISgCIjP20/tbWSPWMEi54QVPRZExkuD9lJL+UIxUKtwVJA8wW1Trb1jMs1RFXo1CBTNZ/5hpC9QvmKWdopKw==}
+    engines: {node: '>=6.0.0'}
+
+  '@jridgewell/sourcemap-codec@1.5.5':
+    resolution: {integrity: sha512-cYQ9310grqxueWbl+WuIUIaiUaDcj7WOq5fVhEljNVgRfOUhY9fy2zTvfoqWsnebh8Sl70VScFbICvJnLKB0Og==}
+
+  '@jridgewell/trace-mapping@0.3.31':
+    resolution: {integrity: sha512-zzNR+SdQSDJzc8joaeP8QQoCQr8NuYx2dIIytl1QeBEZHJ9uW6hebsrYgbz8hJwUQao3TWCMtmfV8Nu1twOLAw==}
+
+  '@noble/curves@1.9.7':
+    resolution: {integrity: sha512-gbKGcRUYIjA3/zCCNaWDciTMFI0dCkvou3TL8Zmy5Nc7sJ47a0jtOeZoTaMxkuqRo9cRhjOdZJXegxYE5FN/xw==}
+    engines: {node: ^14.21.3 || >=16}
+
+  '@noble/curves@2.2.0':
+    resolution: {integrity: sha512-T/BoHgFXirb0ENSPBquzX0rcjXeM6Lo892a2jlYJkqk83LqZx0l1Of7DzlKJ6jkpvMrkHSnAcgb5JegL8SeIkQ==}
+    engines: {node: '>= 20.19.0'}
+
+  '@noble/hashes@1.8.0':
+    resolution: {integrity: sha512-jCs9ldd7NwzpgXDIf6P3+NrHh9/sD6CQdxHyjQI+h/6rDNo88ypBxxz45UDuZHz9r3tNz7N/VInSVoVdtXEI4A==}
+    engines: {node: ^14.21.3 || >=16}
+
+  '@noble/hashes@2.2.0':
+    resolution: {integrity: sha512-IYqDGiTXab6FniAgnSdZwgWbomxpy9FtYvLKs7wCUs2a8RkITG+DFGO1DM9cr+E3/RgADRpFjrKVaJ1z6sjtEg==}
+    engines: {node: '>= 20.19.0'}
+
+  '@rollup/rollup-android-arm-eabi@4.61.1':
+    resolution: {integrity: sha512-JnBB8MdXj45cajvTuO5FmPlvFVJRQgvrz1uSEl3NwqFnReAPGwb8EanbGi4z2nRaqLzjJSv5/JmycoTKlRZxHA==}
+    cpu: [arm]
+    os: [android]
+
+  '@rollup/rollup-android-arm64@4.61.1':
+    resolution: {integrity: sha512-Jx2g7iSjw4AOT0HDPHM9RV3GNjRXwybWtSFZiZAYUTjUwjVrYIwq3kBf+LnhqJlzXFAqTAh2F7IGI+O568exPw==}
+    cpu: [arm64]
+    os: [android]
+
+  '@rollup/rollup-darwin-arm64@4.61.1':
+    resolution: {integrity: sha512-0F1L/Z3Eqv8mT2n3dCpeO8GcTvHvVqkP5/t6DMsn0KzhYVcg+s7Ncl5DS8qjKYEeio6Az0Gt6nyBORay5qIlCA==}
+    cpu: [arm64]
+    os: [darwin]
+
+  '@rollup/rollup-darwin-x64@4.61.1':
+    resolution: {integrity: sha512-qLttcH871ujY4YcVfUSShhOw+CsoTatYz8gRbHO7Bb92QH059/P0y5do1KMs41fY0BpD2x4AJH/gID0zFiqVKQ==}
+    cpu: [x64]
+    os: [darwin]
+
+  '@rollup/rollup-freebsd-arm64@4.61.1':
+    resolution: {integrity: sha512-fUI4RapGE0Oh3mb8mgfvC1O2nU1RpDZUKnDQm3xB1Ipg7C2wTs5Kstz7G2uWK99a8S2yTMq8/P4uycwNa0nJyw==}
+    cpu: [arm64]
+    os: [freebsd]
+
+  '@rollup/rollup-freebsd-x64@4.61.1':
+    resolution: {integrity: sha512-H5YrdvJaDtI/U9/emrD4b++xkvp3y/JvOe4rizHbxvkyMfRS/CiRYdji+Pl8D0brEaNFWUh1drQxgAGIl6Xudw==}
+    cpu: [x64]
+    os: [freebsd]
+
+  '@rollup/rollup-linux-arm-gnueabihf@4.61.1':
+    resolution: {integrity: sha512-Q8CBCCQtDFrYtXoeUXSrnFXKOnyUhx6bz+SkL6A0E7V8kAiCJ5pamq1WtbfpVGhR5TSpXY6ak3avmDc5fHTyJA==}
+    cpu: [arm]
+    os: [linux]
+
+  '@rollup/rollup-linux-arm-musleabihf@4.61.1':
+    resolution: {integrity: sha512-nwnhk1581l0FBVellGcVCAT0Oi06onEA3WB53sf01VO3I0UPBkMH9sXONYME2K0ovXcNayJfNtHfm6mpJElatQ==}
+    cpu: [arm]
+    os: [linux]
+
+  '@rollup/rollup-linux-arm64-gnu@4.61.1':
+    resolution: {integrity: sha512-x5Xr49hwt3hdW75UOZm3395YwwzPyauktslv29KpWL/T+vVAzoT3azLcTWv0eMciBNrx+DYjH4paehHoLpPvpg==}
+    cpu: [arm64]
+    os: [linux]
+
+  '@rollup/rollup-linux-arm64-musl@4.61.1':
+    resolution: {integrity: sha512-unMS3H73DpaoPyyEVPjGKleM/s0mkmsauTENpw4INQY8y4+IuLNjkueQ5QCtC0D3N38Y38yhAU8OoZ20S2Tm6w==}
+    cpu: [arm64]
+    os: [linux]
+
+  '@rollup/rollup-linux-loong64-gnu@4.61.1':
+    resolution: {integrity: sha512-zNZzGRnAhwjFEYmvphJRV5XaQGjs62cCmeYYHUT//NbvEnHauw+I85nGG+SiVg5ld4GX8D1IbKIX+ozITQnhMQ==}
+    cpu: [loong64]
+    os: [linux]
+
+  '@rollup/rollup-linux-loong64-musl@4.61.1':
+    resolution: {integrity: sha512-LdpWGL8X209B2SIvWjqlc8VZgM6PKfontSerGepuldQmHYrAOtnMCXeJkxXGbC+PPZVOuu5czJo7fNV6aeW8rQ==}
+    cpu: [loong64]
+    os: [linux]
+
+  '@rollup/rollup-linux-ppc64-gnu@4.61.1':
+    resolution: {integrity: sha512-EC5kTtNaNGOmbMGqar8dvJy6y/hg99GAwjfBz++pxZhQATXGcRjd6c5en5wcbru0vkRmiMGsQKdMJOOf6sza4g==}
+    cpu: [ppc64]
+    os: [linux]
+
+  '@rollup/rollup-linux-ppc64-musl@4.61.1':
+    resolution: {integrity: sha512-8hiwp6D4acEcNK78I4rP0/XtS1sknWIAMJBPdR4l6zUtyTm5KiTDr5bXmWt4foY7nAN7AThDHgkLIEZOWKbzWw==}
+    cpu: [ppc64]
+    os: [linux]
+
+  '@rollup/rollup-linux-riscv64-gnu@4.61.1':
+    resolution: {integrity: sha512-10dh/h/BqA7DuMPWSxkR8uks18FRwnwOEqr5zOTEl+NOwP/OMzKX8OFR/Of9xxDA7D5qef1Nzar5WDD2kCCr1g==}
+    cpu: [riscv64]
+    os: [linux]
+
+  '@rollup/rollup-linux-riscv64-musl@4.61.1':
+    resolution: {integrity: sha512-YKJ5lg35DP17gcAOggnihe+APw9HLyj1Xn7gsmGumBJAUDa6NGXNixJzmkWLhcK9TOuuyQjdamzvJefkO7qHZQ==}
+    cpu: [riscv64]
+    os: [linux]
+
+  '@rollup/rollup-linux-s390x-gnu@4.61.1':
+    resolution: {integrity: sha512-Mlil5G2Jj6a7B3LWGctg+XPL9vdXYuzCtNXfxOQ0nPjc2m6ueUktocPGH9bnAM0bNRKb/bAWTujUU7IJQdQA+g==}
+    cpu: [s390x]
+    os: [linux]
+
+  '@rollup/rollup-linux-x64-gnu@4.61.1':
+    resolution: {integrity: sha512-bVWIOIk6pV01p4CdUbPP7CJ/434z+OooYjDuFcR+44N35YvKUC66G8MGnvcWx5mWKW3g61J+t74l3Kj15Kwn2Q==}
+    cpu: [x64]
+    os: [linux]
+
+  '@rollup/rollup-linux-x64-musl@4.61.1':
+    resolution: {integrity: sha512-qy5pBvZbqNFheBz61R1rzsezjm0J7O2oNGoWtGoY89SZYLUfxAJTBAqDChqAIdB4rCiIbi9nF7yZ83GnNiLwSw==}
+    cpu: [x64]
+    os: [linux]
+
+  '@rollup/rollup-openbsd-x64@4.61.1':
+    resolution: {integrity: sha512-E83TXjI4zm0+5f2qO+UOudaCYIhYwpJ5jq6YCZNIZ+6CbfhKrkAGezeiASBL9ElxAxFsRS9ZhESv8mfnj6TKeg==}
+    cpu: [x64]
+    os: [openbsd]
+
+  '@rollup/rollup-openharmony-arm64@4.61.1':
+    resolution: {integrity: sha512-fbWnKqVkjrJN38vNe3ahkbk6iejS/3b0Nt7EEtPpE6RBacZcGXNKbzfHN3GUUlXOPghUg0j6XUGrtjX9z1sIvA==}
+    cpu: [arm64]
+    os: [openharmony]
+
+  '@rollup/rollup-win32-arm64-msvc@4.61.1':
+    resolution: {integrity: sha512-ArMl38iVAbk0New1ogihQNY6iphLi4ZaRsa037gUzv5yeKPY8TD3Dmy4x2RNC1VztU/uqm+G+/RwFrSka3Oy2g==}
+    cpu: [arm64]
+    os: [win32]
+
+  '@rollup/rollup-win32-ia32-msvc@4.61.1':
+    resolution: {integrity: sha512-0mYtjHS9ucAbcATycCNK9IGBk/cCe/ma7EmSLGZdsxnOA8cjRIyU04wDpVAD9NiOfLUR9KTxdiO53uOkherqjQ==}
+    cpu: [ia32]
+    os: [win32]
+
+  '@rollup/rollup-win32-x64-gnu@4.61.1':
+    resolution: {integrity: sha512-gK1iCEPfpoSG9wfBihXxvBMi8ZfcWffYkEsC/Eih+iFENTaewvNcrEQ69lIOWYO5pePHKLHHO7nq5AILGO/HQQ==}
+    cpu: [x64]
+    os: [win32]
+
+  '@rollup/rollup-win32-x64-msvc@4.61.1':
+    resolution: {integrity: sha512-X+zaP2x+j4RXGfbp/seSoRHWnPxzApilDszisZxbYH5C/jTxFhCtDNdPGZb9lJyYPs24wGxruPF7Y+sIXt9Gzw==}
+    cpu: [x64]
+    os: [win32]
+
+  '@solana/buffer-layout@4.0.1':
+    resolution: {integrity: sha512-E1ImOIAD1tBZFRdjeM4/pzTiTApC0AOBGwyAMS4fwIodCWArzJ3DWdoh8cKxeFM2fElkxBh2Aqts1BPC373rHA==}
+    engines: {node: '>=5.10'}
+
+  '@solana/codecs-core@2.3.0':
+    resolution: {integrity: sha512-oG+VZzN6YhBHIoSKgS5ESM9VIGzhWjEHEGNPSibiDTxFhsFWxNaz8LbMDPjBUE69r9wmdGLkrQ+wVPbnJcZPvw==}
+    engines: {node: '>=20.18.0'}
+    peerDependencies:
+      typescript: '>=5.3.3'
+
+  '@solana/codecs-numbers@2.3.0':
+    resolution: {integrity: sha512-jFvvwKJKffvG7Iz9dmN51OGB7JBcy2CJ6Xf3NqD/VP90xak66m/Lg48T01u5IQ/hc15mChVHiBm+HHuOFDUrQg==}
+    engines: {node: '>=20.18.0'}
+    peerDependencies:
+      typescript: '>=5.3.3'
+
+  '@solana/errors@2.3.0':
+    resolution: {integrity: sha512-66RI9MAbwYV0UtP7kGcTBVLxJgUxoZGm8Fbc0ah+lGiAw17Gugco6+9GrJCV83VyF2mDWyYnYM9qdI3yjgpnaQ==}
+    engines: {node: '>=20.18.0'}
+    hasBin: true
+    peerDependencies:
+      typescript: '>=5.3.3'
+
+  '@solana/web3.js@1.98.4':
+    resolution: {integrity: sha512-vv9lfnvjUsRiq//+j5pBdXig0IQdtzA0BRZ3bXEP4KaIyF1CcaydWqgyzQgfZMNIsWNWmG+AUHwPy4AHOD6gpw==}
+
+  '@swc/helpers@0.5.23':
+    resolution: {integrity: sha512-5lSsMOTXURePglDfvuAQUqkGek9Hg2kksOYay2m0+XR++b2NWYL/4sWyuvVBIs8oKnJaxkdi9whaL/sqN13afw==}
+
+  '@types/connect@3.4.38':
+    resolution: {integrity: sha512-K6uROf1LD88uDQqJCktA4yzL1YYAK6NgfsI0v/mTgyPKWsX1CnJ0XPSDhViejru1GcRkLWb8RlzFYJRqGUbaug==}
+
+  '@types/estree@1.0.9':
+    resolution: {integrity: sha512-GhdPgy1el4/ImP05X05Uw4cw2/M93BCUmnEvWZNStlCzEKME4Fkk+YpoA5OiHNQmoS7Cafb8Xa3Pya8m1Qrzeg==}
+
+  '@types/node@12.20.55':
+    resolution: {integrity: sha512-J8xLz7q2OFulZ2cyGTLE1TbbZcjpno7FaN6zdJNrgAdrJ+DZzh/uFR6YrTb4C+nXakvud8Q4+rbhoIWlYQbUFQ==}
+
+  '@types/node@20.19.42':
+    resolution: {integrity: sha512-5L7SUaFC1RyDraj2yRhyBzHTobyXHmohD100CChNtyPyleoq37Mqab5Gn8XEKI04dfN/oqPdpHk38MgcQWHbZg==}
+
+  '@types/uuid@10.0.0':
+    resolution: {integrity: sha512-7gqG38EyHgyP1S+7+xomFtL+ZNHcKv6DwNaCZmJmo1vgMugyF3TCnXVg4t1uk89mLNwnLtnY3TpOpCOyp1/xHQ==}
+
+  '@types/ws@7.4.7':
+    resolution: {integrity: sha512-JQbbmxZTZehdc2iszGKs5oC3NFnjeay7mtAWrdt7qNtAVK0g19muApzAy4bm9byz79xa2ZnO/BOBC2R8RC5Lww==}
+
+  '@types/ws@8.18.1':
+    resolution: {integrity: sha512-ThVF6DCVhA8kUGy+aazFQ4kXQ7E1Ty7A3ypFOe0IcJV8O/M511G99AW24irKrW56Wt44yG9+ij8FaqoBGkuBXg==}
+
+  acorn@8.16.0:
+    resolution: {integrity: sha512-UVJyE9MttOsBQIDKw1skb9nAwQuR5wuGD3+82K6JgJlm/Y+KI92oNsMNGZCYdDsVtRHSak0pcV5Dno5+4jh9sw==}
+    engines: {node: '>=0.4.0'}
+    hasBin: true
+
+  agentkeepalive@4.6.0:
+    resolution: {integrity: sha512-kja8j7PjmncONqaTsB8fQ+wE2mSU2DJ9D4XKoJ5PFWIdRMa6SLSN1ff4mOr4jCbfRSsxR4keIiySJU0N9T5hIQ==}
+    engines: {node: '>= 8.0.0'}
+
+  any-promise@1.3.0:
+    resolution: {integrity: sha512-7UvmKalWRt1wgjL1RrGxoSJW/0QZFIegpeGvZG9kjp8vrRu55XTHbwnqq2GpXm9uLbcuhxm3IqX9OB4MZR1b2A==}
+
+  base-x@3.0.11:
+    resolution: {integrity: sha512-xz7wQ8xDhdyP7tQxwdteLYeFfS68tSMNCZ/Y37WJ4bhGfKPpqEIlmIyueQHqOyoPhE6xNUqjzRr8ra0eF9VRvA==}
+
+  base64-js@1.5.1:
+    resolution: {integrity: sha512-AKpaYlHn8t4SVbOHCy+b5+KKgvR4vrsD8vbvrbiQJps7fKDTkjkDry6ji0rUJjC0kzbNePLwzxq8iypo41qeWA==}
+
+  bn.js@5.2.3:
+    resolution: {integrity: sha512-EAcmnPkxpntVL+DS7bO1zhcZNvCkxqtkd0ZY53h06GNQ3DEkkGZ/gKgmDv6DdZQGj9BgfSPKtJJ7Dp1GPP8f7w==}
+
+  borsh@0.7.0:
+    resolution: {integrity: sha512-CLCsZGIBCFnPtkNnieW/a8wmreDmfUtjU2m9yHrzPXIlNbqVs0AQrSatSG6vdNYUqdc83tkQi2eHfF98ubzQLA==}
+
+  bs58@4.0.1:
+    resolution: {integrity: sha512-Ok3Wdf5vOIlBrgCvTq96gBkJw+JUEzdBgyaza5HLtPm7yTHkjRy8+JzNyHF7BHa0bNWOQIp3m5YF0nnFcOIKLw==}
+
+  buffer-layout@1.2.2:
+    resolution: {integrity: sha512-kWSuLN694+KTk8SrYvCqwP2WcgQjoRCiF5b4QDvkkz8EmgD+aWAIceGFKMIAdmF/pH+vpgNV3d3kAKorcdAmWA==}
+    engines: {node: '>=4.5'}
+
+  buffer@6.0.3:
+    resolution: {integrity: sha512-FTiCpNxtwiZZHEZbcbTIcZjERVICn9yq/pDFkTl95/AxzD1naBctN7YO68riM/gLSDY7sdrMby8hofADYuuqOA==}
+
+  bufferutil@4.1.0:
+    resolution: {integrity: sha512-ZMANVnAixE6AWWnPzlW2KpUrxhm9woycYvPOo67jWHyFowASTEd9s+QN1EIMsSDtwhIxN4sWE1jotpuDUIgyIw==}
+    engines: {node: '>=6.14.2'}
+
+  bundle-require@5.1.0:
+    resolution: {integrity: sha512-3WrrOuZiyaaZPWiEt4G3+IffISVC9HYlWueJEBWED4ZH4aIAC2PnkdnuRrR94M+w6yGWn4AglWtJtBI8YqvgoA==}
+    engines: {node: ^12.20.0 || ^14.13.1 || >=16.0.0}
+    peerDependencies:
+      esbuild: '>=0.18'
+
+  cac@6.7.14:
+    resolution: {integrity: sha512-b6Ilus+c3RrdDk+JhLKUAQfzzgLEPy6wcXqS7f/xe1EETvsDP6GORG7SFuOs6cID5YkqchW/LXZbX5bc8j7ZcQ==}
+    engines: {node: '>=8'}
+
+  camelcase@6.3.0:
+    resolution: {integrity: sha512-Gmy6FhYlCY7uOElZUSbxo2UCDH8owEk996gkbrpsgGtrJLM3J7jGxl9Ic7Qwwj4ivOE5AWZWRMecDdF7hqGjFA==}
+    engines: {node: '>=10'}
+
+  chalk@5.6.2:
+    resolution: {integrity: sha512-7NzBL0rN6fMUW+f7A6Io4h40qQlG+xGmtMxfbnH/K7TAtt8JQWVQK+6g0UXKMeVJoyV5EkkNsErQ8pVD3bLHbA==}
+    engines: {node: ^12.17.0 || ^14.13 || >=16.0.0}
+
+  chokidar@4.0.3:
+    resolution: {integrity: sha512-Qgzu8kfBvo+cA4962jnP1KkS6Dop5NS6g7R5LFYJr4b8Ub94PPQXUksCw9PvXoeXPRRddRNC5C1JQUR2SMGtnA==}
+    engines: {node: '>= 14.16.0'}
+
+  commander@14.0.3:
+    resolution: {integrity: sha512-H+y0Jo/T1RZ9qPP4Eh1pkcQcLRglraJaSLoyOtHxu6AapkjWVCy2Sit1QQ4x3Dng8qDlSsZEet7g5Pq06MvTgw==}
+    engines: {node: '>=20'}
+
+  commander@2.20.3:
+    resolution: {integrity: sha512-GpVkmM8vF2vQUkj2LvZmD35JxeJOLCwJ9cUkugyk2nuhbv3+mJvpLYYt+0+USMxE+oj+ey/lJEnhZw75x/OMcQ==}
+
+  commander@4.1.1:
+    resolution: {integrity: sha512-NOKm8xhkzAjzFx8B2v5OAHT+u5pRQc2UCa2Vq9jYL/31o2wi9mxBA7LIFs3sV5VSC49z6pEhfbMULvShKj26WA==}
+    engines: {node: '>= 6'}
+
+  confbox@0.1.8:
+    resolution: {integrity: sha512-RMtmw0iFkeR4YV+fUOSucriAQNb9g8zFR52MWCtl+cCZOFRNL6zeB395vPzFhEjjn4fMxXudmELnl/KF/WrK6w==}
+
+  consola@3.4.2:
+    resolution: {integrity: sha512-5IKcdX0nnYavi6G7TtOhwkYzyjfJlatbjMjuLSfE2kYT5pMDOilZ4OvMhi637CcDICTmz3wARPoyhqyX1Y+XvA==}
+    engines: {node: ^14.18.0 || >=16.10.0}
+
+  cross-fetch@3.2.0:
+    resolution: {integrity: sha512-Q+xVJLoGOeIMXZmbUK4HYk+69cQH6LudR0Vu/pRm2YlU/hDV9CiS0gKUMaWY5f2NeUH9C1nV3bsTlCo0FsTV1Q==}
+
+  debug@4.4.3:
+    resolution: {integrity: sha512-RGwwWnwQvkVfavKVt22FGLw+xYSdzARwm0ru6DhTVA3umU5hZc28V3kO4stgYryrTlLpuvgI9GiijltAjNbcqA==}
+    engines: {node: '>=6.0'}
+    peerDependencies:
+      supports-color: '*'
+    peerDependenciesMeta:
+      supports-color:
+        optional: true
+
+  delay@5.0.0:
+    resolution: {integrity: sha512-ReEBKkIfe4ya47wlPYf/gu5ib6yUG0/Aez0JQZQz94kiWtRQvZIQbTiehsnwHvLSWJnQdhVeqYue7Id1dKr0qw==}
+    engines: {node: '>=10'}
+
+  es6-promise@4.2.8:
+    resolution: {integrity: sha512-HJDGx5daxeIvxdBxvG2cb9g4tEvwIk3i8+nhX0yGrYmZUzbkdg8QbDevheDB8gd0//uPj4c1EQua8Q+MViT0/w==}
+
+  es6-promisify@5.0.0:
+    resolution: {integrity: sha512-C+d6UdsYDk0lMebHNR4S2NybQMMngAOnOwYBQjTOiv0MkoJMP0Myw2mgpDLBcpfCmRLxyFqYhS/CfOENq4SJhQ==}
+
+  esbuild@0.27.7:
+    resolution: {integrity: sha512-IxpibTjyVnmrIQo5aqNpCgoACA/dTKLTlhMHihVHhdkxKyPO1uBBthumT0rdHmcsk9uMonIWS0m4FljWzILh3w==}
+    engines: {node: '>=18'}
+    hasBin: true
+
+  esbuild@0.28.0:
+    resolution: {integrity: sha512-sNR9MHpXSUV/XB4zmsFKN+QgVG82Cc7+/aaxJ8Adi8hyOac+EXptIp45QBPaVyX3N70664wRbTcLTOemCAnyqw==}
+    engines: {node: '>=18'}
+    hasBin: true
+
+  eventemitter3@4.0.7:
+    resolution: {integrity: sha512-8guHBZCwKnFhYdHr2ysuRWErTwhoN2X8XELRlrRwpmfeY2jjuUN4taQMsULKUVo1K4DvZl+0pgfyoysHxvmvEw==}
+
+  eventemitter3@5.0.4:
+    resolution: {integrity: sha512-mlsTRyGaPBjPedk6Bvw+aqbsXDtoAyAzm5MO7JgU+yVRyMQ5O8bD4Kcci7BS85f93veegeCPkL8R4GLClnjLFw==}
+
+  eyes@0.1.8:
+    resolution: {integrity: sha512-GipyPsXO1anza0AOZdy69Im7hGFCNB7Y/NGjDlZGJ3GJJLtwNSb2vrzYrTYJRrRloVx7pl+bhUaTB8yiccPvFQ==}
+    engines: {node: '> 0.1.90'}
+
+  fast-stable-stringify@1.0.0:
+    resolution: {integrity: sha512-wpYMUmFu5f00Sm0cj2pfivpmawLZ0NKdviQ4w9zJeR8JVtOpOxHmLaJuj0vxvGqMJQWyP/COUkF75/57OKyRag==}
+
+  fdir@6.5.0:
+    resolution: {integrity: sha512-tIbYtZbucOs0BRGqPJkshJUYdL+SDH7dVM8gjy+ERp3WAUjLEFJE+02kanyHtwjWOnwrKYBiwAmM0p4kLJAnXg==}
+    engines: {node: '>=12.0.0'}
+    peerDependencies:
+      picomatch: ^3 || ^4
+    peerDependenciesMeta:
+      picomatch:
+        optional: true
+
+  fix-dts-default-cjs-exports@1.0.1:
+    resolution: {integrity: sha512-pVIECanWFC61Hzl2+oOCtoJ3F17kglZC/6N94eRWycFgBH35hHx0Li604ZIzhseh97mf2p0cv7vVrOZGoqhlEg==}
+
+  fsevents@2.3.3:
+    resolution: {integrity: sha512-5xoDfX+fL7faATnagmWPpbFtwh/R77WmMMqqHGS65C3vvB0YHrgF+B1YmZ3441tMj5n63k0212XNoJwzlhffQw==}
+    engines: {node: ^8.16.0 || ^10.6.0 || >=11.0.0}
+    os: [darwin]
+
+  humanize-ms@1.2.1:
+    resolution: {integrity: sha512-Fl70vYtsAFb/C06PTS9dZBo7ihau+Tu/DNCk/OyHhea07S+aeMWpFFkUaXRa8fI+ScZbEI8dfSxwY7gxZ9SAVQ==}
+
+  ieee754@1.2.1:
+    resolution: {integrity: sha512-dcyqhDvX1C46lXZcVqCpK+FtMRQVdIMN6/Df5js2zouUsqG7I6sFxitIC+7KYK29KdXOLHdu9zL4sFnoVQnqaA==}
+
+  isomorphic-ws@4.0.1:
+    resolution: {integrity: sha512-BhBvN2MBpWTaSHdWRb/bwdZJ1WaehQ2L1KngkCkfLUGF0mAWAT1sQUQacEmQ0jXkFw/czDXPNQSL5u2/Krsz1w==}
+    peerDependencies:
+      ws: '*'
+
+  jayson@4.3.0:
+    resolution: {integrity: sha512-AauzHcUcqs8OBnCHOkJY280VaTiCm57AbuO7lqzcw7JapGj50BisE3xhksye4zlTSR1+1tAz67wLTl8tEH1obQ==}
+    engines: {node: '>=8'}
+    hasBin: true
+
+  joycon@3.1.1:
+    resolution: {integrity: sha512-34wB/Y7MW7bzjKRjUKTa46I2Z7eV62Rkhva+KkopW7Qvv/OSWBqvkSY7vusOPrNuZcUG3tApvdVgNB8POj3SPw==}
+    engines: {node: '>=10'}
+
+  json-stringify-safe@5.0.1:
+    resolution: {integrity: sha512-ZClg6AaYvamvYEE82d3Iyd3vSSIjQ+odgjaTzRuO3s7toCdFKczob2i0zCh7JE8kWn17yvAWhUVxvqGwUalsRA==}
+
+  lilconfig@3.1.3:
+    resolution: {integrity: sha512-/vlFKAoH5Cgt3Ie+JLhRbwOsCQePABiU3tJ1egGvyQ+33R/vcwM2Zl2QR/LzjsBeItPt3oSVXapn+m4nQDvpzw==}
+    engines: {node: '>=14'}
+
+  lines-and-columns@1.2.4:
+    resolution: {integrity: sha512-7ylylesZQ/PV29jhEDl3Ufjo6ZX7gCqJr5F7PKrqc93v7fzSymt1BpwEU8nAUXs8qzzvqhbjhK5QZg6Mt/HkBg==}
+
+  load-tsconfig@0.2.5:
+    resolution: {integrity: sha512-IXO6OCs9yg8tMKzfPZ1YmheJbZCiEsnBdcB03l0OcfK9prKnJb96siuHCr5Fl37/yo9DnKU+TLpxzTUspw9shg==}
+    engines: {node: ^12.20.0 || ^14.13.1 || >=16.0.0}
+
+  magic-string@0.30.21:
+    resolution: {integrity: sha512-vd2F4YUyEXKGcLHoq+TEyCjxueSeHnFxyyjNp80yg0XV4vUhnDer/lvvlqM/arB5bXQN5K2/3oinyCRyx8T2CQ==}
+
+  mlly@1.8.2:
+    resolution: {integrity: sha512-d+ObxMQFmbt10sretNDytwt85VrbkhhUA/JBGm1MPaWJ65Cl4wOgLaB1NYvJSZ0Ef03MMEU/0xpPMXUIQ29UfA==}
+
+  ms@2.1.3:
+    resolution: {integrity: sha512-6FlzubTLZG3J2a/NVCAleEhjzq5oxgHyaCU9yYXvcLsvoVaHJq/s5xXI6/XXP6tz7R9xAOtHnSO/tXtF3WRTlA==}
+
+  mz@2.7.0:
+    resolution: {integrity: sha512-z81GNO7nnYMEhrGh9LeymoE4+Yr0Wn5McHIZMK5cfQCl+NDX08sCZgUc9/6MHni9IWuFLm1Z3HTCXu2z9fN62Q==}
+
+  node-fetch@2.7.0:
+    resolution: {integrity: sha512-c4FRfUm/dbcWZ7U+1Wq0AwCyFL+3nt2bEw05wfxSz+DWpWsitgmSgYmy2dQdWyKC1694ELPqMs/YzUSNozLt8A==}
+    engines: {node: 4.x || >=6.0.0}
+    peerDependencies:
+      encoding: ^0.1.0
+    peerDependenciesMeta:
+      encoding:
+        optional: true
+
+  node-gyp-build@4.8.4:
+    resolution: {integrity: sha512-LA4ZjwlnUblHVgq0oBF3Jl/6h/Nvs5fzBLwdEF4nuxnFdsfajde4WfxtJr3CaiH+F6ewcIB/q4jQ4UzPyid+CQ==}
+    hasBin: true
+
+  object-assign@4.1.1:
+    resolution: {integrity: sha512-rJgTQnkUnH1sFw8yT6VSU3zD3sWmu6sZhIseY8VX+GRu3P6F7Fu+JNDoXfklElbLJSnc3FUQHVe4cU5hj+BcUg==}
+    engines: {node: '>=0.10.0'}
+
+  pako@2.1.0:
+    resolution: {integrity: sha512-w+eufiZ1WuJYgPXbV/PO3NCMEc3xqylkKHzp8bxp1uW4qaSNQUkwmLLEc3kKsfz8lpV1F8Ht3U1Cm+9Srog2ug==}
+
+  pathe@2.0.3:
+    resolution: {integrity: sha512-WUjGcAqP1gQacoQe+OBJsFA7Ld4DyXuUIjZ5cc75cLHvJ7dtNsTugphxIADwspS+AraAUePCKrSVtPLFj/F88w==}
+
+  picocolors@1.1.1:
+    resolution: {integrity: sha512-xceH2snhtb5M9liqDsmEw56le376mTZkEX/jEb/RxNFyegNul7eNslCXP9FDj/Lcu0X8KEyMceP2ntpaHrDEVA==}
+
+  picomatch@4.0.4:
+    resolution: {integrity: sha512-QP88BAKvMam/3NxH6vj2o21R6MjxZUAd6nlwAS/pnGvN9IVLocLHxGYIzFhg6fUQ+5th6P4dv4eW9jX3DSIj7A==}
+    engines: {node: '>=12'}
+
+  pirates@4.0.7:
+    resolution: {integrity: sha512-TfySrs/5nm8fQJDcBDuUng3VOUKsd7S+zqvbOTiGXHfxX4wK31ard+hoNuvkicM/2YFzlpDgABOevKSsB4G/FA==}
+    engines: {node: '>= 6'}
+
+  pkg-types@1.3.1:
+    resolution: {integrity: sha512-/Jm5M4RvtBFVkKWRu2BLUTNP8/M2a+UwuAX+ae4770q1qVGtfjG+WTCupoZixokjmHiry8uI+dlY8KXYV5HVVQ==}
+
+  postcss-load-config@6.0.1:
+    resolution: {integrity: sha512-oPtTM4oerL+UXmx+93ytZVN82RrlY/wPUV8IeDxFrzIjXOLF1pN+EmKPLbubvKHT2HC20xXsCAH2Z+CKV6Oz/g==}
+    engines: {node: '>= 18'}
+    peerDependencies:
+      jiti: '>=1.21.0'
+      postcss: '>=8.0.9'
+      tsx: ^4.8.1
+      yaml: ^2.4.2
+    peerDependenciesMeta:
+      jiti:
+        optional: true
+      postcss:
+        optional: true
+      tsx:
+        optional: true
+      yaml:
+        optional: true
+
+  readdirp@4.1.2:
+    resolution: {integrity: sha512-GDhwkLfywWL2s6vEjyhri+eXmfH6j1L7JE27WhqLeYzoh/A3DBaYGEj2H/HFZCn/kMfim73FXxEJTw06WtxQwg==}
+    engines: {node: '>= 14.18.0'}
+
+  resolve-from@5.0.0:
+    resolution: {integrity: sha512-qYg9KP24dD5qka9J47d0aVky0N+b4fTU89LN9iDnjB5waksiC49rvMB0PrUJQGoTmH50XPiqOvAjDfaijGxYZw==}
+    engines: {node: '>=8'}
+
+  rollup@4.61.1:
+    resolution: {integrity: sha512-I4KW6iuRpuu2uHBLraZ1wNZe0DP7lnRha+VJ9tNaYVaVgKhW0aI3h4RYnoRPeql0flHm/Co55b7snEDcOfOJrA==}
+    engines: {node: '>=18.0.0', npm: '>=8.0.0'}
+    hasBin: true
+
+  rpc-websockets@9.3.9:
+    resolution: {integrity: sha512-2iQDaTB4g5fDB2ihrTFSJSibCEuxaRi1q7qTW7ZO9/M5/TC+ToHA4D9/ffNLEbAoHNNrcdeP05oATNk44SKZXA==}
+
+  safe-buffer@5.2.1:
+    resolution: {integrity: sha512-rp3So07KcdmmKbGvgaNxQSJr7bGVSVk5S9Eq1F+ppbRo70+YeaDxkw5Dd8NPN+GD6bjnYm2VuPuCXmpuYvmCXQ==}
+
+  source-map@0.7.6:
+    resolution: {integrity: sha512-i5uvt8C3ikiWeNZSVZNWcfZPItFQOsYTUAOkcUPGd8DqDy1uOUikjt5dG+uRlwyvR108Fb9DOd4GvXfT0N2/uQ==}
+    engines: {node: '>= 12'}
+
+  stream-chain@2.2.5:
+    resolution: {integrity: sha512-1TJmBx6aSWqZ4tx7aTpBDXK0/e2hhcNSTV8+CbFJtDjbb+I1mZ8lHit0Grw9GRT+6JbIrrDd8esncgBi8aBXGA==}
+
+  stream-json@1.9.1:
+    resolution: {integrity: sha512-uWkjJ+2Nt/LO9Z/JyKZbMusL8Dkh97uUBTv3AJQ74y07lVahLY4eEFsPsE97pxYBwr8nnjMAIch5eqI0gPShyw==}
+
+  sucrase@3.35.1:
+    resolution: {integrity: sha512-DhuTmvZWux4H1UOnWMB3sk0sbaCVOoQZjv8u1rDoTV0HTdGem9hkAZtl4JZy8P2z4Bg0nT+YMeOFyVr4zcG5Tw==}
+    engines: {node: '>=16 || 14 >=14.17'}
+    hasBin: true
+
+  superstruct@0.15.5:
+    resolution: {integrity: sha512-4AOeU+P5UuE/4nOUkmcQdW5y7i9ndt1cQd/3iUe+LTz3RxESf/W/5lg4B74HbDMMv8PHnPnGCQFH45kBcrQYoQ==}
+
+  superstruct@2.0.2:
+    resolution: {integrity: sha512-uV+TFRZdXsqXTL2pRvujROjdZQ4RAlBUS5BTh9IGm+jTqQntYThciG/qu57Gs69yjnVUSqdxF9YLmSnpupBW9A==}
+    engines: {node: '>=14.0.0'}
+
+  text-encoding-utf-8@1.0.2:
+    resolution: {integrity: sha512-8bw4MY9WjdsD2aMtO0OzOCY3pXGYNx2d2FfHRVUKkiCPDWjKuOlhLVASS+pD7VkLTVjW268LYJHwsnPFlBpbAg==}
+
+  thenify-all@1.6.0:
+    resolution: {integrity: sha512-RNxQH/qI8/t3thXJDwcstUO4zeqo64+Uy/+sNVRBx4Xn2OX+OZ9oP+iJnNFqplFra2ZUVeKCSa2oVWi3T4uVmA==}
+    engines: {node: '>=0.8'}
+
+  thenify@3.3.1:
+    resolution: {integrity: sha512-RVZSIV5IG10Hk3enotrhvz0T9em6cyHBLkH/YAZuKqd8hRkKhSfCGIcP2KUY0EPxndzANBmNllzWPwak+bheSw==}
+
+  tinyexec@0.3.2:
+    resolution: {integrity: sha512-KQQR9yN7R5+OSwaK0XQoj22pwHoTlgYqmUscPYoknOoWCWfj/5/ABTMRi69FrKU5ffPVh5QcFikpWJI/P1ocHA==}
+
+  tinyglobby@0.2.17:
+    resolution: {integrity: sha512-wXR/dYpcqKmfWpEdZjiKJOwCNFndD0DMnrW/cYjVGttEkBfVgcLFHoNrlj47mjOVic9yyNu65alsgF4NQyTa2g==}
+    engines: {node: '>=12.0.0'}
+
+  toml@3.0.0:
+    resolution: {integrity: sha512-y/mWCZinnvxjTKYhJ+pYxwD0mRLVvOtdS2Awbgxln6iEnt4rk0yBxeSBHkGJcPucRiG0e55mwWp+g/05rsrd6w==}
+
+  tr46@0.0.3:
+    resolution: {integrity: sha512-N3WMsuqV66lT30CrXNbEjx4GEwlow3v6rr4mCcv6prnfwhS01rkgyFdjPNBYd9br7LpXV1+Emh01fHnq2Gdgrw==}
+
+  tree-kill@1.2.2:
+    resolution: {integrity: sha512-L0Orpi8qGpRG//Nd+H90vFB+3iHnue1zSSGmNOOCh1GLJ7rUKVwV2HvijphGQS2UmhUZewS9VgvxYIdgr+fG1A==}
+    hasBin: true
+
+  ts-interface-checker@0.1.13:
+    resolution: {integrity: sha512-Y/arvbn+rrz3JCKl9C4kVNfTfSm2/mEp5FSz5EsZSANGPSlQrpRI5M4PKF+mJnE52jOO90PnPSc3Ur3bTQw0gA==}
+
+  tslib@2.8.1:
+    resolution: {integrity: sha512-oJFu94HQb+KVduSUQL7wnpmqnfmLsOA/nAh6b6EH0wCEoK0/mPeXU6c3wKDV83MkOuHPRHtSXKKU99IBazS/2w==}
+
+  tsup@8.5.1:
+    resolution: {integrity: sha512-xtgkqwdhpKWr3tKPmCkvYmS9xnQK3m3XgxZHwSUjvfTjp7YfXe5tT3GgWi0F2N+ZSMsOeWeZFh7ZZFg5iPhing==}
+    engines: {node: '>=18'}
+    hasBin: true
+    peerDependencies:
+      '@microsoft/api-extractor': ^7.36.0
+      '@swc/core': ^1
+      postcss: ^8.4.12
+      typescript: '>=4.5.0'
+    peerDependenciesMeta:
+      '@microsoft/api-extractor':
+        optional: true
+      '@swc/core':
+        optional: true
+      postcss:
+        optional: true
+      typescript:
+        optional: true
+
+  tsx@4.22.4:
+    resolution: {integrity: sha512-X8EX+XV4QR5xCsrgxaED954zTDfY8KqlDtskKEL0cHhyS/P8b4IFOvGDQpsC9Q1XnLq915wEfwwY/zzskCtmhg==}
+    engines: {node: '>=18.0.0'}
+    hasBin: true
+
+  tweetnacl@1.0.3:
+    resolution: {integrity: sha512-6rt+RN7aOi1nGMyC4Xa5DdYiukl2UWCbcJft7YhxReBGQD7OAM8Pbxw6YMo4r2diNEA8FEmu32YOn9rhaiE5yw==}
+
+  typescript@5.9.3:
+    resolution: {integrity: sha512-jl1vZzPDinLr9eUt3J/t7V6FgNEw9QjvBPdysz9KfQDD41fQrC2Y4vKQdiaUpFT4bXlb1RHhLpp8wtm6M5TgSw==}
+    engines: {node: '>=14.17'}
+    hasBin: true
+
+  ufo@1.6.4:
+    resolution: {integrity: sha512-JFNbkD1Svwe0KvGi8GOeLcP4kAWQ609twvCdcHxq1oSL8svv39ZuSvajcD8B+5D0eL4+s1Is2D/O6KN3qcTeRA==}
+
+  undici-types@6.21.0:
+    resolution: {integrity: sha512-iwDZqg0QAGrg9Rav5H4n0M64c3mkR59cJ6wQp+7C4nI0gsmExaedaYLNO44eT4AtBBwjbTiGPMlt2Md0T9H9JQ==}
+
+  utf-8-validate@6.0.6:
+    resolution: {integrity: sha512-q3l3P9UtEEiAHcsgsqTgf9PPjctrDWoIXW3NpOHFdRDbLvu4DLIcxHangJ4RLrWkBcKjmcs/6NkerI8T/rE4LA==}
+    engines: {node: '>=6.14.2'}
+
+  uuid@14.0.0:
+    resolution: {integrity: sha512-Qo+uWgilfSmAhXCMav1uYFynlQO7fMFiMVZsQqZRMIXp0O7rR7qjkj+cPvBHLgBqi960QCoo/PH2/6ZtVqKvrg==}
+    hasBin: true
+
+  uuid@8.3.2:
+    resolution: {integrity: sha512-+NYs2QeMWy+GWFOEm9xnn6HCDp0l7QBD7ml8zLUmJ+93Q5NF0NocErnwkTkXVFNiX3/fpC6afS8Dhb/gz7R7eg==}
+    deprecated: uuid@10 and below is no longer supported.  For ESM codebases, update to uuid@latest.  For CommonJS codebases, use uuid@11 (but be aware this version will likely be deprecated in 2028).
+    hasBin: true
+
+  webidl-conversions@3.0.1:
+    resolution: {integrity: sha512-2JAn3z8AR6rjK8Sm8orRC0h/bcl/DqL7tRPdGZ4I1CjdF+EaMLmYxBHyXuKL849eucPFhvBoxMsflfOb8kxaeQ==}
+
+  whatwg-url@5.0.0:
+    resolution: {integrity: sha512-saE57nupxk6v3HY35+jzBwYa0rKSy0XR8JSxZPwgLr7ys0IBzhGviA1/TUGJLmSVqs8pb9AnvICXEuOHLprYTw==}
+
+  ws@7.5.11:
+    resolution: {integrity: sha512-zS54Oen9bITtp7kp2XM3AydrCIq1D+HwJOuH+c+e4LfpL/lotP5osijd+UoMnxwAam1GN8R4KtLAyIrIcBNpiA==}
+    engines: {node: '>=8.3.0'}
+    peerDependencies:
+      bufferutil: ^4.0.1
+      utf-8-validate: ^5.0.2
+    peerDependenciesMeta:
+      bufferutil:
+        optional: true
+      utf-8-validate:
+        optional: true
+
+  ws@8.21.0:
+    resolution: {integrity: sha512-Vsp28b7DRcimFQvrqu2Wek3z1iYxDCWqHYB8Qsnk/S4RfaCQzPGPyBNuVjJV3cd6UiKtUtp6sNM77gWvzcCH+g==}
+    engines: {node: '>=10.0.0'}
+    peerDependencies:
+      bufferutil: ^4.0.1
+      utf-8-validate: '>=5.0.2'
+    peerDependenciesMeta:
+      bufferutil:
+        optional: true
+      utf-8-validate:
+        optional: true
+
+snapshots:
+
+  '@babel/runtime@7.29.7': {}
+
+  '@coral-xyz/anchor-errors@0.31.1': {}
+
+  '@coral-xyz/anchor@0.32.1(bufferutil@4.1.0)(typescript@5.9.3)(utf-8-validate@6.0.6)':
+    dependencies:
+      '@coral-xyz/anchor-errors': 0.31.1
+      '@coral-xyz/borsh': 0.31.1(@solana/web3.js@1.98.4(bufferutil@4.1.0)(typescript@5.9.3)(utf-8-validate@6.0.6))
+      '@noble/hashes': 1.8.0
+      '@solana/web3.js': 1.98.4(bufferutil@4.1.0)(typescript@5.9.3)(utf-8-validate@6.0.6)
+      bn.js: 5.2.3
+      bs58: 4.0.1
+      buffer-layout: 1.2.2
+      camelcase: 6.3.0
+      cross-fetch: 3.2.0
+      eventemitter3: 4.0.7
+      pako: 2.1.0
+      superstruct: 0.15.5
+      toml: 3.0.0
+    transitivePeerDependencies:
+      - bufferutil
+      - encoding
+      - typescript
+      - utf-8-validate
+
+  '@coral-xyz/borsh@0.31.1(@solana/web3.js@1.98.4(bufferutil@4.1.0)(typescript@5.9.3)(utf-8-validate@6.0.6))':
+    dependencies:
+      '@solana/web3.js': 1.98.4(bufferutil@4.1.0)(typescript@5.9.3)(utf-8-validate@6.0.6)
+      bn.js: 5.2.3
+      buffer-layout: 1.2.2
+
+  '@esbuild/aix-ppc64@0.27.7':
+    optional: true
+
+  '@esbuild/aix-ppc64@0.28.0':
+    optional: true
+
+  '@esbuild/android-arm64@0.27.7':
+    optional: true
+
+  '@esbuild/android-arm64@0.28.0':
+    optional: true
+
+  '@esbuild/android-arm@0.27.7':
+    optional: true
+
+  '@esbuild/android-arm@0.28.0':
+    optional: true
+
+  '@esbuild/android-x64@0.27.7':
+    optional: true
+
+  '@esbuild/android-x64@0.28.0':
+    optional: true
+
+  '@esbuild/darwin-arm64@0.27.7':
+    optional: true
+
+  '@esbuild/darwin-arm64@0.28.0':
+    optional: true
+
+  '@esbuild/darwin-x64@0.27.7':
+    optional: true
+
+  '@esbuild/darwin-x64@0.28.0':
+    optional: true
+
+  '@esbuild/freebsd-arm64@0.27.7':
+    optional: true
+
+  '@esbuild/freebsd-arm64@0.28.0':
+    optional: true
+
+  '@esbuild/freebsd-x64@0.27.7':
+    optional: true
+
+  '@esbuild/freebsd-x64@0.28.0':
+    optional: true
+
+  '@esbuild/linux-arm64@0.27.7':
+    optional: true
+
+  '@esbuild/linux-arm64@0.28.0':
+    optional: true
+
+  '@esbuild/linux-arm@0.27.7':
+    optional: true
+
+  '@esbuild/linux-arm@0.28.0':
+    optional: true
+
+  '@esbuild/linux-ia32@0.27.7':
+    optional: true
+
+  '@esbuild/linux-ia32@0.28.0':
+    optional: true
+
+  '@esbuild/linux-loong64@0.27.7':
+    optional: true
+
+  '@esbuild/linux-loong64@0.28.0':
+    optional: true
+
+  '@esbuild/linux-mips64el@0.27.7':
+    optional: true
+
+  '@esbuild/linux-mips64el@0.28.0':
+    optional: true
+
+  '@esbuild/linux-ppc64@0.27.7':
+    optional: true
+
+  '@esbuild/linux-ppc64@0.28.0':
+    optional: true
+
+  '@esbuild/linux-riscv64@0.27.7':
+    optional: true
+
+  '@esbuild/linux-riscv64@0.28.0':
+    optional: true
+
+  '@esbuild/linux-s390x@0.27.7':
+    optional: true
+
+  '@esbuild/linux-s390x@0.28.0':
+    optional: true
+
+  '@esbuild/linux-x64@0.27.7':
+    optional: true
+
+  '@esbuild/linux-x64@0.28.0':
+    optional: true
+
+  '@esbuild/netbsd-arm64@0.27.7':
+    optional: true
+
+  '@esbuild/netbsd-arm64@0.28.0':
+    optional: true
+
+  '@esbuild/netbsd-x64@0.27.7':
+    optional: true
+
+  '@esbuild/netbsd-x64@0.28.0':
+    optional: true
+
+  '@esbuild/openbsd-arm64@0.27.7':
+    optional: true
+
+  '@esbuild/openbsd-arm64@0.28.0':
+    optional: true
+
+  '@esbuild/openbsd-x64@0.27.7':
+    optional: true
+
+  '@esbuild/openbsd-x64@0.28.0':
+    optional: true
+
+  '@esbuild/openharmony-arm64@0.27.7':
+    optional: true
+
+  '@esbuild/openharmony-arm64@0.28.0':
+    optional: true
+
+  '@esbuild/sunos-x64@0.27.7':
+    optional: true
+
+  '@esbuild/sunos-x64@0.28.0':
+    optional: true
+
+  '@esbuild/win32-arm64@0.27.7':
+    optional: true
+
+  '@esbuild/win32-arm64@0.28.0':
+    optional: true
+
+  '@esbuild/win32-ia32@0.27.7':
+    optional: true
+
+  '@esbuild/win32-ia32@0.28.0':
+    optional: true
+
+  '@esbuild/win32-x64@0.27.7':
+    optional: true
+
+  '@esbuild/win32-x64@0.28.0':
+    optional: true
+
+  '@iqlabs-official/solana-sdk@0.1.27(bufferutil@4.1.0)(typescript@5.9.3)(utf-8-validate@6.0.6)':
+    dependencies:
+      '@coral-xyz/anchor': 0.32.1(bufferutil@4.1.0)(typescript@5.9.3)(utf-8-validate@6.0.6)
+      '@noble/curves': 2.2.0
+      '@noble/hashes': 1.8.0
+      '@solana/web3.js': 1.98.4(bufferutil@4.1.0)(typescript@5.9.3)(utf-8-validate@6.0.6)
+    transitivePeerDependencies:
+      - bufferutil
+      - encoding
+      - typescript
+      - utf-8-validate
+
+  '@jridgewell/gen-mapping@0.3.13':
+    dependencies:
+      '@jridgewell/sourcemap-codec': 1.5.5
+      '@jridgewell/trace-mapping': 0.3.31
+
+  '@jridgewell/resolve-uri@3.1.2': {}
+
+  '@jridgewell/sourcemap-codec@1.5.5': {}
+
+  '@jridgewell/trace-mapping@0.3.31':
+    dependencies:
+      '@jridgewell/resolve-uri': 3.1.2
+      '@jridgewell/sourcemap-codec': 1.5.5
+
+  '@noble/curves@1.9.7':
+    dependencies:
+      '@noble/hashes': 1.8.0
+
+  '@noble/curves@2.2.0':
+    dependencies:
+      '@noble/hashes': 2.2.0
+
+  '@noble/hashes@1.8.0': {}
+
+  '@noble/hashes@2.2.0': {}
+
+  '@rollup/rollup-android-arm-eabi@4.61.1':
+    optional: true
+
+  '@rollup/rollup-android-arm64@4.61.1':
+    optional: true
+
+  '@rollup/rollup-darwin-arm64@4.61.1':
+    optional: true
+
+  '@rollup/rollup-darwin-x64@4.61.1':
+    optional: true
+
+  '@rollup/rollup-freebsd-arm64@4.61.1':
+    optional: true
+
+  '@rollup/rollup-freebsd-x64@4.61.1':
+    optional: true
+
+  '@rollup/rollup-linux-arm-gnueabihf@4.61.1':
+    optional: true
+
+  '@rollup/rollup-linux-arm-musleabihf@4.61.1':
+    optional: true
+
+  '@rollup/rollup-linux-arm64-gnu@4.61.1':
+    optional: true
+
+  '@rollup/rollup-linux-arm64-musl@4.61.1':
+    optional: true
+
+  '@rollup/rollup-linux-loong64-gnu@4.61.1':
+    optional: true
+
+  '@rollup/rollup-linux-loong64-musl@4.61.1':
+    optional: true
+
+  '@rollup/rollup-linux-ppc64-gnu@4.61.1':
+    optional: true
+
+  '@rollup/rollup-linux-ppc64-musl@4.61.1':
+    optional: true
+
+  '@rollup/rollup-linux-riscv64-gnu@4.61.1':
+    optional: true
+
+  '@rollup/rollup-linux-riscv64-musl@4.61.1':
+    optional: true
+
+  '@rollup/rollup-linux-s390x-gnu@4.61.1':
+    optional: true
+
+  '@rollup/rollup-linux-x64-gnu@4.61.1':
+    optional: true
+
+  '@rollup/rollup-linux-x64-musl@4.61.1':
+    optional: true
+
+  '@rollup/rollup-openbsd-x64@4.61.1':
+    optional: true
+
+  '@rollup/rollup-openharmony-arm64@4.61.1':
+    optional: true
+
+  '@rollup/rollup-win32-arm64-msvc@4.61.1':
+    optional: true
+
+  '@rollup/rollup-win32-ia32-msvc@4.61.1':
+    optional: true
+
+  '@rollup/rollup-win32-x64-gnu@4.61.1':
+    optional: true
+
+  '@rollup/rollup-win32-x64-msvc@4.61.1':
+    optional: true
+
+  '@solana/buffer-layout@4.0.1':
+    dependencies:
+      buffer: 6.0.3
+
+  '@solana/codecs-core@2.3.0(typescript@5.9.3)':
+    dependencies:
+      '@solana/errors': 2.3.0(typescript@5.9.3)
+      typescript: 5.9.3
+
+  '@solana/codecs-numbers@2.3.0(typescript@5.9.3)':
+    dependencies:
+      '@solana/codecs-core': 2.3.0(typescript@5.9.3)
+      '@solana/errors': 2.3.0(typescript@5.9.3)
+      typescript: 5.9.3
+
+  '@solana/errors@2.3.0(typescript@5.9.3)':
+    dependencies:
+      chalk: 5.6.2
+      commander: 14.0.3
+      typescript: 5.9.3
+
+  '@solana/web3.js@1.98.4(bufferutil@4.1.0)(typescript@5.9.3)(utf-8-validate@6.0.6)':
+    dependencies:
+      '@babel/runtime': 7.29.7
+      '@noble/curves': 1.9.7
+      '@noble/hashes': 1.8.0
+      '@solana/buffer-layout': 4.0.1
+      '@solana/codecs-numbers': 2.3.0(typescript@5.9.3)
+      agentkeepalive: 4.6.0
+      bn.js: 5.2.3
+      borsh: 0.7.0
+      bs58: 4.0.1
+      buffer: 6.0.3
+      fast-stable-stringify: 1.0.0
+      jayson: 4.3.0(bufferutil@4.1.0)(utf-8-validate@6.0.6)
+      node-fetch: 2.7.0
+      rpc-websockets: 9.3.9
+      superstruct: 2.0.2
+    transitivePeerDependencies:
+      - bufferutil
+      - encoding
+      - typescript
+      - utf-8-validate
+
+  '@swc/helpers@0.5.23':
+    dependencies:
+      tslib: 2.8.1
+
+  '@types/connect@3.4.38':
+    dependencies:
+      '@types/node': 20.19.42
+
+  '@types/estree@1.0.9': {}
+
+  '@types/node@12.20.55': {}
+
+  '@types/node@20.19.42':
+    dependencies:
+      undici-types: 6.21.0
+
+  '@types/uuid@10.0.0': {}
+
+  '@types/ws@7.4.7':
+    dependencies:
+      '@types/node': 20.19.42
+
+  '@types/ws@8.18.1':
+    dependencies:
+      '@types/node': 20.19.42
+
+  acorn@8.16.0: {}
+
+  agentkeepalive@4.6.0:
+    dependencies:
+      humanize-ms: 1.2.1
+
+  any-promise@1.3.0: {}
+
+  base-x@3.0.11:
+    dependencies:
+      safe-buffer: 5.2.1
+
+  base64-js@1.5.1: {}
+
+  bn.js@5.2.3: {}
+
+  borsh@0.7.0:
+    dependencies:
+      bn.js: 5.2.3
+      bs58: 4.0.1
+      text-encoding-utf-8: 1.0.2
+
+  bs58@4.0.1:
+    dependencies:
+      base-x: 3.0.11
+
+  buffer-layout@1.2.2: {}
+
+  buffer@6.0.3:
+    dependencies:
+      base64-js: 1.5.1
+      ieee754: 1.2.1
+
+  bufferutil@4.1.0:
+    dependencies:
+      node-gyp-build: 4.8.4
+    optional: true
+
+  bundle-require@5.1.0(esbuild@0.27.7):
+    dependencies:
+      esbuild: 0.27.7
+      load-tsconfig: 0.2.5
+
+  cac@6.7.14: {}
+
+  camelcase@6.3.0: {}
+
+  chalk@5.6.2: {}
+
+  chokidar@4.0.3:
+    dependencies:
+      readdirp: 4.1.2
+
+  commander@14.0.3: {}
+
+  commander@2.20.3: {}
+
+  commander@4.1.1: {}
+
+  confbox@0.1.8: {}
+
+  consola@3.4.2: {}
+
+  cross-fetch@3.2.0:
+    dependencies:
+      node-fetch: 2.7.0
+    transitivePeerDependencies:
+      - encoding
+
+  debug@4.4.3:
+    dependencies:
+      ms: 2.1.3
+
+  delay@5.0.0: {}
+
+  es6-promise@4.2.8: {}
+
+  es6-promisify@5.0.0:
+    dependencies:
+      es6-promise: 4.2.8
+
+  esbuild@0.27.7:
+    optionalDependencies:
+      '@esbuild/aix-ppc64': 0.27.7
+      '@esbuild/android-arm': 0.27.7
+      '@esbuild/android-arm64': 0.27.7
+      '@esbuild/android-x64': 0.27.7
+      '@esbuild/darwin-arm64': 0.27.7
+      '@esbuild/darwin-x64': 0.27.7
+      '@esbuild/freebsd-arm64': 0.27.7
+      '@esbuild/freebsd-x64': 0.27.7
+      '@esbuild/linux-arm': 0.27.7
+      '@esbuild/linux-arm64': 0.27.7
+      '@esbuild/linux-ia32': 0.27.7
+      '@esbuild/linux-loong64': 0.27.7
+      '@esbuild/linux-mips64el': 0.27.7
+      '@esbuild/linux-ppc64': 0.27.7
+      '@esbuild/linux-riscv64': 0.27.7
+      '@esbuild/linux-s390x': 0.27.7
+      '@esbuild/linux-x64': 0.27.7
+      '@esbuild/netbsd-arm64': 0.27.7
+      '@esbuild/netbsd-x64': 0.27.7
+      '@esbuild/openbsd-arm64': 0.27.7
+      '@esbuild/openbsd-x64': 0.27.7
+      '@esbuild/openharmony-arm64': 0.27.7
+      '@esbuild/sunos-x64': 0.27.7
+      '@esbuild/win32-arm64': 0.27.7
+      '@esbuild/win32-ia32': 0.27.7
+      '@esbuild/win32-x64': 0.27.7
+
+  esbuild@0.28.0:
+    optionalDependencies:
+      '@esbuild/aix-ppc64': 0.28.0
+      '@esbuild/android-arm': 0.28.0
+      '@esbuild/android-arm64': 0.28.0
+      '@esbuild/android-x64': 0.28.0
+      '@esbuild/darwin-arm64': 0.28.0
+      '@esbuild/darwin-x64': 0.28.0
+      '@esbuild/freebsd-arm64': 0.28.0
+      '@esbuild/freebsd-x64': 0.28.0
+      '@esbuild/linux-arm': 0.28.0
+      '@esbuild/linux-arm64': 0.28.0
+      '@esbuild/linux-ia32': 0.28.0
+      '@esbuild/linux-loong64': 0.28.0
+      '@esbuild/linux-mips64el': 0.28.0
+      '@esbuild/linux-ppc64': 0.28.0
+      '@esbuild/linux-riscv64': 0.28.0
+      '@esbuild/linux-s390x': 0.28.0
+      '@esbuild/linux-x64': 0.28.0
+      '@esbuild/netbsd-arm64': 0.28.0
+      '@esbuild/netbsd-x64': 0.28.0
+      '@esbuild/openbsd-arm64': 0.28.0
+      '@esbuild/openbsd-x64': 0.28.0
+      '@esbuild/openharmony-arm64': 0.28.0
+      '@esbuild/sunos-x64': 0.28.0
+      '@esbuild/win32-arm64': 0.28.0
+      '@esbuild/win32-ia32': 0.28.0
+      '@esbuild/win32-x64': 0.28.0
+
+  eventemitter3@4.0.7: {}
+
+  eventemitter3@5.0.4: {}
+
+  eyes@0.1.8: {}
+
+  fast-stable-stringify@1.0.0: {}
+
+  fdir@6.5.0(picomatch@4.0.4):
+    optionalDependencies:
+      picomatch: 4.0.4
+
+  fix-dts-default-cjs-exports@1.0.1:
+    dependencies:
+      magic-string: 0.30.21
+      mlly: 1.8.2
+      rollup: 4.61.1
+
+  fsevents@2.3.3:
+    optional: true
+
+  humanize-ms@1.2.1:
+    dependencies:
+      ms: 2.1.3
+
+  ieee754@1.2.1: {}
+
+  isomorphic-ws@4.0.1(ws@7.5.11(bufferutil@4.1.0)(utf-8-validate@6.0.6)):
+    dependencies:
+      ws: 7.5.11(bufferutil@4.1.0)(utf-8-validate@6.0.6)
+
+  jayson@4.3.0(bufferutil@4.1.0)(utf-8-validate@6.0.6):
+    dependencies:
+      '@types/connect': 3.4.38
+      '@types/node': 12.20.55
+      '@types/ws': 7.4.7
+      commander: 2.20.3
+      delay: 5.0.0
+      es6-promisify: 5.0.0
+      eyes: 0.1.8
+      isomorphic-ws: 4.0.1(ws@7.5.11(bufferutil@4.1.0)(utf-8-validate@6.0.6))
+      json-stringify-safe: 5.0.1
+      stream-json: 1.9.1
+      uuid: 8.3.2
+      ws: 7.5.11(bufferutil@4.1.0)(utf-8-validate@6.0.6)
+    transitivePeerDependencies:
+      - bufferutil
+      - utf-8-validate
+
+  joycon@3.1.1: {}
+
+  json-stringify-safe@5.0.1: {}
+
+  lilconfig@3.1.3: {}
+
+  lines-and-columns@1.2.4: {}
+
+  load-tsconfig@0.2.5: {}
+
+  magic-string@0.30.21:
+    dependencies:
+      '@jridgewell/sourcemap-codec': 1.5.5
+
+  mlly@1.8.2:
+    dependencies:
+      acorn: 8.16.0
+      pathe: 2.0.3
+      pkg-types: 1.3.1
+      ufo: 1.6.4
+
+  ms@2.1.3: {}
+
+  mz@2.7.0:
+    dependencies:
+      any-promise: 1.3.0
+      object-assign: 4.1.1
+      thenify-all: 1.6.0
+
+  node-fetch@2.7.0:
+    dependencies:
+      whatwg-url: 5.0.0
+
+  node-gyp-build@4.8.4:
+    optional: true
+
+  object-assign@4.1.1: {}
+
+  pako@2.1.0: {}
+
+  pathe@2.0.3: {}
+
+  picocolors@1.1.1: {}
+
+  picomatch@4.0.4: {}
+
+  pirates@4.0.7: {}
+
+  pkg-types@1.3.1:
+    dependencies:
+      confbox: 0.1.8
+      mlly: 1.8.2
+      pathe: 2.0.3
+
+  postcss-load-config@6.0.1(tsx@4.22.4):
+    dependencies:
+      lilconfig: 3.1.3
+    optionalDependencies:
+      tsx: 4.22.4
+
+  readdirp@4.1.2: {}
+
+  resolve-from@5.0.0: {}
+
+  rollup@4.61.1:
+    dependencies:
+      '@types/estree': 1.0.9
+    optionalDependencies:
+      '@rollup/rollup-android-arm-eabi': 4.61.1
+      '@rollup/rollup-android-arm64': 4.61.1
+      '@rollup/rollup-darwin-arm64': 4.61.1
+      '@rollup/rollup-darwin-x64': 4.61.1
+      '@rollup/rollup-freebsd-arm64': 4.61.1
+      '@rollup/rollup-freebsd-x64': 4.61.1
+      '@rollup/rollup-linux-arm-gnueabihf': 4.61.1
+      '@rollup/rollup-linux-arm-musleabihf': 4.61.1
+      '@rollup/rollup-linux-arm64-gnu': 4.61.1
+      '@rollup/rollup-linux-arm64-musl': 4.61.1
+      '@rollup/rollup-linux-loong64-gnu': 4.61.1
+      '@rollup/rollup-linux-loong64-musl': 4.61.1
+      '@rollup/rollup-linux-ppc64-gnu': 4.61.1
+      '@rollup/rollup-linux-ppc64-musl': 4.61.1
+      '@rollup/rollup-linux-riscv64-gnu': 4.61.1
+      '@rollup/rollup-linux-riscv64-musl': 4.61.1
+      '@rollup/rollup-linux-s390x-gnu': 4.61.1
+      '@rollup/rollup-linux-x64-gnu': 4.61.1
+      '@rollup/rollup-linux-x64-musl': 4.61.1
+      '@rollup/rollup-openbsd-x64': 4.61.1
+      '@rollup/rollup-openharmony-arm64': 4.61.1
+      '@rollup/rollup-win32-arm64-msvc': 4.61.1
+      '@rollup/rollup-win32-ia32-msvc': 4.61.1
+      '@rollup/rollup-win32-x64-gnu': 4.61.1
+      '@rollup/rollup-win32-x64-msvc': 4.61.1
+      fsevents: 2.3.3
+
+  rpc-websockets@9.3.9:
+    dependencies:
+      '@swc/helpers': 0.5.23
+      '@types/uuid': 10.0.0
+      '@types/ws': 8.18.1
+      buffer: 6.0.3
+      eventemitter3: 5.0.4
+      uuid: 14.0.0
+      ws: 8.21.0(bufferutil@4.1.0)(utf-8-validate@6.0.6)
+    optionalDependencies:
+      bufferutil: 4.1.0
+      utf-8-validate: 6.0.6
+
+  safe-buffer@5.2.1: {}
+
+  source-map@0.7.6: {}
+
+  stream-chain@2.2.5: {}
+
+  stream-json@1.9.1:
+    dependencies:
+      stream-chain: 2.2.5
+
+  sucrase@3.35.1:
+    dependencies:
+      '@jridgewell/gen-mapping': 0.3.13
+      commander: 4.1.1
+      lines-and-columns: 1.2.4
+      mz: 2.7.0
+      pirates: 4.0.7
+      tinyglobby: 0.2.17
+      ts-interface-checker: 0.1.13
+
+  superstruct@0.15.5: {}
+
+  superstruct@2.0.2: {}
+
+  text-encoding-utf-8@1.0.2: {}
+
+  thenify-all@1.6.0:
+    dependencies:
+      thenify: 3.3.1
+
+  thenify@3.3.1:
+    dependencies:
+      any-promise: 1.3.0
+
+  tinyexec@0.3.2: {}
+
+  tinyglobby@0.2.17:
+    dependencies:
+      fdir: 6.5.0(picomatch@4.0.4)
+      picomatch: 4.0.4
+
+  toml@3.0.0: {}
+
+  tr46@0.0.3: {}
+
+  tree-kill@1.2.2: {}
+
+  ts-interface-checker@0.1.13: {}
+
+  tslib@2.8.1: {}
+
+  tsup@8.5.1(tsx@4.22.4)(typescript@5.9.3):
+    dependencies:
+      bundle-require: 5.1.0(esbuild@0.27.7)
+      cac: 6.7.14
+      chokidar: 4.0.3
+      consola: 3.4.2
+      debug: 4.4.3
+      esbuild: 0.27.7
+      fix-dts-default-cjs-exports: 1.0.1
+      joycon: 3.1.1
+      picocolors: 1.1.1
+      postcss-load-config: 6.0.1(tsx@4.22.4)
+      resolve-from: 5.0.0
+      rollup: 4.61.1
+      source-map: 0.7.6
+      sucrase: 3.35.1
+      tinyexec: 0.3.2
+      tinyglobby: 0.2.17
+      tree-kill: 1.2.2
+    optionalDependencies:
+      typescript: 5.9.3
+    transitivePeerDependencies:
+      - jiti
+      - supports-color
+      - tsx
+      - yaml
+
+  tsx@4.22.4:
+    dependencies:
+      esbuild: 0.28.0
+    optionalDependencies:
+      fsevents: 2.3.3
+
+  tweetnacl@1.0.3: {}
+
+  typescript@5.9.3: {}
+
+  ufo@1.6.4: {}
+
+  undici-types@6.21.0: {}
+
+  utf-8-validate@6.0.6:
+    dependencies:
+      node-gyp-build: 4.8.4
+    optional: true
+
+  uuid@14.0.0: {}
+
+  uuid@8.3.2: {}
+
+  webidl-conversions@3.0.1: {}
+
+  whatwg-url@5.0.0:
+    dependencies:
+      tr46: 0.0.3
+      webidl-conversions: 3.0.1
+
+  ws@7.5.11(bufferutil@4.1.0)(utf-8-validate@6.0.6):
+    optionalDependencies:
+      bufferutil: 4.1.0
+      utf-8-validate: 6.0.6
+
+  ws@8.21.0(bufferutil@4.1.0)(utf-8-validate@6.0.6):
+    optionalDependencies:
+      bufferutil: 4.1.0
+      utf-8-validate: 6.0.6

--- a/scripts/test-runtime.ts
+++ b/scripts/test-runtime.ts
@@ -1,0 +1,76 @@
+// Smoke test for BOTH CLIs + shared/append session log.
+//  1. claude: send a message → capture → append-encrypted → reload
+//  2. codex:  same, independently
+//  3. shared: a second claude turn on the SAME sessionId appends (no dup file)
+// Run: pnpm test:run   (needs claude + codex installed & logged in)
+
+// Isolate test storage in a temp dir so it never pollutes the real ~/.agentnet.
+// MUST be set before importing manual.ts (it reads sessionsDir() at module load).
+import { tmpdir } from "node:os";
+import { join } from "node:path";
+process.env.AGENTNET_HOME = join(tmpdir(), "agentnet-test-" + process.pid);
+
+import nacl from "tweetnacl";
+import { createRuntime } from "../src/runtime/index.js";
+import { manualStorage } from "../src/account/storage/manual.js";
+import { SessionStore } from "../src/account/store.js";
+import type { Wallet } from "../src/runtime/contract.js";
+
+const kp = nacl.sign.keyPair.fromSeed(new Uint8Array(32).fill(7));
+const wallet: Wallet = {
+  address: "TESTWALLET",
+  async signMessage(msg) {
+    return nacl.sign.detached(msg, kp.secretKey);
+  },
+};
+
+const storage = manualStorage();
+const runtime = createRuntime(wallet, storage);
+
+async function runTurn(cli: "claude" | "codex", prompt: string, sessionId?: string) {
+  const handle = await runtime.startSession({ cli, cwd: process.cwd(), sessionId });
+  handle.onMessage((m) => {
+    if (m.role === "assistant") console.log(`    [${cli}] ${m.text.slice(0, 100)}`);
+  });
+  const done = new Promise<void>((resolve) => handle.onTurnEnd(() => resolve()));
+  handle.send(prompt);
+  await done;
+  handle.stop();
+  return handle.sessionId;
+}
+
+async function main() {
+  // 1. claude
+  console.log("→ claude turn 1");
+  const claudeId = await runTurn("claude", "reply with exactly: hello from agentnet");
+  const c1 = await new SessionStore(wallet, storage).load(claudeId);
+  console.log(`  reloaded: ${c1?.messages.length} msgs, title="${c1?.title}"`);
+
+  // 2. codex
+  console.log("→ codex turn 1");
+  const codexId = await runTurn("codex", "reply with exactly: hello from agentnet");
+  const x1 = await new SessionStore(wallet, storage).load(codexId);
+  console.log(`  reloaded: ${x1?.messages.length} msgs, title="${x1?.title}"`);
+
+  // 3. shared/append: resume the SAME claude session, append a 2nd turn
+  console.log("→ claude turn 2 (resume same session, should APPEND)");
+  await runTurn("claude", "now reply with exactly: second turn", claudeId);
+  const c2 = await new SessionStore(wallet, storage).load(claudeId);
+  console.log(`  after 2 turns: ${c2?.messages.length} msgs (expect > ${c1?.messages.length})`);
+
+  const okClaude = (c1?.messages.length ?? 0) > 0;
+  const okCodex = (x1?.messages.length ?? 0) > 0;
+  const okAppend = (c2?.messages.length ?? 0) > (c1?.messages.length ?? 0);
+  console.log(`\n  claude: ${okClaude ? "✅" : "❌"}  codex: ${okCodex ? "✅" : "❌"}  append-grows: ${okAppend ? "✅" : "❌"}`);
+
+  if (okClaude && okCodex && okAppend) console.log("\n✅ PASS — both CLIs capture, encrypt, append, reload.");
+  else {
+    console.log("\n❌ FAIL");
+    process.exit(1);
+  }
+}
+
+main().catch((e) => {
+  console.error("test error:", e);
+  process.exit(1);
+});

--- a/scripts/test-storage.ts
+++ b/scripts/test-storage.ts
@@ -1,0 +1,133 @@
+// Storage-module test (no CLI). Verifies my account/storage adapters + login flow
+// against the real SessionStore, using fake session data.
+//   1. icloud adapter (local-folder) — save → reload → append grows → no dup file
+//   2. custom adapter — against a tiny in-process HTTP server (PUT/GET/list)
+//   3. login flow — initialize(custom) → config.json → login() rebuilds storage
+// Run: pnpm tsx scripts/test-storage.ts
+
+import { createServer } from "node:http";
+import { rm, readdir } from "node:fs/promises";
+import { join } from "node:path";
+import { tmpdir } from "node:os";
+import nacl from "tweetnacl";
+import { SessionStore } from "../src/account/store.js";
+import { icloudStorage } from "../src/account/storage/icloud.js";
+import { customStorage } from "../src/account/storage/custom.js";
+import { initialize, login } from "../src/account/login.js";
+import type { Wallet } from "../src/runtime/contract.js";
+
+const kp = nacl.sign.keyPair.fromSeed(new Uint8Array(32).fill(9));
+const wallet: Wallet = {
+  address: "TESTWALLET",
+  async signMessage(msg) {
+    return nacl.sign.detached(msg, kp.secretKey);
+  },
+};
+
+const meta = (id: string) => ({ sessionId: id, cli: "claude" as const, title: "test", ts: Date.now() });
+const msg = (text: string) => ({ role: "user" as const, text, ts: Date.now() });
+
+let pass = true;
+const check = (name: string, ok: boolean) => {
+  console.log(`  ${ok ? "✅" : "❌"} ${name}`);
+  if (!ok) pass = false;
+};
+
+// 1. iCloud adapter (local folder) -------------------------------------------
+async function testIcloud() {
+  console.log("→ icloud adapter (local folder)");
+  const dir = join(tmpdir(), `agentnet-icloud-${Date.now()}`);
+  const storage = icloudStorage(dir);
+  const store = new SessionStore(wallet, storage);
+  const id = "sess-icloud-1";
+
+  await store.appendMessage(meta(id), msg("first"));
+  const a = await store.load(id);
+  check("save + reload", a?.messages.length === 1);
+
+  await store.appendMessage(meta(id), msg("second"));
+  const b = await store.load(id);
+  check("append grows (1 → 2)", (b?.messages.length ?? 0) === 2);
+
+  const files = await readdir(dir);
+  check("no duplicate file (one .bin)", files.filter((f) => f.endsWith(".bin")).length === 1);
+
+  const ids = await storage.list();
+  check("list() finds the session", ids.includes(id));
+
+  await rm(dir, { recursive: true, force: true });
+}
+
+// 2. custom adapter (in-process HTTP) ----------------------------------------
+async function testCustom() {
+  console.log("→ custom adapter (HTTP PUT/GET/list)");
+  const objs = new Map<string, Buffer>();
+  const server = createServer(async (req, res) => {
+    const url = new URL(req.url || "", "http://x");
+    if (req.method === "PUT") {
+      const chunks: Buffer[] = [];
+      for await (const c of req) chunks.push(c as Buffer);
+      objs.set(url.pathname, Buffer.concat(chunks));
+      res.statusCode = 200;
+      res.end();
+    } else if (req.method === "GET" && url.search === "?list") {
+      res.setHeader("content-type", "application/json");
+      res.end(JSON.stringify([...objs.keys()]));
+    } else if (req.method === "GET") {
+      const b = objs.get(url.pathname);
+      if (!b) { res.statusCode = 404; res.end(); return; }
+      res.end(b);
+    } else { res.statusCode = 405; res.end(); }
+  });
+  await new Promise<void>((r) => server.listen(0, "127.0.0.1", r));
+  const port = (server.address() as { port: number }).port;
+  const base = `http://127.0.0.1:${port}`;
+
+  const storage = customStorage({ kind: "custom", location: base });
+  const store = new SessionStore(wallet, storage);
+  const id = "sess-custom-1";
+
+  await store.appendMessage(meta(id), msg("hello over http"));
+  const a = await store.load(id);
+  check("save + reload over HTTP", a?.messages.length === 1);
+
+  const ids = await storage.list();
+  check("list() over HTTP finds it", ids.includes(id));
+
+  server.close();
+}
+
+// 3. login flow (initialize → config → login) --------------------------------
+async function testLogin() {
+  console.log("→ login flow (initialize custom → config.json → login)");
+  const home = join(tmpdir(), `agentnet-home-${Date.now()}`);
+  process.env.AGENTNET_HOME = home; // paths.ts root override
+  const dir = join(tmpdir(), `agentnet-login-store-${Date.now()}`);
+
+  // initialize with a local-folder "custom" (icloud kind, reuse folder) to avoid network
+  await initialize({ kind: "icloud", location: dir });
+  const session = await login(wallet);
+  check("login() returns a storage", !!session.storage);
+
+  const store = new SessionStore(session.wallet, session.storage);
+  await store.appendMessage(meta("sess-login-1"), msg("via login flow"));
+  const reloaded = await store.load("sess-login-1");
+  check("save + reload through login()'s storage", reloaded?.messages.length === 1);
+
+  await rm(home, { recursive: true, force: true });
+  await rm(dir, { recursive: true, force: true });
+  delete process.env.AGENTNET_HOME;
+}
+
+async function main() {
+  await testIcloud();
+  await testCustom();
+  await testLogin();
+  console.log(pass ? "\n✅ PASS — storage adapters + login flow work." : "\n❌ FAIL");
+  if (!pass) process.exit(1);
+}
+
+main().catch((e) => {
+  console.error("test error:", e);
+  process.exit(1);
+});

--- a/src/account/login.ts
+++ b/src/account/login.ts
@@ -1,0 +1,100 @@
+// Login / initialize flow — the first thing a surface (vscode/CLI) calls.
+//
+//   first run:  connect wallet → pick a storage backend → (gdrive: Google sign-in;
+//               icloud/custom: a path/URL) → save choice to config.json.
+//   later runs: read config.json → rebuild the same storage (gdrive refreshes its
+//               token silently). If nothing is configured yet, isInitialized() is false
+//               and the UI shows the picker.
+//
+// We persist ONLY the non-secret choice (kind + path) in config.json; OAuth tokens
+// live separately (oauth.ts → tokens/google.json). Our server stores nothing.
+
+import { readFile, writeFile, rm } from "node:fs/promises";
+import { configFile, tokenFile, rootDir, ensureDir } from "../core/paths.js";
+import { buildStorage, type StorageConfig, type StorageKind } from "./storage/adapter.js";
+import { googleLogin, isSignedIn } from "./storage/oauth.js";
+import type { StorageAdapter, Wallet } from "../runtime/contract.js";
+
+export interface Session {
+  wallet: Wallet;
+  storage: StorageAdapter;
+}
+
+async function readConfig(): Promise<StorageConfig | null> {
+  try {
+    return JSON.parse(await readFile(configFile(), "utf8")) as StorageConfig;
+  } catch {
+    return null;
+  }
+}
+
+async function writeConfig(cfg: StorageConfig): Promise<void> {
+  await ensureDir(rootDir());
+  await writeFile(configFile(), JSON.stringify(cfg, null, 2));
+}
+
+/** True once a storage backend has been chosen on this device. */
+export async function isInitialized(): Promise<boolean> {
+  return (await readConfig()) !== null;
+}
+
+// First-run setup: record the chosen backend and (for gdrive) run Google sign-in.
+// `openBrowser` is injected by the surface (only used for gdrive).
+export async function initialize(
+  cfg: StorageConfig,
+  openBrowser?: (url: string) => void,
+): Promise<void> {
+  if (cfg.kind === "gdrive" && !(await isSignedIn())) {
+    if (!openBrowser) throw new Error("gdrive needs an openBrowser callback for sign-in");
+    await googleLogin(openBrowser);
+  }
+  await writeConfig(cfg);
+}
+
+// Resume after initialize: rebuild the storage from saved config + bind the wallet.
+// Throws if not initialized yet (UI should call initialize first).
+export async function login(wallet: Wallet): Promise<Session> {
+  const cfg = await readConfig();
+  if (!cfg) throw new Error("not initialized — call initialize() with a storage choice first");
+  const storage = await buildStorage(cfg);
+  return { wallet, storage };
+}
+
+// Which backend is configured right now (for the UI to show "Saving to: Google Drive").
+export async function currentStorageKind(): Promise<StorageKind | null> {
+  return (await readConfig())?.kind ?? null;
+}
+
+// Full "my storage" info for the settings panel: which backend, where, and (for
+// gdrive) whether a token is present on this device. null = not initialized yet.
+export interface StorageInfo {
+  kind: StorageKind;
+  location?: string; // folder (icloud) or base URL (custom); undefined for gdrive/local
+  connected: boolean; // gdrive: has a local token; others: always true once configured
+}
+
+export async function getStorageInfo(): Promise<StorageInfo | null> {
+  const cfg = await readConfig();
+  if (!cfg) return null;
+  const connected = cfg.kind === "gdrive" ? await isSignedIn() : true;
+  return { kind: cfg.kind, location: cfg.location, connected };
+}
+
+// Change the storage backend later (the "use a different cloud?" UI). Same as
+// initialize, but named for intent. Re-binds: returns a fresh Session on the new
+// backend. Existing sessions stay on the old one (no migration here).
+export async function switchStorage(
+  wallet: Wallet,
+  cfg: StorageConfig,
+  openBrowser?: (url: string) => void,
+): Promise<Session> {
+  await initialize(cfg, openBrowser);
+  return login(wallet);
+}
+
+// Disconnect: forget the storage choice and any OAuth token on THIS device.
+// Does not touch already-saved session blobs (they stay in the cloud/folder).
+export async function logout(): Promise<void> {
+  await rm(configFile(), { force: true });
+  await rm(tokenFile("google"), { force: true });
+}

--- a/src/account/sessionLog.ts
+++ b/src/account/sessionLog.ts
@@ -1,0 +1,66 @@
+// The on-disk session format: an APPEND-ONLY log of encrypted records, one per
+// line (JSONL). Each record is independently encrypted, so new messages append
+// without rewriting old ones. claude and codex share one log per sessionId, so
+// they continue the same conversation. Reading = decrypt every line in order.
+//
+// This file is the single source of the storage format — change it here only.
+
+import type { ChatMessage, CanonicalSession } from "../runtime/contract.js";
+import { encryptForWallet, decryptForWallet, type SessionKey } from "../core/crypto.js";
+
+// A log record: either session meta (first line) or one chat message.
+type LogRecord =
+  | { kind: "meta"; sessionId: string; cli: string; title: string; ts: number }
+  | { kind: "msg"; msg: ChatMessage };
+
+const NL = new TextEncoder().encode("\n");
+
+// Encrypt one record → a single "<cipher-json>\n" chunk to append.
+export async function encodeRecord(key: SessionKey, rec: LogRecord): Promise<Uint8Array> {
+  const plain = new TextEncoder().encode(JSON.stringify(rec));
+  const enc = await encryptForWallet(key, plain); // already JSON bytes of {senderPub,iv,ciphertext}
+  const out = new Uint8Array(enc.length + NL.length);
+  out.set(enc, 0);
+  out.set(NL, enc.length);
+  return out;
+}
+
+// Convenience encoders for the two record kinds.
+export function metaRecord(s: Omit<CanonicalSession, "messages">): LogRecord {
+  return { kind: "meta", sessionId: s.sessionId, cli: s.cli, title: s.title, ts: s.ts };
+}
+export function msgRecord(msg: ChatMessage): LogRecord {
+  return { kind: "msg", msg };
+}
+
+// Decode a full log blob → a CanonicalSession (replays records in order).
+export async function decodeLog(
+  key: SessionKey,
+  blob: Uint8Array,
+): Promise<CanonicalSession | null> {
+  const text = new TextDecoder().decode(blob).trim();
+  if (!text) return null;
+
+  let sessionId = "";
+  let cli: "claude" | "codex" = "claude";
+  let title = "";
+  let ts = 0;
+  const messages: ChatMessage[] = [];
+
+  for (const line of text.split("\n")) {
+    if (!line.trim()) continue;
+    const plain = await decryptForWallet(key, new TextEncoder().encode(line));
+    const rec = JSON.parse(new TextDecoder().decode(plain)) as LogRecord;
+    if (rec.kind === "meta") {
+      sessionId = rec.sessionId;
+      cli = rec.cli as "claude" | "codex";
+      title = rec.title;
+      ts = rec.ts;
+    } else {
+      messages.push(rec.msg);
+    }
+  }
+
+  if (!sessionId) return null;
+  return { sessionId, cli, title, messages, ts };
+}

--- a/src/account/storage/adapter.ts
+++ b/src/account/storage/adapter.ts
@@ -1,0 +1,42 @@
+// Storage backend registry. Every backend (local, gdrive, icloud, custom) is a
+// StorageAdapter (put/get/list — see runtime/contract). This file is the one place
+// that knows the list of kinds and how to build one from a saved config, so login.ts
+// and the UI stay backend-agnostic — adding a backend = one entry here.
+
+import type { StorageAdapter } from "../../runtime/contract.js";
+
+export type StorageKind = "local" | "gdrive" | "icloud" | "custom";
+
+// Persisted, non-secret config for the chosen backend (lives in the user's
+// local profile, NOT our server). Secrets (OAuth tokens) live separately via oauth.ts.
+export interface StorageConfig {
+  kind: StorageKind;
+  // icloud/custom-local: a folder path; custom-http: a base URL; gdrive: unused.
+  location?: string;
+  // custom http: optional bearer for the user's own endpoint.
+  authHeader?: string;
+}
+
+// Lazy builders so importing the registry doesn't pull every backend's deps.
+type Builder = (cfg: StorageConfig) => Promise<StorageAdapter>;
+
+const builders: Record<StorageKind, Builder> = {
+  local: async () => (await import("./manual.js")).manualStorage(),
+  gdrive: async () => (await import("./gdrive.js")).gdriveStorage(),
+  icloud: async (cfg) => (await import("./icloud.js")).icloudStorage(cfg.location),
+  custom: async (cfg) => (await import("./custom.js")).customStorage(cfg),
+};
+
+export async function buildStorage(cfg: StorageConfig): Promise<StorageAdapter> {
+  const make = builders[cfg.kind];
+  if (!make) throw new Error(`unknown storage kind: ${cfg.kind}`);
+  return make(cfg);
+}
+
+// What the UI shows in the "where to save?" picker.
+export const STORAGE_OPTIONS: { kind: StorageKind; label: string; needs: string }[] = [
+  { kind: "gdrive", label: "Google Drive", needs: "sign in with Google" },
+  { kind: "icloud", label: "iCloud Drive", needs: "pick your iCloud folder" },
+  { kind: "custom", label: "Custom (S3 / WebDAV / HTTP)", needs: "enter endpoint" },
+  { kind: "local", label: "This device only", needs: "nothing" },
+];

--- a/src/account/storage/custom.ts
+++ b/src/account/storage/custom.ts
@@ -1,0 +1,51 @@
+// Custom StorageAdapter — the user's own HTTP endpoint (S3-compatible, WebDAV,
+// or any server that speaks PUT/GET on a path). Keeps AgentNet storage-agnostic:
+// "we provide no storage" — the user owns the bucket/box.
+//
+// Convention (simplest that works for S3 presign-less buckets and plain servers):
+//   PUT    {base}/{sessionId}.bin     write/overwrite
+//   GET    {base}/{sessionId}.bin     read   (404 → null)
+//   GET    {base}/?list               list   → JSON string[] of object keys
+// An optional bearer/authHeader is sent on every request. No append (whole-blob
+// upload); fine since the blob is a small append-only log.
+
+import type { StorageAdapter } from "../../runtime/contract.js";
+import type { StorageConfig } from "./adapter.js";
+
+export function customStorage(cfg: StorageConfig): StorageAdapter {
+  const base = (cfg.location || "").replace(/\/$/, "");
+  if (!base) throw new Error("custom storage needs a base URL (StorageConfig.location)");
+  const headers: Record<string, string> = cfg.authHeader
+    ? { Authorization: cfg.authHeader }
+    : {};
+  const objUrl = (sessionId: string) => `${base}/${sessionId}.bin`;
+
+  return {
+    async put(sessionId, blob) {
+      const res = await fetch(objUrl(sessionId), {
+        method: "PUT",
+        headers: { ...headers, "Content-Type": "application/octet-stream" },
+        body: Buffer.from(blob),
+      });
+      if (!res.ok) throw new Error(`custom put failed: ${res.status}`);
+    },
+    async get(sessionId) {
+      const res = await fetch(objUrl(sessionId), { headers });
+      if (res.status === 404) return null;
+      if (!res.ok) throw new Error(`custom get failed: ${res.status}`);
+      return new Uint8Array(await res.arrayBuffer());
+    },
+    async list() {
+      const res = await fetch(`${base}/?list`, { headers });
+      if (!res.ok) throw new Error(`custom list failed: ${res.status}`);
+      const keys = (await res.json()) as string[];
+      return keys
+        .filter((k) => k.endsWith(".bin"))
+        .map((k) => k.replace(/^.*\//, "").slice(0, -4));
+    },
+    async remove(sessionId) {
+      const res = await fetch(objUrl(sessionId), { method: "DELETE", headers });
+      if (!res.ok && res.status !== 404) throw new Error(`custom remove failed: ${res.status}`);
+    },
+  };
+}

--- a/src/account/storage/gdrive.ts
+++ b/src/account/storage/gdrive.ts
@@ -1,0 +1,103 @@
+// Google Drive StorageAdapter — stores each session blob as one file in the
+// app-private appDataFolder (the user's other Drive files are never touched).
+// Docs: https://developers.google.com/workspace/drive/api/guides/appdata
+//
+// Filename = "<sessionId>.bin". To avoid duplicates we look up the file id by
+// name first: exists → PATCH (overwrite), else → POST (create). No append API on
+// Drive, so put() uploads the whole blob — fine because the blob is a small log.
+
+import { getAccessToken } from "./oauth.js";
+import type { StorageAdapter } from "../../runtime/contract.js";
+
+const UPLOAD = "https://www.googleapis.com/upload/drive/v3/files";
+const FILES = "https://www.googleapis.com/drive/v3/files";
+
+async function auth(): Promise<Record<string, string>> {
+  return { Authorization: `Bearer ${await getAccessToken()}` };
+}
+
+function name(sessionId: string): string {
+  return `${sessionId}.bin`;
+}
+
+// Find the Drive file id for a sessionId in appDataFolder, or null.
+async function findId(sessionId: string): Promise<string | null> {
+  const q = encodeURIComponent(`name='${name(sessionId)}'`);
+  const url = `${FILES}?spaces=appDataFolder&q=${q}&fields=files(id)`;
+  const res = await fetch(url, { headers: await auth() });
+  if (!res.ok) throw new Error(`drive list failed: ${res.status}`);
+  const data = (await res.json()) as { files: { id: string }[] };
+  return data.files[0]?.id ?? null;
+}
+
+export function gdriveStorage(): StorageAdapter {
+  return {
+    async put(sessionId, blob) {
+      const id = await findId(sessionId);
+      if (id) {
+        // overwrite existing file content (media-only PATCH)
+        const res = await fetch(`${UPLOAD}/${id}?uploadType=media`, {
+          method: "PATCH",
+          headers: { ...(await auth()), "Content-Type": "application/octet-stream" },
+          body: Buffer.from(blob),
+        });
+        if (!res.ok) throw new Error(`drive update failed: ${res.status}`);
+      } else {
+        // create new file in appDataFolder (multipart: metadata + content)
+        const boundary = "agentnet" + Math.random().toString(36).slice(2);
+        const meta = JSON.stringify({ name: name(sessionId), parents: ["appDataFolder"] });
+        const body = buildMultipart(boundary, meta, blob);
+        const res = await fetch(`${UPLOAD}?uploadType=multipart`, {
+          method: "POST",
+          headers: {
+            ...(await auth()),
+            "Content-Type": `multipart/related; boundary=${boundary}`,
+          },
+          body: Buffer.from(body),
+        });
+        if (!res.ok) throw new Error(`drive create failed: ${res.status}`);
+      }
+    },
+
+    async get(sessionId) {
+      const id = await findId(sessionId);
+      if (!id) return null;
+      const res = await fetch(`${FILES}/${id}?alt=media`, { headers: await auth() });
+      if (res.status === 404) return null;
+      if (!res.ok) throw new Error(`drive get failed: ${res.status}`);
+      return new Uint8Array(await res.arrayBuffer());
+    },
+
+    async list() {
+      const url = `${FILES}?spaces=appDataFolder&fields=files(name)&pageSize=1000`;
+      const res = await fetch(url, { headers: await auth() });
+      if (!res.ok) throw new Error(`drive list failed: ${res.status}`);
+      const data = (await res.json()) as { files: { name: string }[] };
+      return data.files
+        .filter((f) => f.name.endsWith(".bin"))
+        .map((f) => f.name.slice(0, -4));
+    },
+
+    async remove(sessionId) {
+      const id = await findId(sessionId);
+      if (!id) return; // already gone
+      const res = await fetch(`${FILES}/${id}`, { method: "DELETE", headers: await auth() });
+      if (!res.ok && res.status !== 404) throw new Error(`drive remove failed: ${res.status}`);
+    },
+  };
+}
+
+// metadata part + binary part as a single multipart/related body
+function buildMultipart(boundary: string, metaJson: string, blob: Uint8Array): Uint8Array {
+  const enc = new TextEncoder();
+  const head = enc.encode(
+    `--${boundary}\r\nContent-Type: application/json; charset=UTF-8\r\n\r\n${metaJson}\r\n` +
+      `--${boundary}\r\nContent-Type: application/octet-stream\r\n\r\n`,
+  );
+  const tail = enc.encode(`\r\n--${boundary}--`);
+  const out = new Uint8Array(head.length + blob.length + tail.length);
+  out.set(head, 0);
+  out.set(blob, head.length);
+  out.set(tail, head.length + blob.length);
+  return out;
+}

--- a/src/account/storage/icloud.ts
+++ b/src/account/storage/icloud.ts
@@ -1,0 +1,57 @@
+// iCloud Drive StorageAdapter — just a local folder that macOS syncs for us.
+// We write files into the user's iCloud Drive path; the OS handles the sync to
+// their other Apple devices. No API, no tokens — that's the whole point of
+// "icloud = local folder" (decided with zo). Supports append for fast writes.
+//
+// Default location is the iCloud Drive container; the user can point `folder`
+// anywhere (login.ts saves it in StorageConfig.location).
+
+import { mkdir, readFile, writeFile, readdir, appendFile, rm } from "node:fs/promises";
+import { join } from "node:path";
+import { homedir } from "node:os";
+import type { StorageAdapter } from "../../runtime/contract.js";
+
+// macOS iCloud Drive root for the user's documents.
+function defaultIcloudDir(): string {
+  return join(
+    homedir(),
+    "Library",
+    "Mobile Documents",
+    "com~apple~CloudDocs",
+    "AgentNet",
+  );
+}
+
+export function icloudStorage(folder?: string): StorageAdapter {
+  const dir = folder || defaultIcloudDir();
+  const path = (sessionId: string) => join(dir, `${sessionId}.bin`);
+
+  return {
+    async put(sessionId, blob) {
+      await mkdir(dir, { recursive: true });
+      await writeFile(path(sessionId), blob);
+    },
+    async append(sessionId, chunk) {
+      await mkdir(dir, { recursive: true });
+      await appendFile(path(sessionId), chunk);
+    },
+    async get(sessionId) {
+      try {
+        return new Uint8Array(await readFile(path(sessionId)));
+      } catch {
+        return null;
+      }
+    },
+    async list() {
+      try {
+        const files = await readdir(dir);
+        return files.filter((f) => f.endsWith(".bin")).map((f) => f.slice(0, -4));
+      } catch {
+        return [];
+      }
+    },
+    async remove(sessionId) {
+      await rm(path(sessionId), { force: true });
+    },
+  };
+}

--- a/src/account/storage/manual.ts
+++ b/src/account/storage/manual.ts
@@ -1,0 +1,47 @@
+// Local-file StorageAdapter — the PoC backend. Swappable later for gdrive /
+// on-chain (same StorageAdapter interface). Stores one file per sessionId under
+// a fixed dir; the blob is already encrypted by the caller (store.ts).
+
+import { mkdir, readFile, writeFile, appendFile, readdir, rm } from "node:fs/promises";
+import { join } from "node:path";
+import { sessionsDir } from "../../core/paths.js";
+import type { StorageAdapter } from "../../runtime/contract.js";
+
+// Path resolved per-call from core/paths (honors AGENTNET_HOME). Resolving at call
+// time — not module load — lets a test set AGENTNET_HOME before first use without
+// fighting import hoisting, so tests never pollute the real ~/.agentnet.
+const EXT = ".log";
+const dir = () => sessionsDir();
+const file = (id: string) => join(dir(), `${id}${EXT}`); // encrypted append-only JSONL
+
+export function manualStorage(): StorageAdapter {
+  return {
+    async put(sessionId, blob) {
+      await mkdir(dir(), { recursive: true });
+      await writeFile(file(sessionId), blob);
+    },
+    // real append — adds the chunk to the file end, no rewrite.
+    async append(sessionId, chunk) {
+      await mkdir(dir(), { recursive: true });
+      await appendFile(file(sessionId), chunk);
+    },
+    async get(sessionId) {
+      try {
+        return new Uint8Array(await readFile(file(sessionId)));
+      } catch {
+        return null;
+      }
+    },
+    async list() {
+      try {
+        const files = await readdir(dir());
+        return files.filter((f) => f.endsWith(EXT)).map((f) => f.slice(0, -EXT.length));
+      } catch {
+        return [];
+      }
+    },
+    async remove(sessionId) {
+      await rm(file(sessionId), { force: true }); // force = no error if already gone
+    },
+  };
+}

--- a/src/account/storage/oauth.ts
+++ b/src/account/storage/oauth.ts
@@ -1,0 +1,154 @@
+// Google OAuth 2.0 for native apps — loopback IP flow with PKCE.
+// Docs: https://developers.google.com/identity/protocols/oauth2/native-app
+//
+// We open a one-shot localhost HTTP listener, send the user to Google's consent
+// page, catch the redirect with ?code=, exchange it (+ PKCE verifier) for tokens,
+// and store them at core/paths tokenFile("google"). PER DEVICE, local only — our
+// server never sees a token. getAccessToken() refreshes transparently.
+//
+// Setup: a Google Cloud OAuth client of type "Desktop app" gives a client_id
+// (and client_secret, which for installed apps is not secret). Provide via
+// GOOGLE_CLIENT_ID / GOOGLE_CLIENT_SECRET env.
+
+import { createServer } from "node:http";
+import { randomBytes, createHash } from "node:crypto";
+import { readFile, writeFile } from "node:fs/promises";
+import { tokenFile, tokensDir, ensureDir } from "../../core/paths.js";
+
+const AUTH_URL = "https://accounts.google.com/o/oauth2/v2/auth";
+const TOKEN_URL = "https://oauth2.googleapis.com/token";
+const SCOPE = "https://www.googleapis.com/auth/drive.appdata";
+const PROVIDER = "google";
+
+interface StoredToken {
+  access_token: string;
+  refresh_token: string;
+  expiry: number; // epoch ms
+}
+
+function clientId(): string {
+  const id = process.env.GOOGLE_CLIENT_ID;
+  if (!id) throw new Error("GOOGLE_CLIENT_ID not set (Desktop-app OAuth client)");
+  return id;
+}
+function clientSecret(): string {
+  return process.env.GOOGLE_CLIENT_SECRET || ""; // not secret for installed apps
+}
+
+// PKCE: verifier + S256 challenge
+function pkce() {
+  const verifier = base64url(randomBytes(32));
+  const challenge = base64url(createHash("sha256").update(verifier).digest());
+  return { verifier, challenge };
+}
+function base64url(buf: Buffer): string {
+  return buf.toString("base64").replace(/\+/g, "-").replace(/\//g, "_").replace(/=+$/, "");
+}
+
+// Run the interactive consent once and persist tokens. `openBrowser` is injected
+// so the UI (vscode/CLI) decides how to open the URL (shell open, vscode.env.openExternal…).
+export async function googleLogin(openBrowser: (url: string) => void): Promise<void> {
+  const { verifier, challenge } = pkce();
+  const state = base64url(randomBytes(16));
+
+  // The listener binds to a random port; redirect_uri is known only inside the
+  // listen callback, so we capture the (code, redirect) pair together and exchange
+  // after — keeping redirect_uri identical between auth request and token request.
+  const { code, redirect } = await new Promise<{ code: string; redirect: string }>(
+    (resolve, reject) => {
+      const server = createServer((req, res) => {
+        const url = new URL(req.url || "", "http://127.0.0.1");
+        const code = url.searchParams.get("code");
+        const gotState = url.searchParams.get("state");
+        res.end("AgentNet: Google connected. You can close this tab.");
+        server.close();
+        if (!code || gotState !== state) reject(new Error("oauth: bad redirect"));
+        else resolve({ code, redirect });
+      });
+      let redirect = "";
+      server.listen(0, "127.0.0.1", () => {
+        const port = (server.address() as { port: number }).port;
+        redirect = `http://127.0.0.1:${port}`;
+        const auth = `${AUTH_URL}?${new URLSearchParams({
+          client_id: clientId(),
+          redirect_uri: redirect,
+          response_type: "code",
+          scope: SCOPE,
+          code_challenge: challenge,
+          code_challenge_method: "S256",
+          state,
+          access_type: "offline", // ensures a refresh_token
+          prompt: "consent",
+        })}`;
+        openBrowser(auth);
+      });
+    },
+  );
+
+  await exchangeCode(code, verifier, redirect);
+}
+
+async function exchangeCode(code: string, verifier: string, redirect: string): Promise<void> {
+  const res = await fetch(TOKEN_URL, {
+    method: "POST",
+    headers: { "Content-Type": "application/x-www-form-urlencoded" },
+    body: new URLSearchParams({
+      client_id: clientId(),
+      client_secret: clientSecret(),
+      redirect_uri: redirect,
+      grant_type: "authorization_code",
+      code,
+      code_verifier: verifier,
+    }),
+  });
+  if (!res.ok) throw new Error(`oauth token exchange failed: ${res.status} ${await res.text()}`);
+  const t = (await res.json()) as { access_token: string; refresh_token: string; expires_in: number };
+  await saveToken({
+    access_token: t.access_token,
+    refresh_token: t.refresh_token,
+    expiry: Date.now() + t.expires_in * 1000,
+  });
+}
+
+// Valid access token, refreshing if expired. Throws if not logged in.
+export async function getAccessToken(): Promise<string> {
+  const tok = await loadToken();
+  if (!tok) throw new Error("not signed in to Google — run googleLogin first");
+  if (Date.now() < tok.expiry - 60_000) return tok.access_token;
+
+  const res = await fetch(TOKEN_URL, {
+    method: "POST",
+    headers: { "Content-Type": "application/x-www-form-urlencoded" },
+    body: new URLSearchParams({
+      client_id: clientId(),
+      client_secret: clientSecret(),
+      grant_type: "refresh_token",
+      refresh_token: tok.refresh_token,
+    }),
+  });
+  if (!res.ok) throw new Error(`oauth refresh failed: ${res.status}`);
+  const t = (await res.json()) as { access_token: string; expires_in: number };
+  const updated: StoredToken = {
+    access_token: t.access_token,
+    refresh_token: tok.refresh_token, // refresh token persists
+    expiry: Date.now() + t.expires_in * 1000,
+  };
+  await saveToken(updated);
+  return updated.access_token;
+}
+
+export async function isSignedIn(): Promise<boolean> {
+  return (await loadToken()) !== null;
+}
+
+async function saveToken(tok: StoredToken): Promise<void> {
+  await ensureDir(tokensDir());
+  await writeFile(tokenFile(PROVIDER), JSON.stringify(tok), { mode: 0o600 });
+}
+async function loadToken(): Promise<StoredToken | null> {
+  try {
+    return JSON.parse(await readFile(tokenFile(PROVIDER), "utf8")) as StoredToken;
+  } catch {
+    return null;
+  }
+}

--- a/src/account/store.ts
+++ b/src/account/store.ts
@@ -1,0 +1,80 @@
+// Session persistence over an append-only encrypted log (see sessionLog.ts).
+// - appendMessage(): adds ONE encrypted line (fast, no rewrite). Uses the
+//   adapter's append if present, else get+put (still additive — the blob is a log).
+// - load(): reads the whole log and replays it into a CanonicalSession.
+// One log per sessionId → claude and codex sharing a sessionId share the log.
+
+import type {
+  CanonicalSession,
+  ChatMessage,
+  SessionMeta,
+  StorageAdapter,
+  Wallet,
+} from "../runtime/contract.js";
+import { deriveSessionKey, type SessionKey } from "../core/crypto.js";
+import { encodeRecord, metaRecord, msgRecord, decodeLog } from "./sessionLog.js";
+
+export class SessionStore {
+  private key?: SessionKey;
+  private started = new Set<string>(); // sessionIds whose meta line is written
+
+  constructor(
+    private wallet: Wallet,
+    private storage: StorageAdapter,
+  ) {}
+
+  private async getKey(): Promise<SessionKey> {
+    if (!this.key) this.key = await deriveSessionKey(this.wallet);
+    return this.key;
+  }
+
+  private async write(sessionId: string, chunk: Uint8Array): Promise<void> {
+    if (this.storage.append) {
+      await this.storage.append(sessionId, chunk);
+    } else {
+      const prev = (await this.storage.get(sessionId)) ?? new Uint8Array();
+      const merged = new Uint8Array(prev.length + chunk.length);
+      merged.set(prev, 0);
+      merged.set(chunk, prev.length);
+      await this.storage.put(sessionId, merged);
+    }
+  }
+
+  // Append one message. On first call for a session, also writes the meta line.
+  async appendMessage(
+    meta: Omit<CanonicalSession, "messages">,
+    msg: ChatMessage,
+  ): Promise<void> {
+    const key = await this.getKey();
+    if (!this.started.has(meta.sessionId)) {
+      // if a log already exists (resumed session), don't re-write meta
+      const existing = await this.storage.get(meta.sessionId);
+      if (!existing || existing.length === 0) {
+        await this.write(meta.sessionId, await encodeRecord(key, metaRecord(meta)));
+      }
+      this.started.add(meta.sessionId);
+    }
+    await this.write(meta.sessionId, await encodeRecord(key, msgRecord(msg)));
+  }
+
+  async remove(sessionId: string): Promise<void> {
+    this.started.delete(sessionId);
+    await this.storage.remove(sessionId);
+  }
+
+  async load(sessionId: string): Promise<CanonicalSession | null> {
+    const blob = await this.storage.get(sessionId);
+    if (!blob) return null;
+    return decodeLog(await this.getKey(), blob);
+  }
+
+  async listMine(): Promise<SessionMeta[]> {
+    const ids = await this.storage.list();
+    const metas: SessionMeta[] = [];
+    for (const id of ids) {
+      const s = await this.load(id);
+      if (s) metas.push({ sessionId: s.sessionId, title: s.title, cli: s.cli, ts: s.ts });
+    }
+    return metas.sort((a, b) => b.ts - a.ts);
+  }
+}

--- a/src/core/crypto.ts
+++ b/src/core/crypto.ts
@@ -1,0 +1,46 @@
+// Encryption for session blobs — built on iqlabs crypto, no new crypto here.
+// Key is derived from the wallet signature (same wallet → same key on any device),
+// so only the wallet can decrypt its own sessions.
+
+import {
+  deriveX25519Keypair,
+  dhEncrypt,
+  dhDecrypt,
+  bytesToHex,
+} from "@iqlabs-official/solana-sdk/crypto";
+import type { Wallet } from "../runtime/contract.js";
+
+export interface SessionKey {
+  privKey: Uint8Array;
+  pubHex: string;
+}
+
+// deriveX25519Keypair signs its OWN fixed message internally (deterministic),
+// so we hand it the wallet's signMessage directly. Same wallet → same key,
+// on any device → can decrypt its own sessions anywhere.
+export async function deriveSessionKey(wallet: Wallet): Promise<SessionKey> {
+  const { privKey, pubKey } = await deriveX25519Keypair(wallet.signMessage);
+  return { privKey, pubHex: bytesToHex(pubKey) };
+}
+
+// Encrypt a session blob to the wallet itself (self-recipient).
+// Returns a single bytes payload (JSON of the dh result) to hand to StorageAdapter.put.
+export async function encryptForWallet(
+  key: SessionKey,
+  plaintext: Uint8Array,
+): Promise<Uint8Array> {
+  const enc = await dhEncrypt(key.pubHex, plaintext);
+  return new TextEncoder().encode(JSON.stringify(enc));
+}
+
+export async function decryptForWallet(
+  key: SessionKey,
+  payload: Uint8Array,
+): Promise<Uint8Array> {
+  const enc = JSON.parse(new TextDecoder().decode(payload)) as {
+    senderPub: string;
+    iv: string;
+    ciphertext: string;
+  };
+  return dhDecrypt(key.privKey, enc.senderPub, enc.iv, enc.ciphertext);
+}

--- a/src/core/paths.ts
+++ b/src/core/paths.ts
@@ -1,0 +1,50 @@
+// Single source of truth for every local path AgentNet writes on a device.
+// Nothing else hard-codes a path or reads ~/.agentnet directly — call these.
+// Layout (all under one root so it's easy to find, back up, or wipe):
+//
+//   ~/.agentnet/                        ROOT  (override with AGENTNET_HOME)
+//   ├── config.json                     which storage backend + non-secret config
+//   ├── tokens/<provider>.json          OAuth tokens, PER DEVICE, local only (gitignored intent)
+//   ├── sessions/<sessionId>.bin        local session logs (local backend / cache)
+//   └── git/                            repos/data WE manage on this device
+//
+// Why files, not just env: a fixed, named layout means a token or session is always
+// findable the same way on every device. AGENTNET_HOME lets tests / multi-account
+// point elsewhere without touching code.
+
+import { join } from "node:path";
+import { homedir } from "node:os";
+import { mkdir } from "node:fs/promises";
+
+/** Root dir for all AgentNet local state. Override: AGENTNET_HOME. */
+export function rootDir(): string {
+  return process.env.AGENTNET_HOME || join(homedir(), ".agentnet");
+}
+
+export function configFile(): string {
+  return join(rootDir(), "config.json");
+}
+
+/** OAuth token file for a provider (e.g. "google"). Per device, never synced/committed. */
+export function tokenFile(provider: string): string {
+  return join(rootDir(), "tokens", `${provider}.json`);
+}
+
+export function tokensDir(): string {
+  return join(rootDir(), "tokens");
+}
+
+/** Local session-log dir (local backend, or a cache for cloud backends). */
+export function sessionsDir(): string {
+  return join(rootDir(), "sessions");
+}
+
+/** Dir for git repos / data AgentNet manages on this device. */
+export function gitDir(): string {
+  return join(rootDir(), "git");
+}
+
+/** Ensure a directory exists (mkdir -p). Call before writing into it. */
+export async function ensureDir(dir: string): Promise<void> {
+  await mkdir(dir, { recursive: true });
+}

--- a/src/index.ts
+++ b/src/index.ts
@@ -1,0 +1,40 @@
+// Public entry for surfaces (vscode, cli). One import point so UIs never reach
+// into internal files. Build a live runtime in one call: connect a wallet,
+// restore the chosen storage, wire the engine.
+
+export type {
+  AgentRuntime,
+  SessionHandle,
+  SessionMeta,
+  ChatMessage,
+  CanonicalSession,
+  Wallet,
+  StorageAdapter,
+} from "./runtime/contract.js";
+
+export { createRuntime } from "./runtime/index.js";
+export { detectCli } from "./runtime/detect.js";
+export type { CliStatus, CliReport } from "./runtime/detect.js";
+export {
+  initialize,
+  isInitialized,
+  login,
+  logout,
+  switchStorage,
+  currentStorageKind,
+  getStorageInfo,
+} from "./account/login.js";
+export { STORAGE_OPTIONS } from "./account/storage/adapter.js";
+export type { StorageConfig, StorageKind } from "./account/storage/adapter.js";
+export { manualStorage } from "./account/storage/manual.js";
+
+import type { AgentRuntime, Wallet } from "./runtime/contract.js";
+import { createRuntime } from "./runtime/index.js";
+import { login } from "./account/login.js";
+
+// Connect a wallet, restore its configured storage, return a ready runtime.
+// (Assumes initialize() was already run once to pick a storage backend.)
+export async function connect(wallet: Wallet): Promise<AgentRuntime> {
+  const session = await login(wallet);
+  return createRuntime(session.wallet, session.storage);
+}

--- a/src/runtime/contract.ts
+++ b/src/runtime/contract.ts
@@ -1,0 +1,86 @@
+// AgentNet runtime ⇄ surface CONTRACT.
+// The single agreed interface between the engine (src/runtime) and any UI
+// (surfaces/vscode, CLI). Both sides import only this. Implementations live
+// in runtime/*; UIs call these and never touch internals.
+//
+// CODE-RULES: keep this the one source of these types. Don't redefine elsewhere.
+
+// ── wallet ──────────────────────────────────────────────
+export interface Wallet {
+  address: string; // base58
+  // used to derive the encryption key (iqlabs deriveX25519Keypair)
+  signMessage(msg: Uint8Array): Promise<Uint8Array>;
+}
+
+// ── storage (swappable: local file now → drive / on-chain later) ──
+export interface StorageAdapter {
+  // put = write/overwrite the whole blob (cloud adapters upload the full file).
+  put(sessionId: string, blob: Uint8Array): Promise<void>;
+  get(sessionId: string): Promise<Uint8Array | null>;
+  list(): Promise<string[]>; // sessionIds this storage holds
+  remove(sessionId: string): Promise<void>; // delete a session's stored blob
+  // OPTIONAL append — adapters that support it (local file) get fast incremental
+  // writes. Cloud adapters can omit it; the store falls back to get+put (which,
+  // because the blob is an append-only log, still only adds content).
+  append?(sessionId: string, chunk: Uint8Array): Promise<void>;
+}
+
+// ── chat message ────────────────────────────────────────
+// `partial` lets us start with whole-turn messages and add streaming deltas
+// later WITHOUT changing the UI contract: today emit one message (partial:false);
+// later emit many (partial:true) then a final (partial:false).
+export interface ChatMessage {
+  role: "user" | "assistant" | "thinking" | "tool";
+  text: string;
+  ts: number;
+  partial?: boolean; // true = streaming delta (future); absent/false = complete
+}
+
+// ── a running session (the handle the UI drives) ────────
+export interface SessionHandle {
+  readonly sessionId: string; // from the CLI's system/init
+  readonly cli: "claude" | "codex";
+  send(userText: string): void; // user input → CLI stdin
+  onMessage(cb: (msg: ChatMessage) => void): void; // CLI output (UI renders)
+  onTurnEnd(cb: () => void): void; // turn finished (runtime auto-saves here)
+  stop(): void;
+}
+
+// ── the engine the UI calls ─────────────────────────────
+export interface AgentRuntime {
+  // spawn claude/codex and start a session. Pass sessionId to resume an old one.
+  // The runtime auto-saves (encrypt → storage) on every turn end — the UI does nothing.
+  startSession(opts: {
+    cli: "claude" | "codex";
+    cwd: string;
+    sessionId?: string; // present = resume, absent = new
+    model?: string;
+  }): Promise<SessionHandle>;
+
+  // list the wallet's saved sessions (for the UI's session list)
+  listSessions(): Promise<SessionMeta[]>;
+
+  // load a saved session's past messages (so a resumed session shows its history).
+  // Returns [] if not found. Call this on resume BEFORE startSession to repaint.
+  loadSession(sessionId: string): Promise<ChatMessage[]>;
+
+  // delete a saved session (storage blob). The UI removes it from the list.
+  deleteSession(sessionId: string): Promise<void>;
+}
+
+// ── persisted forms ─────────────────────────────────────
+export interface SessionMeta {
+  sessionId: string;
+  title: string; // derived (e.g. first user line)
+  cli: "claude" | "codex";
+  ts: number; // last updated
+}
+
+// what gets encrypted to storage (CLI-neutral, so codex↔claude + cross-device)
+export interface CanonicalSession {
+  sessionId: string;
+  cli: "claude" | "codex";
+  title: string;
+  messages: ChatMessage[];
+  ts: number;
+}

--- a/src/runtime/convert/claude.ts
+++ b/src/runtime/convert/claude.ts
@@ -1,0 +1,49 @@
+// Parse claude CLI stream-json lines into our neutral ChatMessage.
+// Reference: opencode-claude-code-plugin claude-code-language-model.ts (line loop).
+// We only need: session_id (from system/init), assistant text/thinking, turn end (result).
+// Tool details are folded into a "tool" message for now (kept minimal).
+
+import type { ParseResult } from "./types.js";
+
+// claude stream-json shapes we read (loose — ignore the rest)
+interface ClaudeLine {
+  type: string;
+  subtype?: string;
+  session_id?: string;
+  message?: { content?: Array<{ type: string; text?: string; thinking?: string }> };
+}
+
+export function parseClaudeLine(line: string): ParseResult {
+  const out: ParseResult = { messages: [], turnEnded: false };
+  const trimmed = line.trim();
+  if (!trimmed) return out;
+
+  let msg: ClaudeLine;
+  try {
+    msg = JSON.parse(trimmed);
+  } catch {
+    return out; // non-JSON line — ignore
+  }
+
+  if (msg.type === "system" && msg.subtype === "init" && msg.session_id) {
+    out.sessionId = msg.session_id;
+  }
+
+  // Complete assistant message (whole-turn mode; deltas added later via `partial`)
+  if (msg.type === "assistant" && msg.message?.content) {
+    for (const block of msg.message.content) {
+      if (block.type === "text" && block.text) {
+        out.messages.push({ role: "assistant", text: block.text, ts: Date.now() });
+      } else if (block.type === "thinking" && block.thinking) {
+        out.messages.push({ role: "thinking", text: block.thinking, ts: Date.now() });
+      }
+    }
+  }
+
+  if (msg.type === "result") {
+    if (msg.session_id) out.sessionId = msg.session_id;
+    out.turnEnded = true;
+  }
+
+  return out;
+}

--- a/src/runtime/convert/codex.ts
+++ b/src/runtime/convert/codex.ts
@@ -1,0 +1,46 @@
+// Parse codex `exec --json` JSONL lines into our neutral ChatMessage.
+// Real events (verified by running codex exec --json):
+//   {"type":"thread.started","thread_id":"<uuid>"}          → sessionId
+//   {"type":"item.completed","item":{"type":"agent_message","text":"..."}} → assistant
+//   {"type":"item.completed","item":{"type":"reasoning","text":"..."}}      → thinking
+//   {"type":"turn.completed","usage":{...}}                 → turn end
+// Same ParseResult shape as claude.ts so runtime treats both uniformly.
+
+import type { ParseResult } from "./types.js";
+
+interface CodexLine {
+  type: string;
+  thread_id?: string;
+  item?: { type?: string; text?: string };
+}
+
+export function parseCodexLine(line: string): ParseResult {
+  const out: ParseResult = { messages: [], turnEnded: false };
+  const trimmed = line.trim();
+  if (!trimmed) return out;
+
+  let msg: CodexLine;
+  try {
+    msg = JSON.parse(trimmed);
+  } catch {
+    return out; // non-JSON line — ignore
+  }
+
+  if (msg.type === "thread.started" && msg.thread_id) {
+    out.sessionId = msg.thread_id;
+  }
+
+  if (msg.type === "item.completed" && msg.item?.text) {
+    if (msg.item.type === "agent_message") {
+      out.messages.push({ role: "assistant", text: msg.item.text, ts: Date.now() });
+    } else if (msg.item.type === "reasoning") {
+      out.messages.push({ role: "thinking", text: msg.item.text, ts: Date.now() });
+    }
+  }
+
+  if (msg.type === "turn.completed") {
+    out.turnEnded = true;
+  }
+
+  return out;
+}

--- a/src/runtime/convert/types.ts
+++ b/src/runtime/convert/types.ts
@@ -1,0 +1,13 @@
+// Shared shape returned by every CLI line parser (claude.ts, codex.ts).
+// Keeping it here lets runtime treat all CLIs uniformly.
+
+import type { ChatMessage } from "../contract.js";
+
+export interface ParseResult {
+  sessionId?: string; // set when the CLI reveals its session/thread id
+  messages: ChatMessage[]; // 0+ complete messages emitted by this line
+  turnEnded: boolean; // true when the CLI signals the turn is done
+}
+
+// A line parser for one CLI's stream-json/jsonl output.
+export type LineParser = (line: string) => ParseResult;

--- a/src/runtime/detect.ts
+++ b/src/runtime/detect.ts
@@ -1,0 +1,43 @@
+// CLI availability check for onboarding. Standalone (no wallet/storage) —
+// answers "is codex/claude installed, and logged in?" so the UI can guide setup.
+
+import { spawn } from "node:child_process";
+
+export type CliStatus = "ok" | "no-login" | "missing";
+export interface CliReport {
+  codex: CliStatus;
+  claude: CliStatus;
+}
+
+// Run `<cmd> <args>` and resolve {code, out, missing}. missing=true on ENOENT.
+function run(cmd: string, args: string[]): Promise<{ code: number | null; out: string; missing: boolean }> {
+  return new Promise((resolve) => {
+    let out = "";
+    const p = spawn(cmd, args, { stdio: ["ignore", "pipe", "pipe"] });
+    p.stdout?.on("data", (d) => (out += d.toString()));
+    p.stderr?.on("data", (d) => (out += d.toString()));
+    p.on("error", () => resolve({ code: null, out: "", missing: true }));
+    p.on("exit", (code) => resolve({ code, out, missing: false }));
+  });
+}
+
+async function checkClaude(): Promise<CliStatus> {
+  const v = await run("claude", ["--version"]);
+  if (v.missing) return "missing";
+  // claude prints version even when logged out; login state surfaces on first use.
+  // Treat installed = ok for now; refine if claude exposes an auth-status command.
+  return "ok";
+}
+
+async function checkCodex(): Promise<CliStatus> {
+  const v = await run("codex", ["--version"]);
+  if (v.missing) return "missing";
+  const status = await run("codex", ["login", "status"]);
+  if (!status.missing && /not logged in|logged out|no auth/i.test(status.out)) return "no-login";
+  return "ok";
+}
+
+export async function detectCli(): Promise<CliReport> {
+  const [codex, claude] = await Promise.all([checkCodex(), checkClaude()]);
+  return { codex, claude };
+}

--- a/src/runtime/index.ts
+++ b/src/runtime/index.ts
@@ -1,0 +1,99 @@
+// AgentRuntime implementation — wires spawn + parse + append-on-the-fly.
+// startSession() spawns the CLI, turns its output into ChatMessages (onMessage),
+// and APPENDS each message to the encrypted log as it happens (no full rewrite).
+// Messages seen before the real sessionId arrives are queued, then flushed once
+// the CLI reveals its id. The UI just calls startSession + send + onMessage.
+
+import { spawnCli } from "./spawn.js";
+import { parseClaudeLine } from "./convert/claude.js";
+import { parseCodexLine } from "./convert/codex.js";
+import type { LineParser } from "./convert/types.js";
+import { SessionStore } from "../account/store.js";
+import type {
+  AgentRuntime,
+  ChatMessage,
+  SessionHandle,
+  SessionMeta,
+  StorageAdapter,
+  Wallet,
+} from "./contract.js";
+
+export function createRuntime(wallet: Wallet, storage: StorageAdapter): AgentRuntime {
+  const store = new SessionStore(wallet, storage);
+
+  return {
+    async startSession(opts): Promise<SessionHandle> {
+      const cli = spawnCli(opts);
+      const parse: LineParser = opts.cli === "claude" ? parseClaudeLine : parseCodexLine;
+
+      let sessionId = opts.sessionId ?? ""; // "" until the CLI reveals its id
+      let title = "";
+      const msgCbs: Array<(m: ChatMessage) => void> = [];
+      const turnCbs: Array<() => void> = [];
+      const pending: ChatMessage[] = []; // messages awaiting a known sessionId
+
+      const meta = () => ({ sessionId, cli: opts.cli, title, ts: Date.now() });
+
+      // Show the message to the UI, then append it to the encrypted log.
+      // Before sessionId is known, queue; flush() drains the queue once it is.
+      const emit = (m: ChatMessage) => {
+        if (!title && m.role === "user") title = m.text.slice(0, 60);
+        for (const cb of msgCbs) cb(m);
+        if (sessionId) void store.appendMessage(meta(), m);
+        else pending.push(m);
+      };
+
+      const flush = async () => {
+        while (pending.length) await store.appendMessage(meta(), pending.shift()!);
+      };
+
+      cli.lines.on("line", (line: string) => {
+        const r = parse(line);
+        if (r.sessionId && !sessionId) {
+          sessionId = r.sessionId;
+          cli.setSessionId?.(r.sessionId); // codex: resume this thread next turn
+          void flush();
+        }
+        for (const m of r.messages) emit(m);
+        if (r.turnEnded) {
+          void flush().then(() => {
+            for (const cb of turnCbs) cb();
+          });
+        }
+      });
+
+      return {
+        get sessionId() {
+          return sessionId;
+        },
+        cli: opts.cli,
+        send(userText: string) {
+          emit({ role: "user", text: userText, ts: Date.now() });
+          cli.send(userText);
+        },
+        onMessage(cb) {
+          msgCbs.push(cb);
+        },
+        onTurnEnd(cb) {
+          turnCbs.push(cb);
+        },
+        stop() {
+          cli.stop();
+        },
+      };
+    },
+
+    async listSessions(): Promise<SessionMeta[]> {
+      return store.listMine();
+    },
+
+    async loadSession(sessionId: string): Promise<ChatMessage[]> {
+      const s = await store.load(sessionId);
+      return s?.messages ?? [];
+    },
+
+    async deleteSession(sessionId: string): Promise<void> {
+      await store.remove(sessionId);
+    },
+  };
+}

--- a/src/runtime/spawn.ts
+++ b/src/runtime/spawn.ts
@@ -1,0 +1,114 @@
+// Spawn an agent CLI and expose its output as line events + a send()/stop().
+// claude and codex have DIFFERENT process models, so each gets its own adapter
+// behind one SpawnedCli interface:
+//   claude — one long-lived process; stdin takes stream-json user messages.
+//   codex  — one `exec` process PER turn; resume by thread id for later turns.
+
+import { spawn, type ChildProcess } from "node:child_process";
+import { createInterface } from "node:readline";
+import { EventEmitter } from "node:events";
+
+export interface SpawnedCli {
+  lines: EventEmitter; // "line" (string), "close", "stderr", "error", "exit"
+  send(text: string): void; // send a user message (per-CLI semantics)
+  stop(): void;
+  // codex needs to know its thread id (parsed from output) to resume; runtime
+  // sets this after seeing the first sessionId. claude ignores it.
+  setSessionId?(id: string): void;
+}
+
+export interface SpawnOpts {
+  cli: "claude" | "codex";
+  cwd: string;
+  sessionId?: string; // resume an existing session
+  model?: string;
+}
+
+export function spawnCli(opts: SpawnOpts): SpawnedCli {
+  return opts.cli === "claude" ? spawnClaude(opts) : spawnCodex(opts);
+}
+
+// ── claude: long-lived stream-json process ───────────────
+function spawnClaude(opts: SpawnOpts): SpawnedCli {
+  const args = ["--output-format", "stream-json", "--input-format", "stream-json", "--verbose"];
+  if (opts.model) args.push("--model", opts.model);
+  // --resume <id> continues an existing conversation; --session-id starts a NEW
+  // conversation pinned to that id. Use resume when we have a prior session.
+  if (opts.sessionId) args.push("--resume", opts.sessionId);
+
+  const proc = spawn("claude", args, {
+    cwd: opts.cwd,
+    stdio: ["pipe", "pipe", "pipe"],
+    env: { ...process.env, TERM: "xterm-256color" },
+  });
+
+  const lines = pipeLines(proc);
+
+  return {
+    lines,
+    send(text: string) {
+      const payload = JSON.stringify({
+        type: "user",
+        message: { role: "user", content: [{ type: "text", text }] },
+      });
+      proc.stdin?.write(payload + "\n");
+    },
+    stop() {
+      proc.kill();
+    },
+  };
+}
+
+// ── codex: one `exec` per turn, resume by thread id ──────
+function spawnCodex(opts: SpawnOpts): SpawnedCli {
+  const lines = new EventEmitter();
+  let threadId = opts.sessionId; // resume target for the next turn
+  let current: ChildProcess | undefined;
+
+  const runTurn = (prompt: string) => {
+    const base = ["exec", "--json", "--skip-git-repo-check"];
+    if (opts.model) base.push("--model", opts.model);
+    // resume existing thread, else start a fresh exec
+    const args = threadId
+      ? ["exec", "resume", threadId, "--json", "--skip-git-repo-check", prompt]
+      : [...base, prompt];
+
+    const proc = spawn("codex", args, {
+      cwd: opts.cwd,
+      stdio: ["ignore", "pipe", "pipe"],
+      env: { ...process.env },
+    });
+    current = proc;
+
+    const rl = createInterface({ input: proc.stdout! });
+    rl.on("line", (line) => lines.emit("line", line));
+    proc.stderr?.on("data", (d: Buffer) => lines.emit("stderr", d.toString()));
+    proc.on("error", (err) => lines.emit("error", err));
+    proc.on("exit", (code) => lines.emit("exit", code));
+  };
+
+  return {
+    lines,
+    send(text: string) {
+      runTurn(text);
+    },
+    stop() {
+      current?.kill();
+    },
+    setSessionId(id: string) {
+      threadId = id; // next send() will `exec resume <id>`
+    },
+  };
+}
+
+// shared: turn a process' stdout into "line" events on an emitter
+function pipeLines(proc: ChildProcess): EventEmitter {
+  const lines = new EventEmitter();
+  const rl = createInterface({ input: proc.stdout! });
+  rl.on("line", (line) => lines.emit("line", line));
+  rl.on("close", () => lines.emit("close"));
+  proc.stderr?.on("data", (d: Buffer) => lines.emit("stderr", d.toString()));
+  proc.on("error", (err) => lines.emit("error", err));
+  proc.on("exit", (code) => lines.emit("exit", code));
+  return lines;
+}

--- a/surfaces/vscode/.vscode/launch.json
+++ b/surfaces/vscode/.vscode/launch.json
@@ -1,0 +1,12 @@
+{
+  "version": "0.2.0",
+  "configurations": [
+    {
+      "name": "Run AgentNet Extension",
+      "type": "extensionHost",
+      "request": "launch",
+      "args": ["--extensionDevelopmentPath=${workspaceFolder}"],
+      "outFiles": ["${workspaceFolder}/dist/**/*.js"]
+    }
+  ]
+}

--- a/surfaces/vscode/package.json
+++ b/surfaces/vscode/package.json
@@ -1,0 +1,37 @@
+{
+  "name": "agentnet-vscode",
+  "displayName": "AgentNet",
+  "description": "Wallet-synced claude/codex sessions in VSCode",
+  "version": "0.0.1",
+  "engines": {
+    "vscode": "^1.90.0"
+  },
+  "categories": [
+    "Other"
+  ],
+  "main": "./dist/extension.js",
+  "activationEvents": [
+    "onStartupFinished"
+  ],
+  "contributes": {
+    "commands": [
+      {
+        "command": "agentnet.openChat",
+        "title": "AgentNet: Open Chat"
+      }
+    ]
+  },
+  "scripts": {
+    "build": "tsup src/extension.ts --format cjs --external vscode --out-dir dist",
+    "watch": "tsup src/extension.ts --format cjs --external vscode --out-dir dist --watch"
+  },
+  "devDependencies": {
+    "@types/node": "^20.0.0",
+    "@types/vscode": "^1.90.0",
+    "tsup": "^8.0.0",
+    "typescript": "^5.6.0"
+  },
+  "dependencies": {
+    "tweetnacl": "^1.0.3"
+  }
+}

--- a/surfaces/vscode/pnpm-lock.yaml
+++ b/surfaces/vscode/pnpm-lock.yaml
@@ -1,0 +1,929 @@
+lockfileVersion: '9.0'
+
+settings:
+  autoInstallPeers: true
+  excludeLinksFromLockfile: false
+
+importers:
+
+  .:
+    dependencies:
+      tweetnacl:
+        specifier: ^1.0.3
+        version: 1.0.3
+    devDependencies:
+      '@types/node':
+        specifier: ^20.0.0
+        version: 20.19.42
+      '@types/vscode':
+        specifier: ^1.90.0
+        version: 1.120.0
+      tsup:
+        specifier: ^8.0.0
+        version: 8.5.1(typescript@5.9.3)
+      typescript:
+        specifier: ^5.6.0
+        version: 5.9.3
+
+packages:
+
+  '@esbuild/aix-ppc64@0.27.7':
+    resolution: {integrity: sha512-EKX3Qwmhz1eMdEJokhALr0YiD0lhQNwDqkPYyPhiSwKrh7/4KRjQc04sZ8db+5DVVnZ1LmbNDI1uAMPEUBnQPg==}
+    engines: {node: '>=18'}
+    cpu: [ppc64]
+    os: [aix]
+
+  '@esbuild/android-arm64@0.27.7':
+    resolution: {integrity: sha512-62dPZHpIXzvChfvfLJow3q5dDtiNMkwiRzPylSCfriLvZeq0a1bWChrGx/BbUbPwOrsWKMn8idSllklzBy+dgQ==}
+    engines: {node: '>=18'}
+    cpu: [arm64]
+    os: [android]
+
+  '@esbuild/android-arm@0.27.7':
+    resolution: {integrity: sha512-jbPXvB4Yj2yBV7HUfE2KHe4GJX51QplCN1pGbYjvsyCZbQmies29EoJbkEc+vYuU5o45AfQn37vZlyXy4YJ8RQ==}
+    engines: {node: '>=18'}
+    cpu: [arm]
+    os: [android]
+
+  '@esbuild/android-x64@0.27.7':
+    resolution: {integrity: sha512-x5VpMODneVDb70PYV2VQOmIUUiBtY3D3mPBG8NxVk5CogneYhkR7MmM3yR/uMdITLrC1ml/NV1rj4bMJuy9MCg==}
+    engines: {node: '>=18'}
+    cpu: [x64]
+    os: [android]
+
+  '@esbuild/darwin-arm64@0.27.7':
+    resolution: {integrity: sha512-5lckdqeuBPlKUwvoCXIgI2D9/ABmPq3Rdp7IfL70393YgaASt7tbju3Ac+ePVi3KDH6N2RqePfHnXkaDtY9fkw==}
+    engines: {node: '>=18'}
+    cpu: [arm64]
+    os: [darwin]
+
+  '@esbuild/darwin-x64@0.27.7':
+    resolution: {integrity: sha512-rYnXrKcXuT7Z+WL5K980jVFdvVKhCHhUwid+dDYQpH+qu+TefcomiMAJpIiC2EM3Rjtq0sO3StMV/+3w3MyyqQ==}
+    engines: {node: '>=18'}
+    cpu: [x64]
+    os: [darwin]
+
+  '@esbuild/freebsd-arm64@0.27.7':
+    resolution: {integrity: sha512-B48PqeCsEgOtzME2GbNM2roU29AMTuOIN91dsMO30t+Ydis3z/3Ngoj5hhnsOSSwNzS+6JppqWsuhTp6E82l2w==}
+    engines: {node: '>=18'}
+    cpu: [arm64]
+    os: [freebsd]
+
+  '@esbuild/freebsd-x64@0.27.7':
+    resolution: {integrity: sha512-jOBDK5XEjA4m5IJK3bpAQF9/Lelu/Z9ZcdhTRLf4cajlB+8VEhFFRjWgfy3M1O4rO2GQ/b2dLwCUGpiF/eATNQ==}
+    engines: {node: '>=18'}
+    cpu: [x64]
+    os: [freebsd]
+
+  '@esbuild/linux-arm64@0.27.7':
+    resolution: {integrity: sha512-RZPHBoxXuNnPQO9rvjh5jdkRmVizktkT7TCDkDmQ0W2SwHInKCAV95GRuvdSvA7w4VMwfCjUiPwDi0ZO6Nfe9A==}
+    engines: {node: '>=18'}
+    cpu: [arm64]
+    os: [linux]
+
+  '@esbuild/linux-arm@0.27.7':
+    resolution: {integrity: sha512-RkT/YXYBTSULo3+af8Ib0ykH8u2MBh57o7q/DAs3lTJlyVQkgQvlrPTnjIzzRPQyavxtPtfg0EopvDyIt0j1rA==}
+    engines: {node: '>=18'}
+    cpu: [arm]
+    os: [linux]
+
+  '@esbuild/linux-ia32@0.27.7':
+    resolution: {integrity: sha512-GA48aKNkyQDbd3KtkplYWT102C5sn/EZTY4XROkxONgruHPU72l+gW+FfF8tf2cFjeHaRbWpOYa/uRBz/Xq1Pg==}
+    engines: {node: '>=18'}
+    cpu: [ia32]
+    os: [linux]
+
+  '@esbuild/linux-loong64@0.27.7':
+    resolution: {integrity: sha512-a4POruNM2oWsD4WKvBSEKGIiWQF8fZOAsycHOt6JBpZ+JN2n2JH9WAv56SOyu9X5IqAjqSIPTaJkqN8F7XOQ5Q==}
+    engines: {node: '>=18'}
+    cpu: [loong64]
+    os: [linux]
+
+  '@esbuild/linux-mips64el@0.27.7':
+    resolution: {integrity: sha512-KabT5I6StirGfIz0FMgl1I+R1H73Gp0ofL9A3nG3i/cYFJzKHhouBV5VWK1CSgKvVaG4q1RNpCTR2LuTVB3fIw==}
+    engines: {node: '>=18'}
+    cpu: [mips64el]
+    os: [linux]
+
+  '@esbuild/linux-ppc64@0.27.7':
+    resolution: {integrity: sha512-gRsL4x6wsGHGRqhtI+ifpN/vpOFTQtnbsupUF5R5YTAg+y/lKelYR1hXbnBdzDjGbMYjVJLJTd2OFmMewAgwlQ==}
+    engines: {node: '>=18'}
+    cpu: [ppc64]
+    os: [linux]
+
+  '@esbuild/linux-riscv64@0.27.7':
+    resolution: {integrity: sha512-hL25LbxO1QOngGzu2U5xeXtxXcW+/GvMN3ejANqXkxZ/opySAZMrc+9LY/WyjAan41unrR3YrmtTsUpwT66InQ==}
+    engines: {node: '>=18'}
+    cpu: [riscv64]
+    os: [linux]
+
+  '@esbuild/linux-s390x@0.27.7':
+    resolution: {integrity: sha512-2k8go8Ycu1Kb46vEelhu1vqEP+UeRVj2zY1pSuPdgvbd5ykAw82Lrro28vXUrRmzEsUV0NzCf54yARIK8r0fdw==}
+    engines: {node: '>=18'}
+    cpu: [s390x]
+    os: [linux]
+
+  '@esbuild/linux-x64@0.27.7':
+    resolution: {integrity: sha512-hzznmADPt+OmsYzw1EE33ccA+HPdIqiCRq7cQeL1Jlq2gb1+OyWBkMCrYGBJ+sxVzve2ZJEVeePbLM2iEIZSxA==}
+    engines: {node: '>=18'}
+    cpu: [x64]
+    os: [linux]
+
+  '@esbuild/netbsd-arm64@0.27.7':
+    resolution: {integrity: sha512-b6pqtrQdigZBwZxAn1UpazEisvwaIDvdbMbmrly7cDTMFnw/+3lVxxCTGOrkPVnsYIosJJXAsILG9XcQS+Yu6w==}
+    engines: {node: '>=18'}
+    cpu: [arm64]
+    os: [netbsd]
+
+  '@esbuild/netbsd-x64@0.27.7':
+    resolution: {integrity: sha512-OfatkLojr6U+WN5EDYuoQhtM+1xco+/6FSzJJnuWiUw5eVcicbyK3dq5EeV/QHT1uy6GoDhGbFpprUiHUYggrw==}
+    engines: {node: '>=18'}
+    cpu: [x64]
+    os: [netbsd]
+
+  '@esbuild/openbsd-arm64@0.27.7':
+    resolution: {integrity: sha512-AFuojMQTxAz75Fo8idVcqoQWEHIXFRbOc1TrVcFSgCZtQfSdc1RXgB3tjOn/krRHENUB4j00bfGjyl2mJrU37A==}
+    engines: {node: '>=18'}
+    cpu: [arm64]
+    os: [openbsd]
+
+  '@esbuild/openbsd-x64@0.27.7':
+    resolution: {integrity: sha512-+A1NJmfM8WNDv5CLVQYJ5PshuRm/4cI6WMZRg1by1GwPIQPCTs1GLEUHwiiQGT5zDdyLiRM/l1G0Pv54gvtKIg==}
+    engines: {node: '>=18'}
+    cpu: [x64]
+    os: [openbsd]
+
+  '@esbuild/openharmony-arm64@0.27.7':
+    resolution: {integrity: sha512-+KrvYb/C8zA9CU/g0sR6w2RBw7IGc5J2BPnc3dYc5VJxHCSF1yNMxTV5LQ7GuKteQXZtspjFbiuW5/dOj7H4Yw==}
+    engines: {node: '>=18'}
+    cpu: [arm64]
+    os: [openharmony]
+
+  '@esbuild/sunos-x64@0.27.7':
+    resolution: {integrity: sha512-ikktIhFBzQNt/QDyOL580ti9+5mL/YZeUPKU2ivGtGjdTYoqz6jObj6nOMfhASpS4GU4Q/Clh1QtxWAvcYKamA==}
+    engines: {node: '>=18'}
+    cpu: [x64]
+    os: [sunos]
+
+  '@esbuild/win32-arm64@0.27.7':
+    resolution: {integrity: sha512-7yRhbHvPqSpRUV7Q20VuDwbjW5kIMwTHpptuUzV+AA46kiPze5Z7qgt6CLCK3pWFrHeNfDd1VKgyP4O+ng17CA==}
+    engines: {node: '>=18'}
+    cpu: [arm64]
+    os: [win32]
+
+  '@esbuild/win32-ia32@0.27.7':
+    resolution: {integrity: sha512-SmwKXe6VHIyZYbBLJrhOoCJRB/Z1tckzmgTLfFYOfpMAx63BJEaL9ExI8x7v0oAO3Zh6D/Oi1gVxEYr5oUCFhw==}
+    engines: {node: '>=18'}
+    cpu: [ia32]
+    os: [win32]
+
+  '@esbuild/win32-x64@0.27.7':
+    resolution: {integrity: sha512-56hiAJPhwQ1R4i+21FVF7V8kSD5zZTdHcVuRFMW0hn753vVfQN8xlx4uOPT4xoGH0Z/oVATuR82AiqSTDIpaHg==}
+    engines: {node: '>=18'}
+    cpu: [x64]
+    os: [win32]
+
+  '@jridgewell/gen-mapping@0.3.13':
+    resolution: {integrity: sha512-2kkt/7niJ6MgEPxF0bYdQ6etZaA+fQvDcLKckhy1yIQOzaoKjBBjSj63/aLVjYE3qhRt5dvM+uUyfCg6UKCBbA==}
+
+  '@jridgewell/resolve-uri@3.1.2':
+    resolution: {integrity: sha512-bRISgCIjP20/tbWSPWMEi54QVPRZExkuD9lJL+UIxUKtwVJA8wW1Trb1jMs1RFXo1CBTNZ/5hpC9QvmKWdopKw==}
+    engines: {node: '>=6.0.0'}
+
+  '@jridgewell/sourcemap-codec@1.5.5':
+    resolution: {integrity: sha512-cYQ9310grqxueWbl+WuIUIaiUaDcj7WOq5fVhEljNVgRfOUhY9fy2zTvfoqWsnebh8Sl70VScFbICvJnLKB0Og==}
+
+  '@jridgewell/trace-mapping@0.3.31':
+    resolution: {integrity: sha512-zzNR+SdQSDJzc8joaeP8QQoCQr8NuYx2dIIytl1QeBEZHJ9uW6hebsrYgbz8hJwUQao3TWCMtmfV8Nu1twOLAw==}
+
+  '@rollup/rollup-android-arm-eabi@4.61.1':
+    resolution: {integrity: sha512-JnBB8MdXj45cajvTuO5FmPlvFVJRQgvrz1uSEl3NwqFnReAPGwb8EanbGi4z2nRaqLzjJSv5/JmycoTKlRZxHA==}
+    cpu: [arm]
+    os: [android]
+
+  '@rollup/rollup-android-arm64@4.61.1':
+    resolution: {integrity: sha512-Jx2g7iSjw4AOT0HDPHM9RV3GNjRXwybWtSFZiZAYUTjUwjVrYIwq3kBf+LnhqJlzXFAqTAh2F7IGI+O568exPw==}
+    cpu: [arm64]
+    os: [android]
+
+  '@rollup/rollup-darwin-arm64@4.61.1':
+    resolution: {integrity: sha512-0F1L/Z3Eqv8mT2n3dCpeO8GcTvHvVqkP5/t6DMsn0KzhYVcg+s7Ncl5DS8qjKYEeio6Az0Gt6nyBORay5qIlCA==}
+    cpu: [arm64]
+    os: [darwin]
+
+  '@rollup/rollup-darwin-x64@4.61.1':
+    resolution: {integrity: sha512-qLttcH871ujY4YcVfUSShhOw+CsoTatYz8gRbHO7Bb92QH059/P0y5do1KMs41fY0BpD2x4AJH/gID0zFiqVKQ==}
+    cpu: [x64]
+    os: [darwin]
+
+  '@rollup/rollup-freebsd-arm64@4.61.1':
+    resolution: {integrity: sha512-fUI4RapGE0Oh3mb8mgfvC1O2nU1RpDZUKnDQm3xB1Ipg7C2wTs5Kstz7G2uWK99a8S2yTMq8/P4uycwNa0nJyw==}
+    cpu: [arm64]
+    os: [freebsd]
+
+  '@rollup/rollup-freebsd-x64@4.61.1':
+    resolution: {integrity: sha512-H5YrdvJaDtI/U9/emrD4b++xkvp3y/JvOe4rizHbxvkyMfRS/CiRYdji+Pl8D0brEaNFWUh1drQxgAGIl6Xudw==}
+    cpu: [x64]
+    os: [freebsd]
+
+  '@rollup/rollup-linux-arm-gnueabihf@4.61.1':
+    resolution: {integrity: sha512-Q8CBCCQtDFrYtXoeUXSrnFXKOnyUhx6bz+SkL6A0E7V8kAiCJ5pamq1WtbfpVGhR5TSpXY6ak3avmDc5fHTyJA==}
+    cpu: [arm]
+    os: [linux]
+
+  '@rollup/rollup-linux-arm-musleabihf@4.61.1':
+    resolution: {integrity: sha512-nwnhk1581l0FBVellGcVCAT0Oi06onEA3WB53sf01VO3I0UPBkMH9sXONYME2K0ovXcNayJfNtHfm6mpJElatQ==}
+    cpu: [arm]
+    os: [linux]
+
+  '@rollup/rollup-linux-arm64-gnu@4.61.1':
+    resolution: {integrity: sha512-x5Xr49hwt3hdW75UOZm3395YwwzPyauktslv29KpWL/T+vVAzoT3azLcTWv0eMciBNrx+DYjH4paehHoLpPvpg==}
+    cpu: [arm64]
+    os: [linux]
+
+  '@rollup/rollup-linux-arm64-musl@4.61.1':
+    resolution: {integrity: sha512-unMS3H73DpaoPyyEVPjGKleM/s0mkmsauTENpw4INQY8y4+IuLNjkueQ5QCtC0D3N38Y38yhAU8OoZ20S2Tm6w==}
+    cpu: [arm64]
+    os: [linux]
+
+  '@rollup/rollup-linux-loong64-gnu@4.61.1':
+    resolution: {integrity: sha512-zNZzGRnAhwjFEYmvphJRV5XaQGjs62cCmeYYHUT//NbvEnHauw+I85nGG+SiVg5ld4GX8D1IbKIX+ozITQnhMQ==}
+    cpu: [loong64]
+    os: [linux]
+
+  '@rollup/rollup-linux-loong64-musl@4.61.1':
+    resolution: {integrity: sha512-LdpWGL8X209B2SIvWjqlc8VZgM6PKfontSerGepuldQmHYrAOtnMCXeJkxXGbC+PPZVOuu5czJo7fNV6aeW8rQ==}
+    cpu: [loong64]
+    os: [linux]
+
+  '@rollup/rollup-linux-ppc64-gnu@4.61.1':
+    resolution: {integrity: sha512-EC5kTtNaNGOmbMGqar8dvJy6y/hg99GAwjfBz++pxZhQATXGcRjd6c5en5wcbru0vkRmiMGsQKdMJOOf6sza4g==}
+    cpu: [ppc64]
+    os: [linux]
+
+  '@rollup/rollup-linux-ppc64-musl@4.61.1':
+    resolution: {integrity: sha512-8hiwp6D4acEcNK78I4rP0/XtS1sknWIAMJBPdR4l6zUtyTm5KiTDr5bXmWt4foY7nAN7AThDHgkLIEZOWKbzWw==}
+    cpu: [ppc64]
+    os: [linux]
+
+  '@rollup/rollup-linux-riscv64-gnu@4.61.1':
+    resolution: {integrity: sha512-10dh/h/BqA7DuMPWSxkR8uks18FRwnwOEqr5zOTEl+NOwP/OMzKX8OFR/Of9xxDA7D5qef1Nzar5WDD2kCCr1g==}
+    cpu: [riscv64]
+    os: [linux]
+
+  '@rollup/rollup-linux-riscv64-musl@4.61.1':
+    resolution: {integrity: sha512-YKJ5lg35DP17gcAOggnihe+APw9HLyj1Xn7gsmGumBJAUDa6NGXNixJzmkWLhcK9TOuuyQjdamzvJefkO7qHZQ==}
+    cpu: [riscv64]
+    os: [linux]
+
+  '@rollup/rollup-linux-s390x-gnu@4.61.1':
+    resolution: {integrity: sha512-Mlil5G2Jj6a7B3LWGctg+XPL9vdXYuzCtNXfxOQ0nPjc2m6ueUktocPGH9bnAM0bNRKb/bAWTujUU7IJQdQA+g==}
+    cpu: [s390x]
+    os: [linux]
+
+  '@rollup/rollup-linux-x64-gnu@4.61.1':
+    resolution: {integrity: sha512-bVWIOIk6pV01p4CdUbPP7CJ/434z+OooYjDuFcR+44N35YvKUC66G8MGnvcWx5mWKW3g61J+t74l3Kj15Kwn2Q==}
+    cpu: [x64]
+    os: [linux]
+
+  '@rollup/rollup-linux-x64-musl@4.61.1':
+    resolution: {integrity: sha512-qy5pBvZbqNFheBz61R1rzsezjm0J7O2oNGoWtGoY89SZYLUfxAJTBAqDChqAIdB4rCiIbi9nF7yZ83GnNiLwSw==}
+    cpu: [x64]
+    os: [linux]
+
+  '@rollup/rollup-openbsd-x64@4.61.1':
+    resolution: {integrity: sha512-E83TXjI4zm0+5f2qO+UOudaCYIhYwpJ5jq6YCZNIZ+6CbfhKrkAGezeiASBL9ElxAxFsRS9ZhESv8mfnj6TKeg==}
+    cpu: [x64]
+    os: [openbsd]
+
+  '@rollup/rollup-openharmony-arm64@4.61.1':
+    resolution: {integrity: sha512-fbWnKqVkjrJN38vNe3ahkbk6iejS/3b0Nt7EEtPpE6RBacZcGXNKbzfHN3GUUlXOPghUg0j6XUGrtjX9z1sIvA==}
+    cpu: [arm64]
+    os: [openharmony]
+
+  '@rollup/rollup-win32-arm64-msvc@4.61.1':
+    resolution: {integrity: sha512-ArMl38iVAbk0New1ogihQNY6iphLi4ZaRsa037gUzv5yeKPY8TD3Dmy4x2RNC1VztU/uqm+G+/RwFrSka3Oy2g==}
+    cpu: [arm64]
+    os: [win32]
+
+  '@rollup/rollup-win32-ia32-msvc@4.61.1':
+    resolution: {integrity: sha512-0mYtjHS9ucAbcATycCNK9IGBk/cCe/ma7EmSLGZdsxnOA8cjRIyU04wDpVAD9NiOfLUR9KTxdiO53uOkherqjQ==}
+    cpu: [ia32]
+    os: [win32]
+
+  '@rollup/rollup-win32-x64-gnu@4.61.1':
+    resolution: {integrity: sha512-gK1iCEPfpoSG9wfBihXxvBMi8ZfcWffYkEsC/Eih+iFENTaewvNcrEQ69lIOWYO5pePHKLHHO7nq5AILGO/HQQ==}
+    cpu: [x64]
+    os: [win32]
+
+  '@rollup/rollup-win32-x64-msvc@4.61.1':
+    resolution: {integrity: sha512-X+zaP2x+j4RXGfbp/seSoRHWnPxzApilDszisZxbYH5C/jTxFhCtDNdPGZb9lJyYPs24wGxruPF7Y+sIXt9Gzw==}
+    cpu: [x64]
+    os: [win32]
+
+  '@types/estree@1.0.9':
+    resolution: {integrity: sha512-GhdPgy1el4/ImP05X05Uw4cw2/M93BCUmnEvWZNStlCzEKME4Fkk+YpoA5OiHNQmoS7Cafb8Xa3Pya8m1Qrzeg==}
+
+  '@types/node@20.19.42':
+    resolution: {integrity: sha512-5L7SUaFC1RyDraj2yRhyBzHTobyXHmohD100CChNtyPyleoq37Mqab5Gn8XEKI04dfN/oqPdpHk38MgcQWHbZg==}
+
+  '@types/vscode@1.120.0':
+    resolution: {integrity: sha512-feaT4Rst+FkTch5zz/ZbNCxoIvo55YU80Be2kiL7OJcod4+CUYf2lUBPdIJzozNnSEMq1VRTGrWEcCGFB3fBmA==}
+
+  acorn@8.16.0:
+    resolution: {integrity: sha512-UVJyE9MttOsBQIDKw1skb9nAwQuR5wuGD3+82K6JgJlm/Y+KI92oNsMNGZCYdDsVtRHSak0pcV5Dno5+4jh9sw==}
+    engines: {node: '>=0.4.0'}
+    hasBin: true
+
+  any-promise@1.3.0:
+    resolution: {integrity: sha512-7UvmKalWRt1wgjL1RrGxoSJW/0QZFIegpeGvZG9kjp8vrRu55XTHbwnqq2GpXm9uLbcuhxm3IqX9OB4MZR1b2A==}
+
+  bundle-require@5.1.0:
+    resolution: {integrity: sha512-3WrrOuZiyaaZPWiEt4G3+IffISVC9HYlWueJEBWED4ZH4aIAC2PnkdnuRrR94M+w6yGWn4AglWtJtBI8YqvgoA==}
+    engines: {node: ^12.20.0 || ^14.13.1 || >=16.0.0}
+    peerDependencies:
+      esbuild: '>=0.18'
+
+  cac@6.7.14:
+    resolution: {integrity: sha512-b6Ilus+c3RrdDk+JhLKUAQfzzgLEPy6wcXqS7f/xe1EETvsDP6GORG7SFuOs6cID5YkqchW/LXZbX5bc8j7ZcQ==}
+    engines: {node: '>=8'}
+
+  chokidar@4.0.3:
+    resolution: {integrity: sha512-Qgzu8kfBvo+cA4962jnP1KkS6Dop5NS6g7R5LFYJr4b8Ub94PPQXUksCw9PvXoeXPRRddRNC5C1JQUR2SMGtnA==}
+    engines: {node: '>= 14.16.0'}
+
+  commander@4.1.1:
+    resolution: {integrity: sha512-NOKm8xhkzAjzFx8B2v5OAHT+u5pRQc2UCa2Vq9jYL/31o2wi9mxBA7LIFs3sV5VSC49z6pEhfbMULvShKj26WA==}
+    engines: {node: '>= 6'}
+
+  confbox@0.1.8:
+    resolution: {integrity: sha512-RMtmw0iFkeR4YV+fUOSucriAQNb9g8zFR52MWCtl+cCZOFRNL6zeB395vPzFhEjjn4fMxXudmELnl/KF/WrK6w==}
+
+  consola@3.4.2:
+    resolution: {integrity: sha512-5IKcdX0nnYavi6G7TtOhwkYzyjfJlatbjMjuLSfE2kYT5pMDOilZ4OvMhi637CcDICTmz3wARPoyhqyX1Y+XvA==}
+    engines: {node: ^14.18.0 || >=16.10.0}
+
+  debug@4.4.3:
+    resolution: {integrity: sha512-RGwwWnwQvkVfavKVt22FGLw+xYSdzARwm0ru6DhTVA3umU5hZc28V3kO4stgYryrTlLpuvgI9GiijltAjNbcqA==}
+    engines: {node: '>=6.0'}
+    peerDependencies:
+      supports-color: '*'
+    peerDependenciesMeta:
+      supports-color:
+        optional: true
+
+  esbuild@0.27.7:
+    resolution: {integrity: sha512-IxpibTjyVnmrIQo5aqNpCgoACA/dTKLTlhMHihVHhdkxKyPO1uBBthumT0rdHmcsk9uMonIWS0m4FljWzILh3w==}
+    engines: {node: '>=18'}
+    hasBin: true
+
+  fdir@6.5.0:
+    resolution: {integrity: sha512-tIbYtZbucOs0BRGqPJkshJUYdL+SDH7dVM8gjy+ERp3WAUjLEFJE+02kanyHtwjWOnwrKYBiwAmM0p4kLJAnXg==}
+    engines: {node: '>=12.0.0'}
+    peerDependencies:
+      picomatch: ^3 || ^4
+    peerDependenciesMeta:
+      picomatch:
+        optional: true
+
+  fix-dts-default-cjs-exports@1.0.1:
+    resolution: {integrity: sha512-pVIECanWFC61Hzl2+oOCtoJ3F17kglZC/6N94eRWycFgBH35hHx0Li604ZIzhseh97mf2p0cv7vVrOZGoqhlEg==}
+
+  fsevents@2.3.3:
+    resolution: {integrity: sha512-5xoDfX+fL7faATnagmWPpbFtwh/R77WmMMqqHGS65C3vvB0YHrgF+B1YmZ3441tMj5n63k0212XNoJwzlhffQw==}
+    engines: {node: ^8.16.0 || ^10.6.0 || >=11.0.0}
+    os: [darwin]
+
+  joycon@3.1.1:
+    resolution: {integrity: sha512-34wB/Y7MW7bzjKRjUKTa46I2Z7eV62Rkhva+KkopW7Qvv/OSWBqvkSY7vusOPrNuZcUG3tApvdVgNB8POj3SPw==}
+    engines: {node: '>=10'}
+
+  lilconfig@3.1.3:
+    resolution: {integrity: sha512-/vlFKAoH5Cgt3Ie+JLhRbwOsCQePABiU3tJ1egGvyQ+33R/vcwM2Zl2QR/LzjsBeItPt3oSVXapn+m4nQDvpzw==}
+    engines: {node: '>=14'}
+
+  lines-and-columns@1.2.4:
+    resolution: {integrity: sha512-7ylylesZQ/PV29jhEDl3Ufjo6ZX7gCqJr5F7PKrqc93v7fzSymt1BpwEU8nAUXs8qzzvqhbjhK5QZg6Mt/HkBg==}
+
+  load-tsconfig@0.2.5:
+    resolution: {integrity: sha512-IXO6OCs9yg8tMKzfPZ1YmheJbZCiEsnBdcB03l0OcfK9prKnJb96siuHCr5Fl37/yo9DnKU+TLpxzTUspw9shg==}
+    engines: {node: ^12.20.0 || ^14.13.1 || >=16.0.0}
+
+  magic-string@0.30.21:
+    resolution: {integrity: sha512-vd2F4YUyEXKGcLHoq+TEyCjxueSeHnFxyyjNp80yg0XV4vUhnDer/lvvlqM/arB5bXQN5K2/3oinyCRyx8T2CQ==}
+
+  mlly@1.8.2:
+    resolution: {integrity: sha512-d+ObxMQFmbt10sretNDytwt85VrbkhhUA/JBGm1MPaWJ65Cl4wOgLaB1NYvJSZ0Ef03MMEU/0xpPMXUIQ29UfA==}
+
+  ms@2.1.3:
+    resolution: {integrity: sha512-6FlzubTLZG3J2a/NVCAleEhjzq5oxgHyaCU9yYXvcLsvoVaHJq/s5xXI6/XXP6tz7R9xAOtHnSO/tXtF3WRTlA==}
+
+  mz@2.7.0:
+    resolution: {integrity: sha512-z81GNO7nnYMEhrGh9LeymoE4+Yr0Wn5McHIZMK5cfQCl+NDX08sCZgUc9/6MHni9IWuFLm1Z3HTCXu2z9fN62Q==}
+
+  object-assign@4.1.1:
+    resolution: {integrity: sha512-rJgTQnkUnH1sFw8yT6VSU3zD3sWmu6sZhIseY8VX+GRu3P6F7Fu+JNDoXfklElbLJSnc3FUQHVe4cU5hj+BcUg==}
+    engines: {node: '>=0.10.0'}
+
+  pathe@2.0.3:
+    resolution: {integrity: sha512-WUjGcAqP1gQacoQe+OBJsFA7Ld4DyXuUIjZ5cc75cLHvJ7dtNsTugphxIADwspS+AraAUePCKrSVtPLFj/F88w==}
+
+  picocolors@1.1.1:
+    resolution: {integrity: sha512-xceH2snhtb5M9liqDsmEw56le376mTZkEX/jEb/RxNFyegNul7eNslCXP9FDj/Lcu0X8KEyMceP2ntpaHrDEVA==}
+
+  picomatch@4.0.4:
+    resolution: {integrity: sha512-QP88BAKvMam/3NxH6vj2o21R6MjxZUAd6nlwAS/pnGvN9IVLocLHxGYIzFhg6fUQ+5th6P4dv4eW9jX3DSIj7A==}
+    engines: {node: '>=12'}
+
+  pirates@4.0.7:
+    resolution: {integrity: sha512-TfySrs/5nm8fQJDcBDuUng3VOUKsd7S+zqvbOTiGXHfxX4wK31ard+hoNuvkicM/2YFzlpDgABOevKSsB4G/FA==}
+    engines: {node: '>= 6'}
+
+  pkg-types@1.3.1:
+    resolution: {integrity: sha512-/Jm5M4RvtBFVkKWRu2BLUTNP8/M2a+UwuAX+ae4770q1qVGtfjG+WTCupoZixokjmHiry8uI+dlY8KXYV5HVVQ==}
+
+  postcss-load-config@6.0.1:
+    resolution: {integrity: sha512-oPtTM4oerL+UXmx+93ytZVN82RrlY/wPUV8IeDxFrzIjXOLF1pN+EmKPLbubvKHT2HC20xXsCAH2Z+CKV6Oz/g==}
+    engines: {node: '>= 18'}
+    peerDependencies:
+      jiti: '>=1.21.0'
+      postcss: '>=8.0.9'
+      tsx: ^4.8.1
+      yaml: ^2.4.2
+    peerDependenciesMeta:
+      jiti:
+        optional: true
+      postcss:
+        optional: true
+      tsx:
+        optional: true
+      yaml:
+        optional: true
+
+  readdirp@4.1.2:
+    resolution: {integrity: sha512-GDhwkLfywWL2s6vEjyhri+eXmfH6j1L7JE27WhqLeYzoh/A3DBaYGEj2H/HFZCn/kMfim73FXxEJTw06WtxQwg==}
+    engines: {node: '>= 14.18.0'}
+
+  resolve-from@5.0.0:
+    resolution: {integrity: sha512-qYg9KP24dD5qka9J47d0aVky0N+b4fTU89LN9iDnjB5waksiC49rvMB0PrUJQGoTmH50XPiqOvAjDfaijGxYZw==}
+    engines: {node: '>=8'}
+
+  rollup@4.61.1:
+    resolution: {integrity: sha512-I4KW6iuRpuu2uHBLraZ1wNZe0DP7lnRha+VJ9tNaYVaVgKhW0aI3h4RYnoRPeql0flHm/Co55b7snEDcOfOJrA==}
+    engines: {node: '>=18.0.0', npm: '>=8.0.0'}
+    hasBin: true
+
+  source-map@0.7.6:
+    resolution: {integrity: sha512-i5uvt8C3ikiWeNZSVZNWcfZPItFQOsYTUAOkcUPGd8DqDy1uOUikjt5dG+uRlwyvR108Fb9DOd4GvXfT0N2/uQ==}
+    engines: {node: '>= 12'}
+
+  sucrase@3.35.1:
+    resolution: {integrity: sha512-DhuTmvZWux4H1UOnWMB3sk0sbaCVOoQZjv8u1rDoTV0HTdGem9hkAZtl4JZy8P2z4Bg0nT+YMeOFyVr4zcG5Tw==}
+    engines: {node: '>=16 || 14 >=14.17'}
+    hasBin: true
+
+  thenify-all@1.6.0:
+    resolution: {integrity: sha512-RNxQH/qI8/t3thXJDwcstUO4zeqo64+Uy/+sNVRBx4Xn2OX+OZ9oP+iJnNFqplFra2ZUVeKCSa2oVWi3T4uVmA==}
+    engines: {node: '>=0.8'}
+
+  thenify@3.3.1:
+    resolution: {integrity: sha512-RVZSIV5IG10Hk3enotrhvz0T9em6cyHBLkH/YAZuKqd8hRkKhSfCGIcP2KUY0EPxndzANBmNllzWPwak+bheSw==}
+
+  tinyexec@0.3.2:
+    resolution: {integrity: sha512-KQQR9yN7R5+OSwaK0XQoj22pwHoTlgYqmUscPYoknOoWCWfj/5/ABTMRi69FrKU5ffPVh5QcFikpWJI/P1ocHA==}
+
+  tinyglobby@0.2.17:
+    resolution: {integrity: sha512-wXR/dYpcqKmfWpEdZjiKJOwCNFndD0DMnrW/cYjVGttEkBfVgcLFHoNrlj47mjOVic9yyNu65alsgF4NQyTa2g==}
+    engines: {node: '>=12.0.0'}
+
+  tree-kill@1.2.2:
+    resolution: {integrity: sha512-L0Orpi8qGpRG//Nd+H90vFB+3iHnue1zSSGmNOOCh1GLJ7rUKVwV2HvijphGQS2UmhUZewS9VgvxYIdgr+fG1A==}
+    hasBin: true
+
+  ts-interface-checker@0.1.13:
+    resolution: {integrity: sha512-Y/arvbn+rrz3JCKl9C4kVNfTfSm2/mEp5FSz5EsZSANGPSlQrpRI5M4PKF+mJnE52jOO90PnPSc3Ur3bTQw0gA==}
+
+  tsup@8.5.1:
+    resolution: {integrity: sha512-xtgkqwdhpKWr3tKPmCkvYmS9xnQK3m3XgxZHwSUjvfTjp7YfXe5tT3GgWi0F2N+ZSMsOeWeZFh7ZZFg5iPhing==}
+    engines: {node: '>=18'}
+    hasBin: true
+    peerDependencies:
+      '@microsoft/api-extractor': ^7.36.0
+      '@swc/core': ^1
+      postcss: ^8.4.12
+      typescript: '>=4.5.0'
+    peerDependenciesMeta:
+      '@microsoft/api-extractor':
+        optional: true
+      '@swc/core':
+        optional: true
+      postcss:
+        optional: true
+      typescript:
+        optional: true
+
+  tweetnacl@1.0.3:
+    resolution: {integrity: sha512-6rt+RN7aOi1nGMyC4Xa5DdYiukl2UWCbcJft7YhxReBGQD7OAM8Pbxw6YMo4r2diNEA8FEmu32YOn9rhaiE5yw==}
+
+  typescript@5.9.3:
+    resolution: {integrity: sha512-jl1vZzPDinLr9eUt3J/t7V6FgNEw9QjvBPdysz9KfQDD41fQrC2Y4vKQdiaUpFT4bXlb1RHhLpp8wtm6M5TgSw==}
+    engines: {node: '>=14.17'}
+    hasBin: true
+
+  ufo@1.6.4:
+    resolution: {integrity: sha512-JFNbkD1Svwe0KvGi8GOeLcP4kAWQ609twvCdcHxq1oSL8svv39ZuSvajcD8B+5D0eL4+s1Is2D/O6KN3qcTeRA==}
+
+  undici-types@6.21.0:
+    resolution: {integrity: sha512-iwDZqg0QAGrg9Rav5H4n0M64c3mkR59cJ6wQp+7C4nI0gsmExaedaYLNO44eT4AtBBwjbTiGPMlt2Md0T9H9JQ==}
+
+snapshots:
+
+  '@esbuild/aix-ppc64@0.27.7':
+    optional: true
+
+  '@esbuild/android-arm64@0.27.7':
+    optional: true
+
+  '@esbuild/android-arm@0.27.7':
+    optional: true
+
+  '@esbuild/android-x64@0.27.7':
+    optional: true
+
+  '@esbuild/darwin-arm64@0.27.7':
+    optional: true
+
+  '@esbuild/darwin-x64@0.27.7':
+    optional: true
+
+  '@esbuild/freebsd-arm64@0.27.7':
+    optional: true
+
+  '@esbuild/freebsd-x64@0.27.7':
+    optional: true
+
+  '@esbuild/linux-arm64@0.27.7':
+    optional: true
+
+  '@esbuild/linux-arm@0.27.7':
+    optional: true
+
+  '@esbuild/linux-ia32@0.27.7':
+    optional: true
+
+  '@esbuild/linux-loong64@0.27.7':
+    optional: true
+
+  '@esbuild/linux-mips64el@0.27.7':
+    optional: true
+
+  '@esbuild/linux-ppc64@0.27.7':
+    optional: true
+
+  '@esbuild/linux-riscv64@0.27.7':
+    optional: true
+
+  '@esbuild/linux-s390x@0.27.7':
+    optional: true
+
+  '@esbuild/linux-x64@0.27.7':
+    optional: true
+
+  '@esbuild/netbsd-arm64@0.27.7':
+    optional: true
+
+  '@esbuild/netbsd-x64@0.27.7':
+    optional: true
+
+  '@esbuild/openbsd-arm64@0.27.7':
+    optional: true
+
+  '@esbuild/openbsd-x64@0.27.7':
+    optional: true
+
+  '@esbuild/openharmony-arm64@0.27.7':
+    optional: true
+
+  '@esbuild/sunos-x64@0.27.7':
+    optional: true
+
+  '@esbuild/win32-arm64@0.27.7':
+    optional: true
+
+  '@esbuild/win32-ia32@0.27.7':
+    optional: true
+
+  '@esbuild/win32-x64@0.27.7':
+    optional: true
+
+  '@jridgewell/gen-mapping@0.3.13':
+    dependencies:
+      '@jridgewell/sourcemap-codec': 1.5.5
+      '@jridgewell/trace-mapping': 0.3.31
+
+  '@jridgewell/resolve-uri@3.1.2': {}
+
+  '@jridgewell/sourcemap-codec@1.5.5': {}
+
+  '@jridgewell/trace-mapping@0.3.31':
+    dependencies:
+      '@jridgewell/resolve-uri': 3.1.2
+      '@jridgewell/sourcemap-codec': 1.5.5
+
+  '@rollup/rollup-android-arm-eabi@4.61.1':
+    optional: true
+
+  '@rollup/rollup-android-arm64@4.61.1':
+    optional: true
+
+  '@rollup/rollup-darwin-arm64@4.61.1':
+    optional: true
+
+  '@rollup/rollup-darwin-x64@4.61.1':
+    optional: true
+
+  '@rollup/rollup-freebsd-arm64@4.61.1':
+    optional: true
+
+  '@rollup/rollup-freebsd-x64@4.61.1':
+    optional: true
+
+  '@rollup/rollup-linux-arm-gnueabihf@4.61.1':
+    optional: true
+
+  '@rollup/rollup-linux-arm-musleabihf@4.61.1':
+    optional: true
+
+  '@rollup/rollup-linux-arm64-gnu@4.61.1':
+    optional: true
+
+  '@rollup/rollup-linux-arm64-musl@4.61.1':
+    optional: true
+
+  '@rollup/rollup-linux-loong64-gnu@4.61.1':
+    optional: true
+
+  '@rollup/rollup-linux-loong64-musl@4.61.1':
+    optional: true
+
+  '@rollup/rollup-linux-ppc64-gnu@4.61.1':
+    optional: true
+
+  '@rollup/rollup-linux-ppc64-musl@4.61.1':
+    optional: true
+
+  '@rollup/rollup-linux-riscv64-gnu@4.61.1':
+    optional: true
+
+  '@rollup/rollup-linux-riscv64-musl@4.61.1':
+    optional: true
+
+  '@rollup/rollup-linux-s390x-gnu@4.61.1':
+    optional: true
+
+  '@rollup/rollup-linux-x64-gnu@4.61.1':
+    optional: true
+
+  '@rollup/rollup-linux-x64-musl@4.61.1':
+    optional: true
+
+  '@rollup/rollup-openbsd-x64@4.61.1':
+    optional: true
+
+  '@rollup/rollup-openharmony-arm64@4.61.1':
+    optional: true
+
+  '@rollup/rollup-win32-arm64-msvc@4.61.1':
+    optional: true
+
+  '@rollup/rollup-win32-ia32-msvc@4.61.1':
+    optional: true
+
+  '@rollup/rollup-win32-x64-gnu@4.61.1':
+    optional: true
+
+  '@rollup/rollup-win32-x64-msvc@4.61.1':
+    optional: true
+
+  '@types/estree@1.0.9': {}
+
+  '@types/node@20.19.42':
+    dependencies:
+      undici-types: 6.21.0
+
+  '@types/vscode@1.120.0': {}
+
+  acorn@8.16.0: {}
+
+  any-promise@1.3.0: {}
+
+  bundle-require@5.1.0(esbuild@0.27.7):
+    dependencies:
+      esbuild: 0.27.7
+      load-tsconfig: 0.2.5
+
+  cac@6.7.14: {}
+
+  chokidar@4.0.3:
+    dependencies:
+      readdirp: 4.1.2
+
+  commander@4.1.1: {}
+
+  confbox@0.1.8: {}
+
+  consola@3.4.2: {}
+
+  debug@4.4.3:
+    dependencies:
+      ms: 2.1.3
+
+  esbuild@0.27.7:
+    optionalDependencies:
+      '@esbuild/aix-ppc64': 0.27.7
+      '@esbuild/android-arm': 0.27.7
+      '@esbuild/android-arm64': 0.27.7
+      '@esbuild/android-x64': 0.27.7
+      '@esbuild/darwin-arm64': 0.27.7
+      '@esbuild/darwin-x64': 0.27.7
+      '@esbuild/freebsd-arm64': 0.27.7
+      '@esbuild/freebsd-x64': 0.27.7
+      '@esbuild/linux-arm': 0.27.7
+      '@esbuild/linux-arm64': 0.27.7
+      '@esbuild/linux-ia32': 0.27.7
+      '@esbuild/linux-loong64': 0.27.7
+      '@esbuild/linux-mips64el': 0.27.7
+      '@esbuild/linux-ppc64': 0.27.7
+      '@esbuild/linux-riscv64': 0.27.7
+      '@esbuild/linux-s390x': 0.27.7
+      '@esbuild/linux-x64': 0.27.7
+      '@esbuild/netbsd-arm64': 0.27.7
+      '@esbuild/netbsd-x64': 0.27.7
+      '@esbuild/openbsd-arm64': 0.27.7
+      '@esbuild/openbsd-x64': 0.27.7
+      '@esbuild/openharmony-arm64': 0.27.7
+      '@esbuild/sunos-x64': 0.27.7
+      '@esbuild/win32-arm64': 0.27.7
+      '@esbuild/win32-ia32': 0.27.7
+      '@esbuild/win32-x64': 0.27.7
+
+  fdir@6.5.0(picomatch@4.0.4):
+    optionalDependencies:
+      picomatch: 4.0.4
+
+  fix-dts-default-cjs-exports@1.0.1:
+    dependencies:
+      magic-string: 0.30.21
+      mlly: 1.8.2
+      rollup: 4.61.1
+
+  fsevents@2.3.3:
+    optional: true
+
+  joycon@3.1.1: {}
+
+  lilconfig@3.1.3: {}
+
+  lines-and-columns@1.2.4: {}
+
+  load-tsconfig@0.2.5: {}
+
+  magic-string@0.30.21:
+    dependencies:
+      '@jridgewell/sourcemap-codec': 1.5.5
+
+  mlly@1.8.2:
+    dependencies:
+      acorn: 8.16.0
+      pathe: 2.0.3
+      pkg-types: 1.3.1
+      ufo: 1.6.4
+
+  ms@2.1.3: {}
+
+  mz@2.7.0:
+    dependencies:
+      any-promise: 1.3.0
+      object-assign: 4.1.1
+      thenify-all: 1.6.0
+
+  object-assign@4.1.1: {}
+
+  pathe@2.0.3: {}
+
+  picocolors@1.1.1: {}
+
+  picomatch@4.0.4: {}
+
+  pirates@4.0.7: {}
+
+  pkg-types@1.3.1:
+    dependencies:
+      confbox: 0.1.8
+      mlly: 1.8.2
+      pathe: 2.0.3
+
+  postcss-load-config@6.0.1:
+    dependencies:
+      lilconfig: 3.1.3
+
+  readdirp@4.1.2: {}
+
+  resolve-from@5.0.0: {}
+
+  rollup@4.61.1:
+    dependencies:
+      '@types/estree': 1.0.9
+    optionalDependencies:
+      '@rollup/rollup-android-arm-eabi': 4.61.1
+      '@rollup/rollup-android-arm64': 4.61.1
+      '@rollup/rollup-darwin-arm64': 4.61.1
+      '@rollup/rollup-darwin-x64': 4.61.1
+      '@rollup/rollup-freebsd-arm64': 4.61.1
+      '@rollup/rollup-freebsd-x64': 4.61.1
+      '@rollup/rollup-linux-arm-gnueabihf': 4.61.1
+      '@rollup/rollup-linux-arm-musleabihf': 4.61.1
+      '@rollup/rollup-linux-arm64-gnu': 4.61.1
+      '@rollup/rollup-linux-arm64-musl': 4.61.1
+      '@rollup/rollup-linux-loong64-gnu': 4.61.1
+      '@rollup/rollup-linux-loong64-musl': 4.61.1
+      '@rollup/rollup-linux-ppc64-gnu': 4.61.1
+      '@rollup/rollup-linux-ppc64-musl': 4.61.1
+      '@rollup/rollup-linux-riscv64-gnu': 4.61.1
+      '@rollup/rollup-linux-riscv64-musl': 4.61.1
+      '@rollup/rollup-linux-s390x-gnu': 4.61.1
+      '@rollup/rollup-linux-x64-gnu': 4.61.1
+      '@rollup/rollup-linux-x64-musl': 4.61.1
+      '@rollup/rollup-openbsd-x64': 4.61.1
+      '@rollup/rollup-openharmony-arm64': 4.61.1
+      '@rollup/rollup-win32-arm64-msvc': 4.61.1
+      '@rollup/rollup-win32-ia32-msvc': 4.61.1
+      '@rollup/rollup-win32-x64-gnu': 4.61.1
+      '@rollup/rollup-win32-x64-msvc': 4.61.1
+      fsevents: 2.3.3
+
+  source-map@0.7.6: {}
+
+  sucrase@3.35.1:
+    dependencies:
+      '@jridgewell/gen-mapping': 0.3.13
+      commander: 4.1.1
+      lines-and-columns: 1.2.4
+      mz: 2.7.0
+      pirates: 4.0.7
+      tinyglobby: 0.2.17
+      ts-interface-checker: 0.1.13
+
+  thenify-all@1.6.0:
+    dependencies:
+      thenify: 3.3.1
+
+  thenify@3.3.1:
+    dependencies:
+      any-promise: 1.3.0
+
+  tinyexec@0.3.2: {}
+
+  tinyglobby@0.2.17:
+    dependencies:
+      fdir: 6.5.0(picomatch@4.0.4)
+      picomatch: 4.0.4
+
+  tree-kill@1.2.2: {}
+
+  ts-interface-checker@0.1.13: {}
+
+  tsup@8.5.1(typescript@5.9.3):
+    dependencies:
+      bundle-require: 5.1.0(esbuild@0.27.7)
+      cac: 6.7.14
+      chokidar: 4.0.3
+      consola: 3.4.2
+      debug: 4.4.3
+      esbuild: 0.27.7
+      fix-dts-default-cjs-exports: 1.0.1
+      joycon: 3.1.1
+      picocolors: 1.1.1
+      postcss-load-config: 6.0.1
+      resolve-from: 5.0.0
+      rollup: 4.61.1
+      source-map: 0.7.6
+      sucrase: 3.35.1
+      tinyexec: 0.3.2
+      tinyglobby: 0.2.17
+      tree-kill: 1.2.2
+    optionalDependencies:
+      typescript: 5.9.3
+    transitivePeerDependencies:
+      - jiti
+      - supports-color
+      - tsx
+      - yaml
+
+  tweetnacl@1.0.3: {}
+
+  typescript@5.9.3: {}
+
+  ufo@1.6.4: {}
+
+  undici-types@6.21.0: {}

--- a/surfaces/vscode/src/extension.ts
+++ b/surfaces/vscode/src/extension.ts
@@ -1,0 +1,114 @@
+// AgentNet VSCode surface — thin UI over the runtime CONTRACT.
+// We import ONLY the contract types; the runtime engine is injected (mock for now,
+// real src/runtime later). The webview is the chat; this file is the bridge:
+//   webview "send" → handle.send()      (user input → CLI)
+//   handle.onMessage → webview "message" (CLI output → panel)
+
+import * as vscode from "vscode";
+import type { AgentRuntime, SessionHandle, Wallet } from "../../../src/runtime/contract";
+import { createRuntime } from "../../../src/runtime/index";
+import { manualStorage } from "../../../src/account/storage/manual";
+import { chatHtml } from "./webview";
+import nacl from "tweetnacl";
+
+// TEMP wallet — a fixed local keypair stands in for Phantom until wallet-connect
+// is wired. signMessage must be deterministic (same key → same session crypto).
+// Replaced later by: const { wallet, storage } = await login(phantom).
+const kp = nacl.sign.keyPair.fromSeed(new Uint8Array(32).fill(7));
+const wallet: Wallet = {
+  address: "TESTWALLET",
+  async signMessage(msg) {
+    return nacl.sign.detached(msg, kp.secretKey);
+  },
+};
+
+// Real runtime over local storage (swap manualStorage → login() result for cloud).
+const runtime: AgentRuntime = createRuntime(wallet, manualStorage());
+
+export function activate(context: vscode.ExtensionContext) {
+  context.subscriptions.push(
+    vscode.commands.registerCommand("agentnet.openChat", () => openChat(context))
+  );
+  // auto-open the chat on activation so testing needs no command
+  openChat(context);
+}
+
+async function openChat(context: vscode.ExtensionContext) {
+  const panel = vscode.window.createWebviewPanel(
+    "agentnetChat",
+    "AgentNet Chat",
+    vscode.ViewColumn.One,
+    { enableScripts: true, retainContextWhenHidden: true }
+  );
+  panel.webview.html = chatHtml();
+
+  let handle: SessionHandle | null = null;
+  let pendingId: string | undefined; // session to (re)spawn lazily on first send
+  let cli: "claude" | "codex" = "claude"; // Platform tab (which CLI)
+  let model: string | undefined;          // Model dropdown ("default" → undefined = CLI picks)
+
+  // open = just show history + remember which session. claude is NOT spawned here
+  // (spawn costs ~2s); we defer it to the first send so switching sessions is instant.
+  async function open(sessionId?: string) {
+    handle?.stop();
+    handle = null;
+    pendingId = sessionId;
+    panel.webview.postMessage({ type: "clear" });
+    if (sessionId) {
+      const history = await runtime.loadSession(sessionId);
+      for (const msg of history) panel.webview.postMessage({ type: "message", msg });
+    }
+  }
+
+  // spawn on demand: first send of an opened session boots claude (resume or new).
+  async function ensureHandle() {
+    if (handle) return handle;
+    handle = await runtime.startSession({ cli, model, cwd: getCwd(), sessionId: pendingId });
+    handle.onMessage((msg) => panel.webview.postMessage({ type: "message", msg }));
+    handle.onTurnEnd(async () => {
+      await pushSessions();
+    });
+    return handle;
+  }
+
+  async function pushSessions() {
+    const list = await runtime.listSessions();
+    panel.webview.postMessage({ type: "sessions", list, activeId: handle?.sessionId ?? pendingId });
+  }
+
+  // webview -> extension
+  panel.webview.onDidReceiveMessage(async (m) => {
+    switch (m?.type) {
+      case "ready": await pushSessions(); await open(); break;            // first load
+      case "new":   await open(); await pushSessions(); break;            // + New
+      case "open":  await open(m.sessionId); await pushSessions(); break; // resume (instant)
+      case "platform":
+        // switch CLI; drop the live handle so the next send spawns the new CLI
+        if (m.cli === "claude" || m.cli === "codex") { cli = m.cli; handle?.stop(); handle = null; }
+        break;
+      case "model":
+        // "default" = let the CLI pick → undefined (no --model flag)
+        model = m.model && m.model !== "default" ? m.model : undefined;
+        handle?.stop(); handle = null;
+        break;
+      case "send":
+        if (typeof m.text === "string") (await ensureHandle()).send(m.text);
+        break;
+      case "delete":
+        if (typeof m.sessionId === "string") {
+          await runtime.deleteSession(m.sessionId);
+          if (m.sessionId === (handle?.sessionId ?? pendingId)) await open(); // cleared active one
+          await pushSessions();
+        }
+        break;
+    }
+  });
+
+  panel.onDidDispose(() => handle?.stop());
+}
+
+function getCwd(): string {
+  return vscode.workspace.workspaceFolders?.[0]?.uri.fsPath ?? process.cwd();
+}
+
+export function deactivate() {}

--- a/surfaces/vscode/src/webview.ts
+++ b/surfaces/vscode/src/webview.ts
@@ -1,0 +1,258 @@
+// Chat webview (HTML + inline JS). VSCode standard postMessage pattern.
+//   input  -> vscode.postMessage({type:"send"})            (user -> extension)
+//   render <- extension.postMessage({type:"message"|...})  (CLI output -> panel)
+//
+// Layout follows the codex panel reference (visual only — its code is closed):
+//   top    = Platform tabs (claude code | codex)  -> postMessage {type:"platform"}
+//   left   = session list: title + relative time, "모두 보기(N)" when long
+//   bottom = model dropdown + input
+//
+// Typing effect via the contract's `partial` flag:
+//   partial:true  -> append the delta to the CURRENT bubble (streaming)
+//   partial:false -> that bubble is complete (start a new one next time)
+
+export function chatHtml(): string {
+  return /* html */ `<!DOCTYPE html>
+<html lang="en">
+<head>
+<meta charset="UTF-8" />
+<meta name="viewport" content="width=device-width, initial-scale=1.0" />
+<style>
+  body { font-family: var(--vscode-font-family); margin: 0; color: var(--vscode-foreground);
+         background: var(--vscode-editor-background); display: flex; flex-direction: column; height: 100vh; }
+
+  /* top platform tabs (claude code | codex) */
+  #tabs { display: flex; border-bottom: 1px solid var(--vscode-panel-border); }
+  .tab { padding: 10px 16px; cursor: pointer; font-size: 0.9em; opacity: 0.6;
+         border-bottom: 2px solid transparent; user-select: none; }
+  .tab:hover { opacity: 0.85; }
+  .tab.active { opacity: 1; border-bottom-color: var(--vscode-focusBorder); }
+
+  #wrap { flex: 1; display: flex; min-height: 0; }
+
+  /* left session list */
+  #sidebar { width: 230px; border-right: 1px solid var(--vscode-panel-border);
+             display: flex; flex-direction: column; overflow-y: auto; }
+  #sidebar h3 { font-size: 0.75em; opacity: 0.6; padding: 10px 12px 4px; margin: 0; text-transform: uppercase; }
+  .sess { display: flex; justify-content: space-between; gap: 8px; align-items: baseline;
+          padding: 8px 12px; cursor: pointer; font-size: 0.9em; border-left: 2px solid transparent; }
+  .sess:hover { background: var(--vscode-list-hoverBackground); }
+  .sess.active { background: var(--vscode-list-activeSelectionBackground); border-left-color: var(--vscode-focusBorder); }
+  .sess .title { overflow: hidden; text-overflow: ellipsis; white-space: nowrap; flex: 1; }
+  .sess .time { opacity: 0.5; font-size: 0.85em; white-space: nowrap; }
+  .sess .del { opacity: 0; font-size: 0.9em; padding: 0 2px; border-radius: 3px; }
+  .sess:hover .del { opacity: 0.5; }
+  .sess .del:hover { opacity: 1; background: var(--vscode-inputValidation-errorBackground); }
+  #showAll { padding: 8px 12px; cursor: pointer; font-size: 0.85em; opacity: 0.6; }
+  #showAll:hover { opacity: 1; }
+  #empty { opacity: 0.4; text-align: center; padding: 24px 12px; font-size: 0.85em; }
+  #newBtn { margin: 8px 12px; }
+
+  /* right chat area */
+  #main { flex: 1; display: flex; flex-direction: column; min-width: 0; }
+  #log { flex: 1; overflow-y: auto; padding: 12px; display: flex; flex-direction: column; }
+  .msg { margin: 6px 0; padding: 8px 10px; border-radius: 8px; white-space: pre-wrap; line-height: 1.4; max-width: 85%; }
+  .user      { background: var(--vscode-input-background); align-self: flex-end; }
+  .assistant { background: var(--vscode-editorWidget-background); align-self: flex-start; }
+  .thinking  { opacity: 0.55; font-style: italic; align-self: flex-start; }
+  .tool      { opacity: 0.8; font-family: var(--vscode-editor-font-family); font-size: 0.9em; align-self: flex-start; }
+  .cursor::after { content: "\\u258B"; opacity: 0.6; animation: blink 1s step-end infinite; }
+  @keyframes blink { 50% { opacity: 0; } }
+
+  #controls { display: flex; gap: 8px; align-items: center; padding: 6px 10px;
+              border-top: 1px solid var(--vscode-panel-border); font-size: 0.85em; }
+  #controls label { opacity: 0.6; }
+  #model { background: var(--vscode-dropdown-background); color: var(--vscode-dropdown-foreground);
+           border: 1px solid var(--vscode-dropdown-border); border-radius: 4px; padding: 3px 6px; }
+  #bar { display: flex; gap: 6px; padding: 10px; border-top: 1px solid var(--vscode-panel-border); }
+  #input { flex: 1; padding: 8px; background: var(--vscode-input-background);
+           color: var(--vscode-input-foreground); border: 1px solid var(--vscode-input-border);
+           border-radius: 6px; resize: none; font-family: inherit; }
+  button { padding: 8px 14px; background: var(--vscode-button-background);
+           color: var(--vscode-button-foreground); border: none; border-radius: 6px; cursor: pointer; }
+</style>
+</head>
+<body>
+  <div id="tabs">
+    <div class="tab active" data-cli="claude">claude code</div>
+    <div class="tab" data-cli="codex">codex</div>
+  </div>
+  <div id="wrap">
+    <div id="sidebar">
+      <h3>Sessions</h3>
+      <div id="sessList"></div>
+      <div id="showAll" style="display:none"></div>
+      <div id="empty" style="display:none">No sessions yet.<br/>Start a chat below.</div>
+      <button id="newBtn">+ New</button>
+    </div>
+    <div id="main">
+      <div id="log"></div>
+      <div id="controls">
+        <label>Model</label>
+        <select id="model"></select>
+      </div>
+      <div id="bar">
+        <textarea id="input" rows="1" placeholder="Message claude/codex... (Enter to send)"></textarea>
+        <button id="send">Send</button>
+      </div>
+    </div>
+  </div>
+<script>
+  const vscode = acquireVsCodeApi();
+  const log = document.getElementById('log');
+  const input = document.getElementById('input');
+  const sessList = document.getElementById('sessList');
+  const showAll = document.getElementById('showAll');
+  const emptyEl = document.getElementById('empty');
+  const modelSel = document.getElementById('model');
+  const tabs = Array.from(document.querySelectorAll('.tab'));
+
+  let streaming = null;     // bubble currently being streamed into
+  let allSessions = [];     // last sessions payload from extension
+  let activeId = null;
+  let expanded = false;     // "모두 보기" toggled?
+  const COLLAPSED = 5;      // sessions shown before "모두 보기(N)"
+
+  // Platform = which CLI. Model = the actual model inside it.
+  // value 'default' = pass no --model (CLI's own default); label shows WHICH model
+  // that currently is, so the user knows what 'default' resolves to. We're just a
+  // wrapper — when a CLI ships a new default, only this label needs updating.
+  const MODELS = {
+    claude: [
+      { value: 'default', label: 'default (Opus 4.8)' },
+      { value: 'opus',    label: 'opus' },
+      { value: 'sonnet',  label: 'sonnet' },
+      { value: 'haiku',   label: 'haiku' },
+    ],
+    codex: [
+      { value: 'default',      label: 'default (gpt-5-codex)' },
+      { value: 'gpt-5',        label: 'gpt-5' },
+      { value: 'gpt-5-codex',  label: 'gpt-5-codex' },
+      { value: 'o3',           label: 'o3' },
+    ],
+  };
+  let cli = 'claude';
+
+  // ---- platform tabs + model dropdown ----
+  function fillModels() {
+    modelSel.innerHTML = '';
+    for (const m of (MODELS[cli] || [{ value: 'default', label: 'default' }])) {
+      const o = document.createElement('option');
+      o.value = m.value; o.textContent = m.label;
+      modelSel.appendChild(o);
+    }
+  }
+  function selectTab(next) {
+    if (next === cli) return;
+    cli = next;
+    tabs.forEach(t => t.classList.toggle('active', t.dataset.cli === cli));
+    fillModels();
+    vscode.postMessage({ type: 'platform', cli });
+    vscode.postMessage({ type: 'model', model: modelSel.value });
+  }
+  tabs.forEach(t => t.addEventListener('click', () => selectTab(t.dataset.cli)));
+  modelSel.addEventListener('change', () => vscode.postMessage({ type: 'model', model: modelSel.value }));
+  fillModels();
+
+  // ---- relative time ("3개월", "1일", "방금") ----
+  function rel(ts) {
+    const s = Math.max(0, (Date.now() - ts) / 1000);
+    if (s < 60) return '방금';
+    const m = s / 60; if (m < 60) return Math.floor(m) + '분';
+    const h = m / 60; if (h < 24) return Math.floor(h) + '시간';
+    const d = h / 24; if (d < 30) return Math.floor(d) + '일';
+    const mo = d / 30; if (mo < 12) return Math.floor(mo) + '개월';
+    return Math.floor(mo / 12) + '년';
+  }
+
+  // ---- chat bubbles ----
+  function bubble(role) {
+    const el = document.createElement('div');
+    el.className = 'msg ' + role;
+    log.appendChild(el);
+    log.scrollTop = log.scrollHeight;
+    return el;
+  }
+  function onMessage(msg) {
+    if (msg.partial) {
+      if (!streaming || streaming.dataset.role !== msg.role) {
+        streaming = bubble(msg.role);
+        streaming.dataset.role = msg.role;
+        streaming.classList.add('cursor');
+      }
+      streaming.textContent += msg.text;
+    } else {
+      if (streaming && streaming.dataset.role === msg.role) {
+        streaming.textContent += msg.text;
+        streaming.classList.remove('cursor');
+        streaming = null;
+      } else {
+        bubble(msg.role).textContent = msg.text;
+      }
+    }
+    log.scrollTop = log.scrollHeight;
+  }
+
+  // ---- session list (title + relative time + 모두 보기) ----
+  function renderSessions() {
+    sessList.innerHTML = '';
+    emptyEl.style.display = allSessions.length ? 'none' : 'block';
+    const shown = expanded ? allSessions : allSessions.slice(0, COLLAPSED);
+    for (const s of shown) {
+      const el = document.createElement('div');
+      el.className = 'sess' + (s.sessionId === activeId ? ' active' : '');
+      const title = document.createElement('span');
+      title.className = 'title';
+      title.textContent = s.title || '(untitled)';
+      const time = document.createElement('span');
+      time.className = 'time';
+      time.textContent = rel(s.ts);
+      const del = document.createElement('span');
+      del.className = 'del';
+      del.textContent = '\\u2715'; // x mark
+      del.title = 'Delete session';
+      del.onclick = (e) => {
+        e.stopPropagation(); // don't trigger the row's open
+        vscode.postMessage({ type: 'delete', sessionId: s.sessionId });
+      };
+      el.appendChild(title); el.appendChild(time); el.appendChild(del);
+      el.onclick = () => vscode.postMessage({ type: 'open', sessionId: s.sessionId });
+      sessList.appendChild(el);
+    }
+    if (allSessions.length > COLLAPSED) {
+      showAll.style.display = 'block';
+      showAll.textContent = expanded ? '접기' : '모두 보기(' + allSessions.length + ')';
+    } else {
+      showAll.style.display = 'none';
+    }
+  }
+  showAll.addEventListener('click', () => { expanded = !expanded; renderSessions(); });
+
+  // ---- input ----
+  function send() {
+    const text = input.value.trim();
+    if (!text) return;
+    vscode.postMessage({ type: 'send', text });
+    input.value = '';
+  }
+  document.getElementById('send').addEventListener('click', send);
+  document.getElementById('newBtn').addEventListener('click', () => vscode.postMessage({ type: 'new' }));
+  input.addEventListener('keydown', (e) => {
+    // e.isComposing = IME (Korean/Japanese/Chinese) mid-composition; don't send
+    // a half-formed syllable. keyCode 229 is the legacy IME-in-progress signal.
+    if (e.isComposing || e.keyCode === 229) return;
+    if (e.key === 'Enter' && !e.shiftKey) { e.preventDefault(); send(); }
+  });
+
+  window.addEventListener('message', (event) => {
+    const m = event.data;
+    if (m.type === 'message') onMessage(m.msg);
+    else if (m.type === 'sessions') { allSessions = m.list || []; activeId = m.activeId; renderSessions(); }
+    else if (m.type === 'clear') { log.innerHTML = ''; streaming = null; }
+  });
+
+  vscode.postMessage({ type: 'ready' });
+</script>
+</body>
+</html>`;
+}

--- a/surfaces/vscode/tsconfig.json
+++ b/surfaces/vscode/tsconfig.json
@@ -1,0 +1,14 @@
+{
+  "compilerOptions": {
+    "module": "commonjs",
+    "target": "ES2022",
+    "lib": ["ES2022", "DOM"],
+    "outDir": "dist",
+    "rootDir": "..",
+    "strict": true,
+    "esModuleInterop": true,
+    "skipLibCheck": true,
+    "moduleResolution": "node"
+  },
+  "include": ["src/**/*", "../../src/runtime/contract.ts"]
+}

--- a/tsconfig.json
+++ b/tsconfig.json
@@ -1,0 +1,15 @@
+{
+  "compilerOptions": {
+    "target": "ES2022",
+    "module": "ESNext",
+    "moduleResolution": "Bundler",
+    "strict": true,
+    "esModuleInterop": true,
+    "skipLibCheck": true,
+    "resolveJsonModule": true,
+    "declaration": true,
+    "outDir": "dist",
+    "types": ["node"]
+  },
+  "include": ["src", "scripts"]
+}


### PR DESCRIPTION
## AgentNet — Session Runtime MVP

An **engine + VSCode chat UI** that captures sessions from **both claude and codex**,
encrypts them with the user's wallet, and syncs them to user-owned storage.
Built in parallel by three working sessions (runtime / storage / UI) sharing one
`contract.ts`. **This is the first code PR** — until now the repo held only plans.

> Honest status map: [`plans/STATUS.md`](plans/STATUS.md) · Next steps: [`plans/roadmap-2tracks.md`](plans/roadmap-2tracks.md)

---

### What actually works (no overclaiming)

```mermaid
flowchart TB
    subgraph DONE["WORKING (pnpm test:run PASS)"]
        ENGINE["runtime engine<br/>claude + codex: spawn / capture / resume"]
        CRYPTO["session encryption<br/>wallet sig -> key, append-only log"]
        STORE["4 storage backends<br/>local / icloud / custom / gdrive"]
        UICHAT["VSCode chat UI<br/>chat / session list / delete / model select"]
    end
    subgraph WIRED_NOT["BUILT but not wired into the UI"]
        ONBOARD["onboarding (login / detectCli / STORAGE_OPTIONS ready)"]
    end
    subgraph MISSING["NOT built yet"]
        PHANTOM["real Phantom wallet (currently a fake keypair)"]
        ONCHAIN["on-chain layer (skill NFT / reputation)"]
    end
    UICHAT -->|"real call"| ENGINE --> CRYPTO --> STORE
    UICHAT -.->|"fake wallet"| PHANTOM
    UICHAT -.->|"not called"| ONBOARD
    style DONE fill:#e6ffe6,stroke:#3a3
    style WIRED_NOT fill:#fff8e0,stroke:#cc3
    style MISSING fill:#ffe6e6,stroke:#c33
```

**The graph above, in words — three honesty tiers:**

- **Green = working & tested.** The chat UI makes a *real* call into the runtime
  engine; the engine spawns the actual `claude`/`codex` CLIs, captures their
  output, encrypts each message with a wallet-derived key, and appends it to an
  encrypted log in one of four storage backends. `pnpm test:run` exercises this
  end-to-end for both CLIs (capture → encrypt → append → reload).
- **Yellow = built but not plugged in.** `login()`, `detectCli()`, and
  `STORAGE_OPTIONS` all exist and work, but `extension.ts` doesn't call them yet —
  so there's no onboarding screen and storage is hard-pinned to local. The parts
  are done; only the wiring is missing.
- **Red = not built.** The wallet is still a fake test keypair (dashed line), and
  the on-chain layer (skill NFTs, reputation) is design-only.

**Working (tested):**
- **runtime** — claude (long-lived stream-json process) + codex (`exec` + resume by
  thread id); both captured & resumable through one `SpawnedCli` interface
- **encryption** — wallet signature → X25519 key (same wallet decrypts on any
  device), append-only encrypted JSONL log (no duplicate files, no full rewrites)
- **storage** — local / icloud / custom(HTTP) / gdrive(OAuth PKCE + refresh), all implemented
- **VSCode** — real runtime (not a mock): chat, session list, delete, model dropdown,
  claude/codex tabs, IME-safe input, lazy spawn (instant session switching)

**Built but not wired** — `login()` / `detectCli()` / `STORAGE_OPTIONS` exist; the UI
doesn't call them yet (no onboarding screen, storage pinned to local).

**Not built** — real Phantom wallet (fake test keypair today), on-chain layer (skill
NFT / notes / `mysessions` index), mobile/CLI surfaces.

---

### Where this goes next — two tracks

```mermaid
flowchart TB
    BASE["this PR (shared foundation)"]
    BASE --> T1["Track 1 — identity & multi-device sessions (off-chain)"]
    BASE --> T2["Track 2 — on-chain AgentNet (skill NFTs / reputation)"]
    T1 --> CONV["wallet = agent: sessions + skills + reputation, all on one wallet"]
    T2 --> CONV
    style BASE fill:#e6ffe6,stroke:#3a3
    style T1 fill:#e6f0ff,stroke:#36c
    style T2 fill:#f0e6ff,stroke:#93c
    style CONV fill:#fff8e0,stroke:#cc3
```

This PR is the **shared foundation** both tracks stand on. From here the work forks:

- **Track 1 — identity & multi-device sessions (off-chain, private).**
  Connect a real Phantom wallet → wire the onboarding/storage picker (parts already
  exist) → verify the same wallet restores its sessions on another device → build
  mobile/CLI surfaces. End state: connect your wallet anywhere and yesterday's
  conversation is there, encrypted, synced to *your* cloud. Sessions stay encrypted
  and private — only the wallet can read them.

- **Track 2 — on-chain AgentNet (public marketplace).**
  The wallet (= an agent) publishes / searches / buys **skill NFTs** (Token-2022,
  soulbound, `supply` = popularity) and leaves **reputation notes** on-chain. Designs
  live in `plans/` (skill-nft-structure, search, notes, workflow-nft); code is still 0.

The two tracks are **independent** (on-chain code never touches the session pipeline),
so they can run in parallel. They **converge** on one idea: *connect your wallet, and
your whole agent — sessions + skills + reputation — comes with it.*

---

### Review notes (for the next developer)
- `src/runtime/contract.ts` is the **contract** for the whole system — engine and UI
  share only this. Read it first; everything else is an implementation of it.
- The fake wallet in `extension.ts` is an intentional placeholder (commented as such).
  A real wallet is Track 1's first task.
- ⚠️ Sessions saved now are encrypted with the *fake* key — once a real wallet is
  attached, they won't decrypt (different key). Discard test sessions at that switch.
- Verify: `pnpm install && pnpm test:run` (uses a temp `AGENTNET_HOME`, so it never
  pollutes the real `~/.agentnet`).
- A per-file "what does this do" table is in [`plans/STATUS.md`](plans/STATUS.md) §2.
