### PR TITLE
feat: extend Wallet with on-chain signing (unblocks Track 2)

### DIFF
--- a/scripts/test-runtime.ts
+++ b/scripts/test-runtime.ts
@@ -10,20 +10,12 @@ import { tmpdir } from "node:os";
 import { join } from "node:path";
 process.env.AGENTNET_HOME = join(tmpdir(), "agentnet-test-" + process.pid);
 
-import nacl from "tweetnacl";
 import { createRuntime } from "../src/runtime/index.js";
 import { manualStorage } from "../src/account/storage/manual.js";
 import { SessionStore } from "../src/account/store.js";
-import type { Wallet } from "../src/runtime/contract.js";
+import { testWallet } from "../src/account/keypairWallet.js";
 
-const kp = nacl.sign.keyPair.fromSeed(new Uint8Array(32).fill(7));
-const wallet: Wallet = {
-  address: "TESTWALLET",
-  async signMessage(msg) {
-    return nacl.sign.detached(msg, kp.secretKey);
-  },
-};
-
+const wallet = testWallet();
 const storage = manualStorage();
 const runtime = createRuntime(wallet, storage);
 

--- a/scripts/test-storage.ts
+++ b/scripts/test-storage.ts
@@ -9,20 +9,13 @@ import { createServer } from "node:http";
 import { rm, readdir } from "node:fs/promises";
 import { join } from "node:path";
 import { tmpdir } from "node:os";
-import nacl from "tweetnacl";
 import { SessionStore } from "../src/account/store.js";
 import { icloudStorage } from "../src/account/storage/icloud.js";
 import { customStorage } from "../src/account/storage/custom.js";
 import { initialize, login } from "../src/account/login.js";
-import type { Wallet } from "../src/runtime/contract.js";
+import { testWallet } from "../src/account/keypairWallet.js";
 
-const kp = nacl.sign.keyPair.fromSeed(new Uint8Array(32).fill(9));
-const wallet: Wallet = {
-  address: "TESTWALLET",
-  async signMessage(msg) {
-    return nacl.sign.detached(msg, kp.secretKey);
-  },
-};
+const wallet = testWallet(9);
 
 const meta = (id: string) => ({ sessionId: id, cli: "claude" as const, title: "test", ts: Date.now() });
 const msg = (text: string) => ({ role: "user" as const, text, ts: Date.now() });

--- a/src/account/keypairWallet.ts
+++ b/src/account/keypairWallet.ts
@@ -1,0 +1,36 @@
+// Build a full Wallet from a Solana Keypair. Satisfies BOTH capabilities:
+//   - signMessage  (ed25519 detached sig → session encryption key)
+//   - WalletSigner (publicKey + signTransaction/signAllTransactions → on-chain)
+// Used by tests, the CLI (local key), and any non-interactive signer. Interactive
+// front-ends (Phantom/mobile) implement Wallet directly instead of via a Keypair.
+
+import { Keypair, type Transaction, type VersionedTransaction } from "@solana/web3.js";
+import nacl from "tweetnacl";
+import type { Wallet } from "../runtime/contract.js";
+
+export function keypairWallet(kp: Keypair): Wallet {
+  return {
+    address: kp.publicKey.toBase58(),
+    publicKey: kp.publicKey,
+    async signMessage(msg) {
+      return nacl.sign.detached(msg, kp.secretKey);
+    },
+    async signTransaction<T extends Transaction | VersionedTransaction>(tx: T): Promise<T> {
+      if ("version" in tx) (tx as VersionedTransaction).sign([kp]);
+      else (tx as Transaction).partialSign(kp);
+      return tx;
+    },
+    async signAllTransactions<T extends Transaction | VersionedTransaction>(txs: T[]): Promise<T[]> {
+      for (const tx of txs) {
+        if ("version" in tx) (tx as VersionedTransaction).sign([kp]);
+        else (tx as Transaction).partialSign(kp);
+      }
+      return txs;
+    },
+  };
+}
+
+// Deterministic test wallet from a seed byte (same seed → same key everywhere).
+export function testWallet(seed = 7): Wallet {
+  return keypairWallet(Keypair.fromSeed(new Uint8Array(32).fill(seed)));
+}

--- a/src/runtime/contract.ts
+++ b/src/runtime/contract.ts
@@ -6,8 +6,16 @@
 // CODE-RULES: keep this the one source of these types. Don't redefine elsewhere.
 
 // ── wallet ──────────────────────────────────────────────
-export interface Wallet {
-  address: string; // base58
+// Two capabilities, one wallet:
+//   signMessage      → derive the session encryption key (Track 1, off-chain)
+//   WalletSigner     → sign Solana txs for the on-chain layer (Track 2)
+// WalletSigner is iqlabs-sdk's own type (publicKey + signTransaction +
+// signAllTransactions) — the SAME shape Phantom exposes, so any front-end
+// (Phantom, Ledger, a local Keypair, mobile wallet) can satisfy it.
+import type { WalletSigner } from "@iqlabs-official/solana-sdk/utils";
+
+export interface Wallet extends WalletSigner {
+  address: string; // base58 (== publicKey.toBase58())
   // used to derive the encryption key (iqlabs deriveX25519Keypair)
   signMessage(msg: Uint8Array): Promise<Uint8Array>;
 }

--- a/surfaces/vscode/src/extension.ts
+++ b/surfaces/vscode/src/extension.ts
@@ -5,22 +5,16 @@
 //   handle.onMessage → webview "message" (CLI output → panel)
 
 import * as vscode from "vscode";
-import type { AgentRuntime, SessionHandle, Wallet } from "../../../src/runtime/contract";
+import type { AgentRuntime, SessionHandle } from "../../../src/runtime/contract";
 import { createRuntime } from "../../../src/runtime/index";
 import { manualStorage } from "../../../src/account/storage/manual";
+import { testWallet } from "../../../src/account/keypairWallet";
 import { chatHtml } from "./webview";
-import nacl from "tweetnacl";
 
 // TEMP wallet — a fixed local keypair stands in for Phantom until wallet-connect
-// is wired. signMessage must be deterministic (same key → same session crypto).
-// Replaced later by: const { wallet, storage } = await login(phantom).
-const kp = nacl.sign.keyPair.fromSeed(new Uint8Array(32).fill(7));
-const wallet: Wallet = {
-  address: "TESTWALLET",
-  async signMessage(msg) {
-    return nacl.sign.detached(msg, kp.secretKey);
-  },
-};
+// is wired. testWallet provides the full Wallet (signMessage + signTransaction),
+// so on-chain code can run against it too. Replaced later by a real Phantom adapter.
+const wallet = testWallet();
 
 // Real runtime over local storage (swap manualStorage → login() result for cloud).
 const runtime: AgentRuntime = createRuntime(wallet, manualStorage());


### PR DESCRIPTION
Wallet only had signMessage (session encryption). On-chain work needs Solana tx signing, so Wallet now extends iqlabs-sdk WalletSigner (publicKey + signTransaction + signAllTransactions) — same shape Phantom exposes, so any front-end can satisfy it via an adapter.

- contract.ts: Wallet extends WalletSigner
- account/keypairWallet.ts: keypairWallet(kp) builds a full Wallet from a Keypair (real tx signing); testWallet(seed) for tests/CLI
- scripts + vscode: use testWallet()

Track 2 can now start against testWallet on devnet without a real wallet. Real Phantom UI stays a Track 1 task.

Tested: pnpm test:run PASS, vscode build OK.