### PR TITLE
feat(webview): engine picker at onboarding (Claude/Codex choice)

### DIFF
--- a/surfaces/webview/src/App.tsx
+++ b/surfaces/webview/src/App.tsx
@@ -1,20 +1,23 @@
 import { useStore } from "./state/store";
 import { ConnectWallet } from "./onboarding/ConnectWallet";
+import { PickEngine } from "./onboarding/PickEngine";
 import { ConnectClaude } from "./onboarding/ConnectClaude";
 import { ChatScreen } from "./chat/ChatScreen";
 import { Toast } from "./Toast";
 
 // Phase router: the store flips phase on the dispatcher's handshake events.
-//   connecting  → opening the SSE stream / sent `ready`, waiting for init|sessions
-//   onboarding  → no runtime yet → connect a wallet
-//   claudeAuth  → wallet in, claude logged out → connect the Claude subscription
-//   chat        → runtime ready → the chat shell
+//   connecting   → opening the SSE stream / sent `ready`, waiting for init|sessions
+//   onboarding   → no runtime yet → connect a wallet
+//   engineSelect → wallet in → pick which engine to activate (claude or codex)
+//   claudeAuth   → claude chosen but logged out → connect the Claude subscription
+//   chat         → runtime ready → the chat shell
 export function App() {
   const { state } = useStore();
   return (
     <>
       {state.phase === "connecting" && <Connecting />}
       {state.phase === "onboarding" && <ConnectWallet />}
+      {state.phase === "engineSelect" && <PickEngine />}
       {state.phase === "claudeAuth" && <ConnectClaude />}
       {state.phase === "chat" && <ChatScreen />}
       <Toast />

--- a/surfaces/webview/src/onboarding/PickEngine.tsx
+++ b/surfaces/webview/src/onboarding/PickEngine.tsx
@@ -1,0 +1,85 @@
+// Engine picker — the screen after wallet connect. The user chooses which agent engine to
+// activate (Claude or Codex) instead of being forced through Claude. The chosen engine
+// becomes the active tab and runs its own gate next: Claude → subscription login if it's
+// logged out; Codex → "coming soon" (its login flow + interactive approvals aren't wired
+// yet — codex-sdk exposes approvalPolicy only, so we don't pretend it works).
+
+import { useState } from "react";
+import { OnboardingShell, OnboardingButton } from "./OnboardingShell";
+import { useStore } from "../state/store";
+import type { EngineStatus } from "../state/store";
+
+// One-line status pill mirroring the CLI's badges, so the user sees up front whether an
+// engine is ready / logged out / not installed before picking it.
+function StatusPill({ status }: { status: EngineStatus | undefined }) {
+  if (status === "ok") return <span className="text-xs text-[#00E673]">● ready</span>;
+  if (status === "no-login") return <span className="text-xs text-amber-400">● sign-in needed</span>;
+  return <span className="text-xs text-zinc-500">● not installed</span>;
+}
+
+function EngineCard({
+  name,
+  status,
+  comingSoon,
+  selected,
+  onClick,
+}: {
+  name: string;
+  status: EngineStatus | undefined;
+  comingSoon?: boolean;
+  selected?: boolean;
+  onClick: () => void;
+}) {
+  return (
+    <button
+      onClick={onClick}
+      className={`flex w-full items-center justify-between rounded-xl border px-4 py-3.5 text-left transition ${
+        selected ? "border-[#00E673] bg-zinc-900" : "border-zinc-700 hover:bg-zinc-800/60"
+      }`}
+    >
+      <span className="flex flex-col gap-1">
+        <span className="text-sm font-medium text-zinc-100">
+          {name}
+          {comingSoon && <span className="ml-2 text-xs text-zinc-500">coming soon</span>}
+        </span>
+        <StatusPill status={status} />
+      </span>
+    </button>
+  );
+}
+
+export function PickEngine() {
+  const { state, selectEngine } = useStore();
+  const report = state.cliReport;
+  // local-only: which card is highlighted, and whether to show the codex coming-soon note.
+  const [codexNote, setCodexNote] = useState(false);
+
+  return (
+    <OnboardingShell
+      title="Choose your engine"
+      subtitle="Pick which agent to activate. You can switch later."
+    >
+      <EngineCard
+        name="Claude"
+        status={report?.claude}
+        selected={!codexNote}
+        onClick={() => selectEngine("claude")}
+      />
+      <EngineCard
+        name="Codex"
+        status={report?.codex}
+        comingSoon
+        selected={codexNote}
+        onClick={() => setCodexNote(true)}
+      />
+      {codexNote && (
+        <p className="mt-1 text-center text-sm text-amber-400/90">
+          Codex isn't ready yet — sign-in and tool approvals aren't wired. Pick Claude for now.
+        </p>
+      )}
+      <OnboardingButton className="mt-1" onClick={() => selectEngine("claude")}>
+        Continue with Claude
+      </OnboardingButton>
+    </OnboardingShell>
+  );
+}

--- a/surfaces/webview/src/state/store.tsx
+++ b/surfaces/webview/src/state/store.tsx
@@ -24,10 +24,15 @@ import type {
 
 // A rendered log entry. We keep messages as-is and stream into the last assistant/
 // thinking bubble when `partial` is set, matching the HTML webview's bubble model.
+export type EngineStatus = "ok" | "no-login" | "missing";
+
 export interface State {
-  phase: "connecting" | "onboarding" | "claudeAuth" | "chat";
+  phase: "connecting" | "onboarding" | "engineSelect" | "claudeAuth" | "chat";
   walletAddress: string | null;
   cli: Cli;
+  // per-engine install/login status from the post-wallet `cliStatus` event, kept so the
+  // engine picker can show a live badge next to each choice (null until it arrives).
+  cliReport: { claude: EngineStatus; codex: EngineStatus } | null;
   // claude subscription login during onboarding: the OAuth URL to open and the status
   // of the in-flight login (null when no error/pending state to show).
   claudeLoginUrl: string | null;
@@ -49,6 +54,7 @@ const initialState: State = {
   phase: "connecting",
   walletAddress: null,
   cli: "claude",
+  cliReport: null,
   claudeLoginUrl: null,
   claudeLoginError: null,
   log: [],
@@ -88,7 +94,8 @@ function appendMessage(log: ChatMessage[], msg: ChatMessage): ChatMessage[] {
 type LocalAction =
   | { type: "__typing" }
   | { type: "__removeApproval"; id: string }
-  | { type: "__clearToast" };
+  | { type: "__clearToast" }
+  | { type: "__selectEngine"; cli: Cli };
 type Action = ServerMessage | LocalAction;
 
 function reducer(state: State, ev: Action): State {
@@ -99,6 +106,15 @@ function reducer(state: State, ev: Action): State {
       return { ...state, approvals: state.approvals.filter((a) => a.id !== ev.id) };
     case "__clearToast":
       return { ...state, toast: null };
+    case "__selectEngine": {
+      // User picked which engine to activate. Codex is gated "coming soon" (no login
+      // flow / interactive approvals yet — codex-sdk exposes approvalPolicy only), so it
+      // never advances here; the picker shows its disabled state inline. Claude becomes
+      // the active tab and gates on subscription login only if it's logged out.
+      if (ev.cli === "codex") return state;
+      const needsLogin = state.cliReport?.claude === "no-login";
+      return { ...state, cli: "claude", phase: needsLogin ? "claudeAuth" : "chat" };
+    }
     case "init":
       // Onboarding handshake: no runtime yet → show ConnectWallet.
       return { ...state, phase: "onboarding" };
@@ -107,9 +123,14 @@ function reducer(state: State, ev: Action): State {
       // claude needs a subscription login first. Stay in onboarding meanwhile.
       return { ...state, walletAddress: ev.address };
     case "cliStatus":
-      // After wallet: if claude is installed but logged out, gate on the subscription
-      // login screen; otherwise proceed to chat (the dispatcher attaches on next /events).
-      return { ...state, phase: ev.claude === "no-login" ? "claudeAuth" : "chat" };
+      // After wallet: don't force claude. Record both engines' status and show the engine
+      // picker so the user chooses which one to activate. The chosen engine then runs its
+      // own gate (claude → login if needed; codex → coming-soon) via __selectEngine.
+      return {
+        ...state,
+        cliReport: { claude: ev.claude, codex: ev.codex },
+        phase: "engineSelect",
+      };
     case "claudeLoginUrl":
       return { ...state, claudeLoginUrl: ev.url, claudeLoginError: null };
     case "claudeLoginStatus":
@@ -160,6 +181,7 @@ interface Store {
   startTyping: () => void;
   resolveApproval: (id: string) => void;
   clearToast: () => void;
+  selectEngine: (cli: Cli) => void;
 }
 
 const StoreContext = createContext<Store | null>(null);
@@ -208,6 +230,8 @@ export function StoreProvider({ children }: { children: ReactNode }) {
       // Drop an answered approval from the dock immediately; core won't re-send it.
       resolveApproval: (id) => raw({ type: "__removeApproval", id }),
       clearToast: () => raw({ type: "__clearToast" }),
+      // Activate the chosen engine; routing (login gate / chat) is decided in the reducer.
+      selectEngine: (cli) => raw({ type: "__selectEngine", cli }),
     };
   }, [state]);
 


### PR DESCRIPTION
Closes #7 (webview surface).

## What
After wallet connect, onboarding now offers a **Claude / Codex** choice instead of forcing the user through Claude. The chosen engine becomes the active tab and runs its own gate.

Previously `cliStatus` routed straight to `claudeAuth`/`chat` and ignored `cli.codex` entirely.

## Changes
- **`state/store.tsx`** — new `engineSelect` phase + `cliReport` (both engines' install/login status). `cliStatus` records status and shows the picker. New `__selectEngine` reducer gates per engine: Claude → login screen if logged out, else chat.
- **`onboarding/PickEngine.tsx`** (new) — Claude/Codex cards with live status pills, brand-styled via `OnboardingShell`.
- **`App.tsx`** — route the `engineSelect` phase.

## Codex: gated "coming soon"
Codex login + interactive approvals aren't wired yet (codex-sdk exposes `approvalPolicy` only — see `packages/core/src/runtime/spawn.ts`). Selecting Codex shows a note and doesn't advance — the issue's accepted "clearly disabled" outcome.

Auth strategy (device-auth vs API-key) deliberately **deferred** — device-auth is beta and ChatGPT-subscription use in third-party apps isn't sanctioned by OpenAI, unlike Anthropic's `claude` sub-login.

## Notes
- No server/protocol change: `cliStatus{claude,codex}` already arrives; gating is client-side.
- `tsc --noEmit` clean.
- CLI surface gets the same picker on `feat/agentnet-cli` (separate changeset).