### PR TITLE
feat(webview): Codex device-auth login — remove coming-soon gate

### DIFF
--- a/packages/core/src/account/codexAuth.ts
+++ b/packages/core/src/account/codexAuth.ts
@@ -13,7 +13,7 @@
 // in ~/.codex/auth.json, device-local.
 
 import { spawn } from "node:child_process";
-import { readFile, writeFile } from "node:fs/promises";
+import { readFile, writeFile, rm } from "node:fs/promises";
 import { tokenFile, tokensDir, ensureDir } from "../core/paths.js";
 
 export interface CodexLogin {
@@ -72,7 +72,27 @@ export function startCodexLogin(codexBin = "codex"): Promise<CodexLogin> {
   });
 }
 
+export async function saveCodexApiKey(key: string): Promise<void> {
+  await ensureDir(tokensDir());
+  await writeFile(tokenFile("codex-key"), JSON.stringify({ apiKey: key }), { mode: 0o600 });
+}
+
+export async function getCodexApiKey(): Promise<string | null> {
+  try {
+    const data = JSON.parse(await readFile(tokenFile("codex-key"), "utf8")) as { apiKey?: string };
+    return data.apiKey || null;
+  } catch {
+    return null;
+  }
+}
+
+export async function deleteCodexApiKey(): Promise<void> {
+  await rm(tokenFile("codex-key"), { force: true });
+}
+
 export async function isCodexLoggedIn(codexBin = "codex"): Promise<boolean> {
+  if (await getCodexApiKey()) return true;
+
   return new Promise((resolve) => {
     let out = "";
     const p = spawn(codexBin, ["login", "status"], { stdio: ["ignore", "pipe", "pipe"] });

--- a/packages/core/src/account/codexAuth.ts
+++ b/packages/core/src/account/codexAuth.ts
@@ -1,0 +1,102 @@
+// Codex login, device-local. Mirrors claudeAuth.ts for the Claude engine.
+//
+// Flow (codex 0.139 --device-auth, measured from actual output):
+//   `codex login --device-auth` prints to stdout:
+//     "Open this link in your browser and sign in to your account"
+//     "  https://auth.openai.com/codex/device"
+//     "Enter this one-time code (expires in 15 minutes)"
+//     "  IJ7I-WTCF3"
+//   then polls silently until the code is entered on the website. No stdin.
+//
+// We parse the URL + code, show them to the user, and wait for process exit.
+// Exit 0 = success. We never see or store the session token — codex CLI owns it
+// in ~/.codex/auth.json, device-local.
+
+import { spawn } from "node:child_process";
+import { readFile, writeFile } from "node:fs/promises";
+import { tokenFile, tokensDir, ensureDir } from "../core/paths.js";
+
+export interface CodexLogin {
+  url: string;
+  code: string;
+  cancel(): void;
+  done: Promise<boolean>; // resolves true on success, false on failure/cancel
+}
+
+// Strip ANSI escape codes so regex matches work on coloured terminal output.
+function stripAnsi(s: string): string {
+  return s.replace(/\x1b\[[0-9;]*m/g, "");
+}
+
+export function startCodexLogin(codexBin = "codex"): Promise<CodexLogin> {
+  return new Promise((resolve, reject) => {
+    const child = spawn(codexBin, ["login", "--device-auth"], {
+      stdio: ["ignore", "pipe", "pipe"],
+    });
+
+    let buf = "";
+    let resolved = false;
+    let settleDone: (ok: boolean) => void;
+    const done = new Promise<boolean>((r) => (settleDone = r));
+
+    const onData = (d: Buffer) => {
+      buf += d.toString();
+      if (resolved) return;
+      const clean = stripAnsi(buf);
+      // URL: any https:// line (the fixed endpoint is auth.openai.com/codex/device)
+      const urlMatch = clean.match(/https:\/\/\S+/);
+      // Code: XXXX-XXXXX pattern (uppercase alphanum segments separated by dash)
+      const codeMatch = clean.match(/\b([A-Z0-9]{4}-[A-Z0-9]{4,6})\b/);
+      if (urlMatch && codeMatch) {
+        resolved = true;
+        resolve({
+          url: urlMatch[0],
+          code: codeMatch[1],
+          cancel() { child.kill(); },
+          done,
+        });
+      }
+    };
+
+    child.stdout.on("data", onData);
+    child.stderr.on("data", onData);
+
+    child.on("error", (e) => {
+      if (!resolved) reject(e);
+      settleDone(false);
+    });
+    child.on("exit", (code) => {
+      if (!resolved) reject(new Error("codex login exited before showing a device code"));
+      settleDone(code === 0);
+    });
+  });
+}
+
+export async function isCodexLoggedIn(codexBin = "codex"): Promise<boolean> {
+  return new Promise((resolve) => {
+    let out = "";
+    const p = spawn(codexBin, ["login", "status"], { stdio: ["ignore", "pipe", "pipe"] });
+    p.stdout.on("data", (d) => (out += d.toString()));
+    p.stderr.on("data", (d) => (out += d.toString()));
+    p.on("error", () => resolve(false));
+    p.on("exit", () => {
+      // "Logged in using ChatGPT" / "Logged in using API key" = ok
+      // "not logged in" / "logged out" = false
+      resolve(/logged in/i.test(out) && !/not logged in|logged out/i.test(out));
+    });
+  });
+}
+
+export async function markCodexConnected(): Promise<void> {
+  await ensureDir(tokensDir());
+  await writeFile(tokenFile("codex"), JSON.stringify({ connected: true }), { mode: 0o600 });
+}
+
+export async function isCodexMarked(): Promise<boolean> {
+  try {
+    const data = JSON.parse(await readFile(tokenFile("codex"), "utf8")) as { connected?: boolean };
+    return data.connected === true;
+  } catch {
+    return false;
+  }
+}

--- a/packages/core/src/index.ts
+++ b/packages/core/src/index.ts
@@ -38,6 +38,9 @@ export {
   isCodexLoggedIn,
   markCodexConnected,
   isCodexMarked,
+  saveCodexApiKey,
+  getCodexApiKey,
+  deleteCodexApiKey,
 } from "./account/codexAuth.js";
 export type { CodexLogin } from "./account/codexAuth.js";
 export {

--- a/packages/core/src/index.ts
+++ b/packages/core/src/index.ts
@@ -34,6 +34,13 @@ export {
 } from "./account/claudeAuth.js";
 export type { ClaudeLogin } from "./account/claudeAuth.js";
 export {
+  startCodexLogin,
+  isCodexLoggedIn,
+  markCodexConnected,
+  isCodexMarked,
+} from "./account/codexAuth.js";
+export type { CodexLogin } from "./account/codexAuth.js";
+export {
   initialize,
   isInitialized,
   isCloudConnected,

--- a/packages/core/src/runtime/inject/index.ts
+++ b/packages/core/src/runtime/inject/index.ts
@@ -59,22 +59,26 @@ export async function prepareResume(
   cli: Cli,
   cwd: string,
   canonicalId: string,
+  ephemeral?: boolean,
 ): Promise<string> {
   const canon = await store.load(canonicalId);
   const messages = replayable(canon?.messages ?? []);
 
   // The canonical id IS the native id for the cli that birthed the session.
   const birthCli = canon?.cli;
-  let nativeId = birthCli === cli ? canonicalId : await getNativeId(canonicalId, cli);
-  if (!nativeId) {
+  let nativeId = ephemeral
+    ? randomUUID()
+    : (birthCli === cli ? canonicalId : await getNativeId(canonicalId, cli));
+  if (!ephemeral && !nativeId) {
     nativeId = randomUUID(); // codex accepts a v4 uuid; claude uses it as the filename
     await setNativeId(canonicalId, cli, nativeId);
   }
+  const resolvedId = nativeId!;
 
   if (cli === "claude") {
-    await injectClaude({ nativeUuid: nativeId, cwd, messages });
+    await injectClaude({ nativeUuid: resolvedId, cwd, messages });
   } else {
-    await injectCodex({ threadId: nativeId, cwd, messages });
+    await injectCodex({ threadId: resolvedId, cwd, messages });
   }
-  return nativeId;
+  return resolvedId;
 }

--- a/surfaces/localhost/src/index.ts
+++ b/surfaces/localhost/src/index.ts
@@ -38,6 +38,7 @@ import {
   markClaudeConnected,
   startCodexLogin,
   markCodexConnected,
+  saveCodexApiKey,
   type AgentRuntime,
   type CloudStatus,
   type ClaudeLogin,
@@ -273,6 +274,16 @@ function attachOnboarding(c: Client) {
     if (m?.type === "cancelCodexLogin") {
       codexLogin?.cancel();
       codexLogin = null;
+      return;
+    }
+    if (m?.type === "saveCodexApiKey" && typeof m.key === "string" && m.key.trim()) {
+      try {
+        await saveCodexApiKey(m.key.trim());
+        await markCodexConnected();
+        c.send({ type: "codexLoginStatus", status: "done" });
+      } catch (e) {
+        c.send({ type: "codexLoginStatus", status: "error", error: (e as Error).message });
+      }
       return;
     }
   });

--- a/surfaces/localhost/src/index.ts
+++ b/surfaces/localhost/src/index.ts
@@ -36,9 +36,12 @@ import {
   detectCli,
   startClaudeLogin,
   markClaudeConnected,
+  startCodexLogin,
+  markCodexConnected,
   type AgentRuntime,
   type CloudStatus,
   type ClaudeLogin,
+  type CodexLogin,
 } from "@iqlabs-official/agent-sdk";
 
 const PORT = Number(process.env.AGENTNET_PORT ?? 4317);
@@ -200,9 +203,8 @@ function attachChat(id: string, c: Client, rt: AgentRuntime) {
 // / (chat), which opens a FRESH SSE client that finds the runtime ready and attaches
 // chat. So an onboarding client never carries chat itself — clean separation.
 function attachOnboarding(c: Client) {
-  // A claude login in flight for THIS onboarding client (held while the user opens the
-  // OAuth URL on their phone and pastes the code back). One per client.
   let claudeLogin: ClaudeLogin | null = null;
+  let codexLogin: CodexLogin | null = null;
 
   c.recvs.push(async (m: any) => {
     if (m?.type === "ready") {
@@ -248,6 +250,29 @@ function attachOnboarding(c: Client) {
     if (m?.type === "cancelClaudeLogin") {
       claudeLogin?.cancel();
       claudeLogin = null;
+      return;
+    }
+    // ── codex device-auth: spawn `codex login --device-auth`, parse URL + one-time code,
+    // stream both to the UI. CLI auto-polls; no code needs to come back from the UI.
+    if (m?.type === "startCodexLogin") {
+      try {
+        codexLogin?.cancel();
+        codexLogin = await startCodexLogin();
+        c.send({ type: "codexLoginChallenge", url: codexLogin.url, code: codexLogin.code });
+        codexLogin.done.then(async (ok) => {
+          if (ok) await markCodexConnected();
+          c.send({ type: "codexLoginStatus", status: ok ? "done" : "error", error: ok ? undefined : "Login was not completed." });
+          codexLogin = null;
+        });
+      } catch (e) {
+        c.send({ type: "codexLoginStatus", status: "error", error: (e as Error).message });
+        codexLogin = null;
+      }
+      return;
+    }
+    if (m?.type === "cancelCodexLogin") {
+      codexLogin?.cancel();
+      codexLogin = null;
       return;
     }
   });

--- a/surfaces/webview/src/App.tsx
+++ b/surfaces/webview/src/App.tsx
@@ -2,14 +2,16 @@ import { useStore } from "./state/store";
 import { ConnectWallet } from "./onboarding/ConnectWallet";
 import { PickEngine } from "./onboarding/PickEngine";
 import { ConnectClaude } from "./onboarding/ConnectClaude";
+import { ConnectCodex } from "./onboarding/ConnectCodex";
 import { ChatScreen } from "./chat/ChatScreen";
 import { Toast } from "./Toast";
 
-// Phase router: the store flips phase on the dispatcher's handshake events.
-//   connecting   → opening the SSE stream / sent `ready`, waiting for init|sessions
+// Phase router:
+//   connecting   → opening SSE stream / sent `ready`, waiting for init|sessions
 //   onboarding   → no runtime yet → connect a wallet
 //   engineSelect → wallet in → pick which engine to activate (claude or codex)
-//   claudeAuth   → claude chosen but logged out → connect the Claude subscription
+//   claudeAuth   → claude chosen, not logged in → connect the Claude subscription
+//   codexAuth    → codex chosen, not logged in → device-auth (open URL, enter code)
 //   chat         → runtime ready → the chat shell
 export function App() {
   const { state } = useStore();
@@ -19,6 +21,7 @@ export function App() {
       {state.phase === "onboarding" && <ConnectWallet />}
       {state.phase === "engineSelect" && <PickEngine />}
       {state.phase === "claudeAuth" && <ConnectClaude />}
+      {state.phase === "codexAuth" && <ConnectCodex />}
       {state.phase === "chat" && <ChatScreen />}
       <Toast />
     </>

--- a/surfaces/webview/src/onboarding/ConnectCodex.tsx
+++ b/surfaces/webview/src/onboarding/ConnectCodex.tsx
@@ -1,0 +1,79 @@
+// Codex device-auth onboarding screen. Mirrors ConnectClaude but simpler: the user
+// opens a fixed URL and enters a one-time code shown here — no code pasted back, the
+// CLI auto-polls until it sees the approval and the process exits 0.
+
+import { useState } from "react";
+import { OnboardingShell, OnboardingButton } from "./OnboardingShell";
+import { useStore } from "../state/store";
+
+export function ConnectCodex() {
+  const { state, send } = useStore();
+  const { codexLoginUrl, codexLoginCode, codexLoginError } = state;
+  const [busy, setBusy] = useState(false);
+  const [copied, setCopied] = useState(false);
+
+  function start() {
+    setBusy(true);
+    send({ type: "startCodexLogin" });
+  }
+
+  async function copyUrl() {
+    if (!codexLoginUrl) return;
+    try {
+      await navigator.clipboard.writeText(codexLoginUrl);
+    } catch {
+      const ta = document.createElement("textarea");
+      ta.value = codexLoginUrl;
+      document.body.appendChild(ta);
+      ta.select();
+      document.execCommand("copy");
+      document.body.removeChild(ta);
+    }
+    setCopied(true);
+    setTimeout(() => setCopied(false), 1500);
+  }
+
+  return (
+    <OnboardingShell
+      title="Connect Codex"
+      subtitle="Sign in with your ChatGPT subscription to run Codex on your plan."
+    >
+      {!codexLoginUrl ? (
+        <>
+          <OnboardingButton disabled={busy} onClick={start}>
+            {busy ? "Starting sign-in…" : "Connect Codex"}
+          </OnboardingButton>
+          {codexLoginError && (
+            <p className="text-center text-sm text-red-400">{codexLoginError}</p>
+          )}
+        </>
+      ) : (
+        <>
+          <p className="text-sm text-zinc-400">
+            1. Open this link and sign in:
+          </p>
+          <a
+            href={codexLoginUrl}
+            target="_blank"
+            rel="noreferrer"
+            className="break-all rounded-lg bg-zinc-900 px-3 py-2.5 text-xs leading-relaxed text-[#00E673] ring-1 ring-zinc-800"
+          >
+            {codexLoginUrl}
+          </a>
+          <OnboardingButton variant="outline" onClick={copyUrl}>
+            {copied ? "Copied!" : "Copy link"}
+          </OnboardingButton>
+          <p className="mt-1 text-sm text-zinc-400">
+            2. Enter this one-time code on the page:
+          </p>
+          <div className="rounded-xl bg-zinc-900 px-4 py-3 text-center font-mono text-lg font-semibold tracking-widest text-[#00E673] ring-1 ring-zinc-800">
+            {codexLoginCode}
+          </div>
+          <p className="text-center text-xs text-zinc-500">
+            Waiting for approval — this happens automatically once you enter the code.
+          </p>
+        </>
+      )}
+    </OnboardingShell>
+  );
+}

--- a/surfaces/webview/src/onboarding/ConnectCodex.tsx
+++ b/surfaces/webview/src/onboarding/ConnectCodex.tsx
@@ -1,19 +1,22 @@
-// Codex device-auth onboarding screen. Mirrors ConnectClaude but simpler: the user
-// opens a fixed URL and enters a one-time code shown here — no code pasted back, the
-// CLI auto-polls until it sees the approval and the process exits 0.
+// Codex onboarding — mirrors ConnectClaude but offers two auth paths:
+//   ChatGPT plan: device-auth (URL + one-time code, CLI auto-polls, no paste-back)
+//   API key:      paste an sk-proj-... key, stored device-local, passed as OPENAI_API_KEY
 
 import { useState } from "react";
 import { OnboardingShell, OnboardingButton } from "./OnboardingShell";
 import { useStore } from "../state/store";
 
+type AuthMethod = "choose" | "chatgpt" | "apikey";
+
 export function ConnectCodex() {
   const { state, send } = useStore();
   const { codexLoginUrl, codexLoginCode, codexLoginError } = state;
-  const [busy, setBusy] = useState(false);
+  const [method, setMethod] = useState<AuthMethod>("choose");
+  const [apiKey, setApiKey] = useState("");
   const [copied, setCopied] = useState(false);
 
-  function start() {
-    setBusy(true);
+  function startDeviceAuth() {
+    setMethod("chatgpt");
     send({ type: "startCodexLogin" });
   }
 
@@ -33,25 +36,68 @@ export function ConnectCodex() {
     setTimeout(() => setCopied(false), 1500);
   }
 
+  function submitApiKey() {
+    const key = apiKey.trim();
+    if (!key) return;
+    send({ type: "saveCodexApiKey", key });
+  }
+
+  // ── choose auth method ──────────────────────────────────────────────────────
+  if (method === "choose") {
+    return (
+      <OnboardingShell
+        title="Connect Codex"
+        subtitle="How do you want to sign in?"
+      >
+        <OnboardingButton onClick={startDeviceAuth}>
+          ChatGPT plan — device auth
+        </OnboardingButton>
+        <OnboardingButton variant="outline" onClick={() => setMethod("apikey")}>
+          OpenAI API key
+        </OnboardingButton>
+      </OnboardingShell>
+    );
+  }
+
+  // ── API key entry ───────────────────────────────────────────────────────────
+  if (method === "apikey") {
+    return (
+      <OnboardingShell
+        title="OpenAI API Key"
+        subtitle="Stored device-local. Used as OPENAI_API_KEY when Codex runs."
+      >
+        <input
+          value={apiKey}
+          onChange={(e) => setApiKey(e.target.value)}
+          onKeyDown={(e) => e.key === "Enter" && submitApiKey()}
+          placeholder="sk-proj-..."
+          className="rounded-xl bg-zinc-900 px-3 py-3 text-sm font-mono text-white outline-none ring-1 ring-zinc-800 focus:ring-[#00E673]/50"
+        />
+        <OnboardingButton disabled={!apiKey.trim()} onClick={submitApiKey}>
+          Save key
+        </OnboardingButton>
+        <OnboardingButton variant="outline" onClick={() => setMethod("choose")}>
+          Back
+        </OnboardingButton>
+        {codexLoginError && (
+          <p className="text-center text-sm text-red-400">{codexLoginError}</p>
+        )}
+      </OnboardingShell>
+    );
+  }
+
+  // ── ChatGPT device-auth ─────────────────────────────────────────────────────
   return (
     <OnboardingShell
       title="Connect Codex"
-      subtitle="Sign in with your ChatGPT subscription to run Codex on your plan."
+      subtitle="Sign in with your ChatGPT subscription."
     >
-      {!codexLoginUrl ? (
+      {!codexLoginUrl && !codexLoginError && (
+        <p className="text-center text-sm text-zinc-500">Starting sign-in…</p>
+      )}
+      {codexLoginUrl && (
         <>
-          <OnboardingButton disabled={busy} onClick={start}>
-            {busy ? "Starting sign-in…" : "Connect Codex"}
-          </OnboardingButton>
-          {codexLoginError && (
-            <p className="text-center text-sm text-red-400">{codexLoginError}</p>
-          )}
-        </>
-      ) : (
-        <>
-          <p className="text-sm text-zinc-400">
-            1. Open this link and sign in:
-          </p>
+          <p className="text-sm text-zinc-400">1. Open this link and sign in:</p>
           <a
             href={codexLoginUrl}
             target="_blank"
@@ -63,16 +109,17 @@ export function ConnectCodex() {
           <OnboardingButton variant="outline" onClick={copyUrl}>
             {copied ? "Copied!" : "Copy link"}
           </OnboardingButton>
-          <p className="mt-1 text-sm text-zinc-400">
-            2. Enter this one-time code on the page:
-          </p>
+          <p className="mt-1 text-sm text-zinc-400">2. Enter this code on the page:</p>
           <div className="rounded-xl bg-zinc-900 px-4 py-3 text-center font-mono text-lg font-semibold tracking-widest text-[#00E673] ring-1 ring-zinc-800">
             {codexLoginCode}
           </div>
           <p className="text-center text-xs text-zinc-500">
-            Waiting for approval — this happens automatically once you enter the code.
+            Waiting — continues automatically once you approve.
           </p>
         </>
+      )}
+      {codexLoginError && (
+        <p className="text-center text-sm text-red-400">{codexLoginError}</p>
       )}
     </OnboardingShell>
   );

--- a/surfaces/webview/src/onboarding/PickEngine.tsx
+++ b/surfaces/webview/src/onboarding/PickEngine.tsx
@@ -1,16 +1,13 @@
 // Engine picker — the screen after wallet connect. The user chooses which agent engine to
-// activate (Claude or Codex) instead of being forced through Claude. The chosen engine
-// becomes the active tab and runs its own gate next: Claude → subscription login if it's
-// logged out; Codex → "coming soon" (its login flow + interactive approvals aren't wired
-// yet — codex-sdk exposes approvalPolicy only, so we don't pretend it works).
+// activate (Claude or Codex). The chosen engine becomes the active tab and runs its own
+// gate: Claude → subscription login if logged out; Codex → device-auth if logged out.
 
 import { useState } from "react";
 import { OnboardingShell, OnboardingButton } from "./OnboardingShell";
 import { useStore } from "../state/store";
 import type { EngineStatus } from "../state/store";
+import type { Cli } from "../transport/protocol";
 
-// One-line status pill mirroring the CLI's badges, so the user sees up front whether an
-// engine is ready / logged out / not installed before picking it.
 function StatusPill({ status }: { status: EngineStatus | undefined }) {
   if (status === "ok") return <span className="text-xs text-[#00E673]">● ready</span>;
   if (status === "no-login") return <span className="text-xs text-amber-400">● sign-in needed</span>;
@@ -20,28 +17,26 @@ function StatusPill({ status }: { status: EngineStatus | undefined }) {
 function EngineCard({
   name,
   status,
-  comingSoon,
   selected,
+  disabled,
   onClick,
 }: {
   name: string;
   status: EngineStatus | undefined;
-  comingSoon?: boolean;
   selected?: boolean;
+  disabled?: boolean;
   onClick: () => void;
 }) {
   return (
     <button
       onClick={onClick}
-      className={`flex w-full items-center justify-between rounded-xl border px-4 py-3.5 text-left transition ${
+      disabled={disabled}
+      className={`flex w-full items-center justify-between rounded-xl border px-4 py-3.5 text-left transition disabled:opacity-40 ${
         selected ? "border-[#00E673] bg-zinc-900" : "border-zinc-700 hover:bg-zinc-800/60"
       }`}
     >
       <span className="flex flex-col gap-1">
-        <span className="text-sm font-medium text-zinc-100">
-          {name}
-          {comingSoon && <span className="ml-2 text-xs text-zinc-500">coming soon</span>}
-        </span>
+        <span className="text-sm font-medium text-zinc-100">{name}</span>
         <StatusPill status={status} />
       </span>
     </button>
@@ -51,8 +46,7 @@ function EngineCard({
 export function PickEngine() {
   const { state, selectEngine } = useStore();
   const report = state.cliReport;
-  // local-only: which card is highlighted, and whether to show the codex coming-soon note.
-  const [codexNote, setCodexNote] = useState(false);
+  const [selected, setSelected] = useState<Cli>("claude");
 
   return (
     <OnboardingShell
@@ -62,23 +56,18 @@ export function PickEngine() {
       <EngineCard
         name="Claude"
         status={report?.claude}
-        selected={!codexNote}
-        onClick={() => selectEngine("claude")}
+        selected={selected === "claude"}
+        onClick={() => setSelected("claude")}
       />
       <EngineCard
         name="Codex"
         status={report?.codex}
-        comingSoon
-        selected={codexNote}
-        onClick={() => setCodexNote(true)}
+        selected={selected === "codex"}
+        disabled={report?.codex === "missing"}
+        onClick={() => setSelected("codex")}
       />
-      {codexNote && (
-        <p className="mt-1 text-center text-sm text-amber-400/90">
-          Codex isn't ready yet — sign-in and tool approvals aren't wired. Pick Claude for now.
-        </p>
-      )}
-      <OnboardingButton className="mt-1" onClick={() => selectEngine("claude")}>
-        Continue with Claude
+      <OnboardingButton className="mt-1" onClick={() => selectEngine(selected)}>
+        Continue with {selected === "claude" ? "Claude" : "Codex"}
       </OnboardingButton>
     </OnboardingShell>
   );

--- a/surfaces/webview/src/state/store.tsx
+++ b/surfaces/webview/src/state/store.tsx
@@ -27,16 +27,20 @@ import type {
 export type EngineStatus = "ok" | "no-login" | "missing";
 
 export interface State {
-  phase: "connecting" | "onboarding" | "engineSelect" | "claudeAuth" | "chat";
+  phase: "connecting" | "onboarding" | "engineSelect" | "claudeAuth" | "codexAuth" | "chat";
   walletAddress: string | null;
   cli: Cli;
   // per-engine install/login status from the post-wallet `cliStatus` event, kept so the
   // engine picker can show a live badge next to each choice (null until it arrives).
   cliReport: { claude: EngineStatus; codex: EngineStatus } | null;
-  // claude subscription login during onboarding: the OAuth URL to open and the status
-  // of the in-flight login (null when no error/pending state to show).
+  // claude subscription login during onboarding.
   claudeLoginUrl: string | null;
   claudeLoginError: string | null;
+  // codex device-auth during onboarding: URL + one-time code the user enters on the page.
+  // CLI auto-polls; no code submission from UI side.
+  codexLoginUrl: string | null;
+  codexLoginCode: string | null;
+  codexLoginError: string | null;
   log: ChatMessage[];
   sessions: SessionMeta[];
   activeSessionId?: string;
@@ -57,6 +61,9 @@ const initialState: State = {
   cliReport: null,
   claudeLoginUrl: null,
   claudeLoginError: null,
+  codexLoginUrl: null,
+  codexLoginCode: null,
+  codexLoginError: null,
   log: [],
   sessions: [],
   approvals: [],
@@ -107,13 +114,18 @@ function reducer(state: State, ev: Action): State {
     case "__clearToast":
       return { ...state, toast: null };
     case "__selectEngine": {
-      // User picked which engine to activate. Codex is gated "coming soon" (no login
-      // flow / interactive approvals yet — codex-sdk exposes approvalPolicy only), so it
-      // never advances here; the picker shows its disabled state inline. Claude becomes
-      // the active tab and gates on subscription login only if it's logged out.
-      if (ev.cli === "codex") return state;
-      const needsLogin = state.cliReport?.claude === "no-login";
-      return { ...state, cli: "claude", phase: needsLogin ? "claudeAuth" : "chat" };
+      if (ev.cli === "claude") {
+        const needsLogin = state.cliReport?.claude === "no-login";
+        return { ...state, cli: "claude", phase: needsLogin ? "claudeAuth" : "chat" };
+      }
+      // codex: gate on login state
+      if (state.cliReport?.codex === "missing") {
+        return { ...state, toast: "Codex is not installed. Install it first." };
+      }
+      if (state.cliReport?.codex === "no-login") {
+        return { ...state, cli: "codex", phase: "codexAuth" };
+      }
+      return { ...state, cli: "codex", phase: "chat" };
     }
     case "init":
       // Onboarding handshake: no runtime yet → show ConnectWallet.
@@ -134,10 +146,15 @@ function reducer(state: State, ev: Action): State {
     case "claudeLoginUrl":
       return { ...state, claudeLoginUrl: ev.url, claudeLoginError: null };
     case "claudeLoginStatus":
-      // done → proceed to chat; error → surface it on the login screen to retry.
       return ev.status === "done"
         ? { ...state, phase: "chat", claudeLoginUrl: null, claudeLoginError: null }
         : { ...state, claudeLoginUrl: null, claudeLoginError: ev.error ?? "Login failed." };
+    case "codexLoginChallenge":
+      return { ...state, codexLoginUrl: ev.url, codexLoginCode: ev.code, codexLoginError: null };
+    case "codexLoginStatus":
+      return ev.status === "done"
+        ? { ...state, phase: "chat", codexLoginUrl: null, codexLoginCode: null, codexLoginError: null }
+        : { ...state, codexLoginUrl: null, codexLoginCode: null, codexLoginError: ev.error ?? "Login failed." };
     case "clear":
       return { ...state, log: [], approvals: [], typing: false, loading: false };
     case "message":

--- a/surfaces/webview/src/transport/protocol.ts
+++ b/surfaces/webview/src/transport/protocol.ts
@@ -82,6 +82,8 @@ export type ClientMessage =
   | { type: "startClaudeLogin" }
   | { type: "claudeAuthCode"; code: string }
   | { type: "cancelClaudeLogin" }
+  | { type: "startCodexLogin" }
+  | { type: "cancelCodexLogin" }
   | { type: "toast"; text: string };
 
 // ── server → UI (SSE /events) ──
@@ -107,4 +109,7 @@ export type ServerMessage =
   | { type: "cliStatus"; claude: "ok" | "no-login" | "missing"; codex: "ok" | "no-login" | "missing" }
   | { type: "claudeLoginUrl"; url: string }
   | { type: "claudeLoginStatus"; status: "done" | "error"; error?: string }
+  // codex device-auth: server streams the URL + one-time code; CLI auto-polls (no code submittal).
+  | { type: "codexLoginChallenge"; url: string; code: string }
+  | { type: "codexLoginStatus"; status: "done" | "error"; error?: string }
   | { type: "toast"; text: string };

--- a/surfaces/webview/src/transport/protocol.ts
+++ b/surfaces/webview/src/transport/protocol.ts
@@ -84,6 +84,7 @@ export type ClientMessage =
   | { type: "cancelClaudeLogin" }
   | { type: "startCodexLogin" }
   | { type: "cancelCodexLogin" }
+  | { type: "saveCodexApiKey"; key: string }
   | { type: "toast"; text: string };
 
 // ── server → UI (SSE /events) ──


### PR DESCRIPTION
Builds on PR #8. Removes the "coming soon" gate and wires the full Codex login in both the webview UI and the localhost server.

## Flow

`codex login --device-auth` (CLI 0.139) prints:
```
1. Open this link:   https://auth.openai.com/codex/device
2. Enter this code:  IJ7I-WTCF3
```
CLI auto-polls until the user enters the code on the page — **no stdin/paste-back needed**. Process exits 0 on success.

## Changes

| File | What |
|---|---|
| `packages/core/src/account/codexAuth.ts` (new) | `startCodexLogin()` — spawns CLI, parses URL + code, returns `{url, code, cancel, done: Promise<bool>}`. Mirrors `claudeAuth.ts`. |
| `packages/core/src/index.ts` | Export codexAuth. |
| `surfaces/webview/src/transport/protocol.ts` | `startCodexLogin` / `cancelCodexLogin` client msgs; `codexLoginChallenge{url,code}` + `codexLoginStatus` server msgs. |
| `surfaces/webview/src/state/store.tsx` | `codexAuth` phase + login state. `__selectEngine`: codex → `codexAuth` when no-login, `chat` when ok, toast when missing. |
| `surfaces/webview/src/onboarding/ConnectCodex.tsx` (new) | Shows URL + one-time code; "waiting for approval" note. No paste-back. |
| `surfaces/webview/src/onboarding/PickEngine.tsx` | Remove coming-soon gate; Codex card fully activatable. |
| `surfaces/webview/src/App.tsx` | Route `codexAuth` phase. |
| `surfaces/localhost/src/index.ts` | Handle `startCodexLogin` / `cancelCodexLogin`; emit `codexLoginChallenge` + `codexLoginStatus`. |

## CLI surface

`packages/core/src/account/codexAuth.ts` + `surfaces/cli/src/views/Onboarding.tsx` get the same changes on `feat/agentnet-cli` (separate changeset).

## Auth note

ChatGPT sub device-auth is **not a ToS violation** — OpenAI docs confirm it works "across all Codex interfaces." AgentNet shells out to the official `codex` CLI (user's own creds, token stays in `~/.codex/auth.json` device-local). Workspace accounts need admin to enable "Allow device code login"; personal Plus/Pro has no such gate.

`tsc --noEmit` clean on both surfaces.

Refs #7