### PR TITLE
feat(core): integrate the on-chain marketplace layer into packages/core

### DIFF
--- a/packages/core/package.json
+++ b/packages/core/package.json
@@ -11,6 +11,7 @@
   },
   "scripts": {
     "build": "tsup",
+    "test": "vitest run",
     "test:run": "tsx test/test-runtime.ts"
   },
   "peerDependencies": {
@@ -24,11 +25,16 @@
     "tsup": "^8.0.0",
     "tsx": "^4.19.2",
     "tweetnacl": "^1.0.3",
-    "typescript": "^5.6.0"
+    "typescript": "^5.6.0",
+    "vitest": "^4.1.8"
   },
   "dependencies": {
     "@anthropic-ai/claude-agent-sdk": "^0.3.170",
+    "@modelcontextprotocol/sdk": "^1.29.0",
     "@openai/codex-sdk": "^0.139.0",
+    "@solana/spl-token": "^0.4.14",
+    "@solana/spl-token-group": "^0.0.7",
+    "@solana/spl-token-metadata": "^0.1.6",
     "dompurify": "^3.4.9",
     "marked": "^18.0.5"
   }

--- a/packages/core/scripts/bootstrap-collections.ts
+++ b/packages/core/scripts/bootstrap-collections.ts
@@ -1,0 +1,135 @@
+import {
+  Connection,
+  Keypair,
+  PublicKey,
+  Transaction,
+  SystemProgram,
+} from "@solana/web3.js";
+import {
+  ExtensionType,
+  createInitializeMint2Instruction,
+  getMintLen,
+  TOKEN_2022_PROGRAM_ID,
+  createInitializeGroupPointerInstruction,
+} from "@solana/spl-token";
+import {
+  createInitializeGroupInstruction,
+} from "@solana/spl-token-group";
+import { tryMinterPubkey } from "../src/nft/minter.js";
+
+/**
+ * Bootstraps the TokenGroup collections for AgentNet.
+ * Usage:
+ *  export SOLANA_RPC_URL="..."
+ *  export PAYER_SECRET="..." (JSON array format)
+ *  export AGENTNET_MINTER_PUBKEY="..."   (or AGENTNET_MINTER_SECRET)
+ *  npx tsx scripts/bootstrap-collections.ts
+ *
+ * The group UPDATE AUTHORITY is set to the protocol minter — enrollment
+ * (createSkillMint) passes the minter as `groupUpdateAuthority` and the minter
+ * co-signs each member add, so the group's stored update authority MUST match
+ * the minter or every enrollment fails on-chain ("incorrect update authority").
+ */
+async function main() {
+  const rpcUrl = process.env.SOLANA_RPC_URL || "http://127.0.0.1:8899";
+  const conn = new Connection(rpcUrl, "confirmed");
+
+  const secretRaw = process.env.PAYER_SECRET;
+  if (!secretRaw) {
+    throw new Error("Please set PAYER_SECRET as a JSON array");
+  }
+  const payer = Keypair.fromSecretKey(Uint8Array.from(JSON.parse(secretRaw)));
+
+  // The minter must be the group's update authority (it co-signs every member
+  // enrollment). Resolve it the same way createSkillMint does.
+  const minterPk = tryMinterPubkey();
+  if (!minterPk) {
+    throw new Error(
+      "Set AGENTNET_MINTER_PUBKEY (or AGENTNET_MINTER_SECRET) — the group update authority must equal the enrollment minter.",
+    );
+  }
+
+  console.log("Payer:", payer.publicKey.toBase58());
+  console.log("Group update authority (minter):", minterPk.toBase58());
+
+  async function createCollectionMint(maxSize: number): Promise<PublicKey> {
+    const mintKeypair = Keypair.generate();
+    const mint = mintKeypair.publicKey;
+
+    // Phase 1: Pre-init extensions
+    const preInitExtensions = [ExtensionType.GroupPointer];
+    const preInitMintLen = getMintLen(preInitExtensions);
+    const preInitLamports = await conn.getMinimumBalanceForRentExemption(preInitMintLen);
+
+    // Phase 2: Total size including post-init extensions
+    const totalExtensions = [ExtensionType.GroupPointer, ExtensionType.TokenGroup];
+    const totalMintLen = getMintLen(totalExtensions);
+    const totalLamports = await conn.getMinimumBalanceForRentExemption(totalMintLen);
+    const postInitLamports = totalLamports - preInitLamports;
+
+    const tx = new Transaction().add(
+      // 1. Create account with pre-init space
+      SystemProgram.createAccount({
+        fromPubkey: payer.publicKey,
+        newAccountPubkey: mint,
+        lamports: preInitLamports,
+        space: preInitMintLen,
+        programId: TOKEN_2022_PROGRAM_ID,
+      }),
+      // 2. Init GroupPointer (pre-init)
+      createInitializeGroupPointerInstruction(
+        mint,
+        payer.publicKey, // authority
+        mint, // groupAddress = the mint itself
+        TOKEN_2022_PROGRAM_ID
+      ),
+      // 3. Init Mint
+      createInitializeMint2Instruction(
+        mint,
+        0, // decimals
+        payer.publicKey, // mintAuthority
+        payer.publicKey, // freezeAuthority
+        TOKEN_2022_PROGRAM_ID
+      ),
+      // 4. Transfer rent for TokenGroup (post-init)
+      SystemProgram.transfer({
+        fromPubkey: payer.publicKey,
+        toPubkey: mint,
+        lamports: postInitLamports > 0 ? postInitLamports : 0,
+      }),
+      // 5. Init TokenGroup (post-init; reallocates internally)
+      createInitializeGroupInstruction({
+        programId: TOKEN_2022_PROGRAM_ID,
+        group: mint,
+        mint: mint,
+        mintAuthority: payer.publicKey, // payer signs group init (it owns the mint)
+        updateAuthority: minterPk, // MUST equal the enrollment minter (see header)
+        maxSize: BigInt(maxSize),
+      })
+    );
+
+    const { blockhash, lastValidBlockHeight } = await conn.getLatestBlockhash();
+    tx.recentBlockhash = blockhash;
+    tx.feePayer = payer.publicKey;
+    tx.sign(payer, mintKeypair);
+
+    const sig = await conn.sendRawTransaction(tx.serialize());
+    await conn.confirmTransaction({ signature: sig, blockhash, lastValidBlockHeight });
+
+    return mint;
+  }
+
+  console.log("Creating Skills Collection...");
+  const skillsCollection = await createCollectionMint(1000000);
+  console.log("SKILLS_COLLECTION_MINT =", skillsCollection.toBase58());
+
+  console.log("Creating Workflows Collection...");
+  const workflowsCollection = await createCollectionMint(1000000);
+  console.log("WORKFLOWS_COLLECTION_MINT =", workflowsCollection.toBase58());
+
+  console.log("\nAdd these to your environment variables:");
+  console.log(`export AGENTNET_SKILLS_COLLECTION_PUBKEY="${skillsCollection.toBase58()}"`);
+  console.log(`export AGENTNET_WORKFLOWS_COLLECTION_PUBKEY="${workflowsCollection.toBase58()}"`);
+}
+
+main().catch(console.error);

--- a/packages/core/scripts/probe-das-group.ts
+++ b/packages/core/scripts/probe-das-group.ts
@@ -1,0 +1,105 @@
+// Probe: does a DAS RPC enumerate Token-2022 TokenGroup members via
+// getAssetsByGroup(groupKey:"collection")? This is the single unverified fact
+// the umbrella/§4 design rests on (see src/core/skillSource.ts dasSource).
+//
+// Read-only — no SOL spent, runs against mainnet (or any DAS RPC). It does NOT
+// assert anything; it reports exactly what the RPC returns and prints a verdict.
+//
+// Usage:
+//   export DAS_RPC_URL="https://mainnet.helius-rpc.com/?api-key=..."   # must support DAS
+//   export PROBE_COLLECTION="<token-2022 TokenGroup mint>"            # or AGENTNET_SKILLS_COLLECTION_PUBKEY
+//   export PROBE_MEMBER="<a known member mint>"                       # optional but recommended
+//   npx tsx scripts/probe-das-group.ts
+//
+// Interpreting the result:
+//   A. getAssetsByGroup returns the member  -> §4 works as designed. Ship dasSource.
+//   B. it returns nothing, BUT getAsset(member).mint_extensions shows
+//      token_group_member -> DAS indexes the 2022 group extension but NOT under
+//      the "collection" group key. getAssetsByGroup("collection") is the wrong
+//      call; need searchAssets / a different grouping. dasSource needs a rewrite.
+//   C. neither -> this DAS provider doesn't index Token-2022 groups at all.
+//      Keep the index-table CacheLayer; revisit with a different provider.
+
+const rpcUrl = process.env.DAS_RPC_URL;
+const collection = process.env.PROBE_COLLECTION || process.env.AGENTNET_SKILLS_COLLECTION_PUBKEY;
+const member = process.env.PROBE_MEMBER;
+
+async function rpc(method: string, params: unknown): Promise<any> {
+  const res = await fetch(rpcUrl!, {
+    method: "POST",
+    headers: { "Content-Type": "application/json" },
+    body: JSON.stringify({ jsonrpc: "2.0", id: "probe", method, params }),
+  });
+  return res.json();
+}
+
+async function main() {
+  if (!rpcUrl) throw new Error("set DAS_RPC_URL (a DAS-capable RPC, e.g. Helius mainnet)");
+  if (!collection) throw new Error("set PROBE_COLLECTION (the Token-2022 TokenGroup mint)");
+
+  console.log("DAS RPC:", rpcUrl.replace(/api-key=[^&]+/, "api-key=***"));
+  console.log("Collection:", collection);
+  console.log("Member:", member ?? "(none provided)");
+  console.log("");
+
+  // 1. The actual call dasSource makes.
+  console.log("── getAssetsByGroup(groupKey: collection) ──");
+  const byGroup = await rpc("getAssetsByGroup", {
+    groupKey: "collection",
+    groupValue: collection,
+    page: 1,
+    limit: 100,
+  });
+  if (byGroup.error) {
+    console.log("  RPC error:", JSON.stringify(byGroup.error));
+  } else {
+    const items = byGroup.result?.items ?? [];
+    console.log(`  total returned: ${items.length}`);
+    for (const it of items.slice(0, 10)) console.log("   -", it.id);
+  }
+
+  // 2. Inspect one member directly — does DAS even index its group membership?
+  let memberShowsGroup = false;
+  let memberInByGroup = false;
+  if (member) {
+    console.log("\n── getAsset(member) ──");
+    const asset = await rpc("getAsset", { id: member });
+    if (asset.error) {
+      console.log("  RPC error:", JSON.stringify(asset.error));
+    } else {
+      const grouping = asset.result?.grouping ?? [];
+      const ext = asset.result?.mint_extensions ?? asset.result?.token_info?.mint_extensions;
+      console.log("  grouping:", JSON.stringify(grouping));
+      console.log("  mint_extensions:", JSON.stringify(ext)?.slice(0, 400));
+      memberShowsGroup = JSON.stringify(ext ?? {}).includes("group_member")
+        || grouping.some((g: any) => g.group_value === collection);
+      const ids = (byGroup.result?.items ?? []).map((i: any) => i.id);
+      memberInByGroup = ids.includes(member);
+    }
+  }
+
+  // 3. Verdict.
+  console.log("\n══ VERDICT ══");
+  if (memberInByGroup) {
+    console.log("A. getAssetsByGroup returns the member → §4 works. dasSource is correct.");
+  } else if (memberShowsGroup) {
+    console.log(
+      "B. DAS indexes the Token-2022 group on the asset, but getAssetsByGroup(collection)\n" +
+        "   does NOT return it. dasSource's query is wrong — needs searchAssets / different key.",
+    );
+  } else if (member) {
+    console.log(
+      "C. DAS does not surface this Token-2022 group at all. Keep the index-table\n" +
+        "   CacheLayer; this provider can't back dasSource.",
+    );
+  } else {
+    console.log(
+      "Inconclusive — provide PROBE_MEMBER (a known member mint) to distinguish B vs C.",
+    );
+  }
+}
+
+main().catch((e) => {
+  console.error(e);
+  process.exit(1);
+});

--- a/packages/core/src/core/chain.spec.ts
+++ b/packages/core/src/core/chain.spec.ts
@@ -1,0 +1,117 @@
+import { describe, it, expect, vi, beforeEach } from "vitest";
+import { Connection, PublicKey, Keypair } from "@solana/web3.js";
+import { init, ensureDbRoot, createTable, writeRow, codeIn, signerAddress, tableExists, readCodeIn } from "./chain.js";
+import { readCodeIn as sdkReadCodeIn } from "@iqlabs-official/solana-sdk/reader";
+
+// Mock the solana-sdk modules
+vi.mock("@iqlabs-official/solana-sdk/contract", async () => {
+  const { PublicKey } = await import("@solana/web3.js");
+  return {
+    getDbRootPda: vi.fn().mockReturnValue(new PublicKey("11111111111111111111111111111111")),
+    getTablePda: vi.fn().mockReturnValue(new PublicKey("11111111111111111111111111111111")),
+    initializeDbRootInstruction: vi.fn().mockReturnValue(new (require("@solana/web3.js").TransactionInstruction)({ keys: [], programId: new PublicKey("11111111111111111111111111111111"), data: Buffer.alloc(0) })),
+    createInstructionBuilder: vi.fn().mockReturnValue({}),
+  };
+});
+
+vi.mock("@iqlabs-official/solana-sdk/reader", () => ({
+  readTableRows: vi.fn().mockResolvedValue([]),
+  readCodeIn: vi.fn().mockResolvedValue({ data: "mocked code", metadata: "{}" }),
+}));
+
+vi.mock("@iqlabs-official/solana-sdk/utils", () => ({
+  toSeedBytes: vi.fn().mockReturnValue(new Uint8Array([1, 2, 3])),
+}));
+
+vi.mock("@iqlabs-official/solana-sdk/writer", () => ({
+  createTable: vi.fn().mockResolvedValue("mockTxSigCreate"),
+  writeRow: vi.fn().mockResolvedValue("mockTxSigWrite"),
+  codeIn: vi.fn().mockResolvedValue("mockTxSigCodeIn"),
+}));
+
+describe("core/chain", () => {
+  let mockConn: any;
+  let signer: Keypair;
+
+  beforeEach(() => {
+    mockConn = {
+      getAccountInfo: vi.fn().mockResolvedValue(null),
+      getLatestBlockhash: vi.fn().mockResolvedValue({ blockhash: "11111111111111111111111111111111", lastValidBlockHeight: 1 }),
+      sendRawTransaction: vi.fn().mockResolvedValue("mockSig"),
+      confirmTransaction: vi.fn().mockResolvedValue({}),
+    };
+    init(mockConn as any as Connection);
+    signer = Keypair.generate();
+    vi.clearAllMocks();
+  });
+
+  it("should return null if dbRoot already exists", async () => {
+    mockConn.getAccountInfo.mockResolvedValueOnce({ data: new Uint8Array() });
+    const sig = await ensureDbRoot(signer);
+    expect(sig).toBeNull();
+  });
+
+  it("should initialize dbRoot if it does not exist", async () => {
+    const sig = await ensureDbRoot(signer);
+    expect(sig).toBe("mockSig");
+    expect(mockConn.sendRawTransaction).toHaveBeenCalled();
+  });
+
+  it("should call createTable from solana-sdk writer", async () => {
+    const sig = await createTable(signer, "hint", ["col1"], "col1", { writers: [signer.publicKey.toBase58()] });
+    expect(sig).toBe("mockTxSigCreate");
+  });
+
+  it("should call writeRow from solana-sdk writer", async () => {
+    const sig = await writeRow(signer, "hint", '{"foo":"bar"}');
+    expect(sig).toBe("mockTxSigWrite");
+  });
+
+  it("should call codeIn from solana-sdk writer", async () => {
+    const sig = await codeIn(signer, "hello world", "test.md", "text/markdown");
+    expect(sig).toBe("mockTxSigCodeIn");
+  });
+
+  it("should return false if table does not exist", async () => {
+    mockConn.getAccountInfo.mockResolvedValueOnce(null);
+    expect(await tableExists("non-existent")).toBe(false);
+  });
+
+  it("should return true if table exists", async () => {
+    mockConn.getAccountInfo.mockResolvedValueOnce({ data: new Uint8Array() });
+    expect(await tableExists("existing")).toBe(true);
+  });
+
+  it("should get correct signer address", async () => {
+    expect(await signerAddress(signer)).toBe(signer.publicKey.toBase58());
+  });
+
+  describe("readCodeIn — gateway-first", () => {
+    it("returns the gateway's /data result when the gateway responds OK", async () => {
+      vi.stubGlobal("fetch", vi.fn().mockResolvedValue({
+        ok: true,
+        json: async () => ({ data: "from gateway", metadata: "{}" }),
+      }));
+      const r = await readCodeIn("sig123");
+      expect(r).toEqual({ data: "from gateway", metadata: "{}" });
+      expect(sdkReadCodeIn).not.toHaveBeenCalled(); // gateway hit → no RPC
+      vi.unstubAllGlobals();
+    });
+
+    it("falls back to the SDK read when the gateway fails", async () => {
+      vi.stubGlobal("fetch", vi.fn().mockRejectedValue(new Error("network down")));
+      const r = await readCodeIn("sig123");
+      expect(r).toEqual({ data: "mocked code", metadata: "{}" }); // the SDK mock
+      expect(sdkReadCodeIn).toHaveBeenCalledWith("sig123");
+      vi.unstubAllGlobals();
+    });
+
+    it("falls back to the SDK read when the gateway returns non-OK", async () => {
+      vi.stubGlobal("fetch", vi.fn().mockResolvedValue({ ok: false }));
+      const r = await readCodeIn("sig123");
+      expect(r).toEqual({ data: "mocked code", metadata: "{}" });
+      expect(sdkReadCodeIn).toHaveBeenCalled();
+      vi.unstubAllGlobals();
+    });
+  });
+});

--- a/packages/core/src/core/chain.ts
+++ b/packages/core/src/core/chain.ts
@@ -1,0 +1,238 @@
+// Thin wrappers over solana-sdk (iqlabs). PDA derivation stays behind hints,
+// and all chain operations go through these functions so that reads/writes/key
+// logic never duplicates. Every module calls only this file, not solana-sdk directly.
+//
+// The `Connection` is held in module state, wired once by `init()` — no caller
+// above this layer threads a connection anymore.
+
+import {
+  PublicKey,
+  SystemProgram,
+  Transaction,
+  type Connection,
+} from "@solana/web3.js";
+import {
+  getDbRootPda,
+  getTablePda,
+  initializeDbRootInstruction,
+  createInstructionBuilder,
+} from "@iqlabs-official/solana-sdk/contract";
+import {
+  readTableRows,
+  readCodeIn as sdkReadCodeIn,
+} from "@iqlabs-official/solana-sdk/reader";
+import {
+  toSeedBytes,
+  type SignerInput,
+  type WalletSigner,
+} from "@iqlabs-official/solana-sdk/utils";
+import {
+  createTable as sdkCreateTable,
+  writeRow as sdkWriteRow,
+  codeIn as sdkCodeIn,
+} from "@iqlabs-official/solana-sdk/writer";
+import { AGENTNET_ROOT_ID } from "./seed.js";
+import type { Row, ReadOptions, SignerInput as DomainSignerInput } from "./types.js";
+
+/** DbRoot PDA for the `agentnet-root` namespace — derived once, reused everywhere. */
+const DB_ROOT_SEED = toSeedBytes(AGENTNET_ROOT_ID);
+const DB_ROOT = getDbRootPda(DB_ROOT_SEED);
+
+let connection: Connection | null = null;
+
+function conn(): Connection {
+  if (!connection) {
+    throw new Error("chain layer not initialized — call init({ connection })");
+  }
+  return connection;
+}
+
+function asSolana(signer: DomainSignerInput): SignerInput {
+  return signer as SignerInput;
+}
+
+async function signTx(signer: SignerInput, tx: Transaction): Promise<Transaction> {
+  const Keypair = (await import("@solana/web3.js")).Keypair;
+  if (signer instanceof Keypair || "secretKey" in signer) {
+    tx.partialSign(signer as any);
+    return tx;
+  }
+  return (signer as WalletSigner).signTransaction(tx);
+}
+
+function tablePda(hint: string): PublicKey {
+  return getTablePda(DB_ROOT, toSeedBytes(hint));
+}
+
+async function accountExists(pda: PublicKey): Promise<boolean> {
+  return (await conn().getAccountInfo(pda)) !== null;
+}
+
+// ===== Public interface =====
+
+export function init(rpcConnection: Connection): void {
+  connection = rpcConnection;
+}
+
+export async function ensureDbRoot(signer: DomainSignerInput): Promise<string | null> {
+  if (await accountExists(DB_ROOT)) return null;
+
+  const s = asSolana(signer);
+  const builder = createInstructionBuilder();
+  const ix = initializeDbRootInstruction(
+    builder,
+    {
+      db_root: DB_ROOT,
+      signer: s.publicKey,
+      system_program: SystemProgram.programId,
+    },
+    { db_root_id: DB_ROOT_SEED },
+  );
+
+  const tx = new Transaction().add(ix);
+  const c = conn();
+  const { blockhash, lastValidBlockHeight } = await c.getLatestBlockhash();
+  tx.recentBlockhash = blockhash;
+  tx.feePayer = s.publicKey;
+  const signed = await signTx(s, tx);
+  const signature = await c.sendRawTransaction(signed.serialize());
+  await c.confirmTransaction({ signature, blockhash, lastValidBlockHeight });
+  return signature;
+}
+
+/**
+ * Token/collection gate enforced on writes by the IQ contract. `gateType`
+ * defaults to a Token gate (hold ≥ `amount` of `mint`); use the SDK's
+ * GateType.Collection value for NFT-collection membership.
+ */
+export interface TableGate {
+  mint: string; // token mint / collection the writer must hold
+  amount?: number; // min amount (default 1)
+  gateType?: number; // GateType.Token (0) | GateType.Collection (1)
+}
+
+interface TableOptions {
+  writers?: string[];
+  gate?: TableGate;
+}
+
+export async function createTable(
+  signer: DomainSignerInput,
+  hint: string,
+  columns: string[],
+  idColumn: string,
+  options?: TableOptions,
+): Promise<string | null> {
+  const s = asSolana(signer);
+  const writers = options?.writers?.map((w) => new PublicKey(w));
+  const gate = options?.gate
+    ? {
+        mint: new PublicKey(options.gate.mint),
+        amount: options.gate.amount ?? 1,
+        gateType: options.gate.gateType,
+      }
+    : undefined;
+
+  return sdkCreateTable(
+    conn(),
+    s,
+    AGENTNET_ROOT_ID,
+    hint,
+    hint,
+    columns,
+    idColumn,
+    [],
+    gate as any,
+    writers,
+    hint,
+  );
+}
+
+/**
+ * Create the table for `hint` if it doesn't exist yet. No-op if already created.
+ *
+ * `writeRow` requires the table PDA to be initialized first (createTable is a
+ * separate on-chain instruction), so every writer must ensure its table exists
+ * before the first row — same lazy pattern as `ensureDbRoot`.
+ *
+ * Pass `options.gate` to have the IQ contract enforce token/collection holding
+ * on every write (set at creation; the gate is fixed for the table's life).
+ */
+export async function ensureTable(
+  signer: DomainSignerInput,
+  hint: string,
+  columns: string[],
+  idColumn: string,
+  options?: TableOptions,
+): Promise<string | null> {
+  if (await accountExists(tablePda(hint))) return null;
+  return createTable(signer, hint, columns, idColumn, options);
+}
+
+export async function writeRow(
+  signer: DomainSignerInput,
+  hint: string,
+  rowJson: string,
+): Promise<string> {
+  return sdkWriteRow(conn(), asSolana(signer), AGENTNET_ROOT_ID, hint, rowJson);
+}
+
+export async function readRows(hint: string, options?: ReadOptions): Promise<Row[]> {
+  const pda = tablePda(hint);
+  return readTableRows(pda, options);
+}
+
+export async function readRowsByPda(pda: PublicKey, options?: ReadOptions): Promise<Row[]> {
+  return readTableRows(pda, options);
+}
+
+export async function codeIn(
+  signer: DomainSignerInput,
+  data: string | string[],
+  filename: string,
+  filetype: string,
+  onProgress?: (percent: number) => void,
+): Promise<string> {
+  return sdkCodeIn(
+    { connection: conn(), signer: asSolana(signer) },
+    data,
+    filename,
+    0,
+    filetype,
+    onProgress,
+  );
+}
+
+// Gateway base for code-in reads. The gateway caches inscriptions (L1/L2/L3), so
+// `GET /data/{sig}` is far cheaper than an RPC scan. Default to the public
+// gateway; override with AGENTNET_GATEWAY_URL. Pattern mirrors iq-wide-web's
+// readCodeInGW.
+const GATEWAY_URL = process.env.AGENTNET_GATEWAY_URL || "https://gateway.iqlabs.dev";
+
+// Read a code-in inscription by its tx signature. Tries the gateway's cached
+// `/data/{sig}` first; on any failure (network, non-OK, parse), falls back to
+// the SDK's direct RPC read — so it always resolves the same shape.
+export async function readCodeIn(txSig: string): Promise<{ data: string | null; metadata: string }> {
+  try {
+    const res = await fetch(`${GATEWAY_URL}/data/${txSig}`);
+    if (res.ok) {
+      const json = (await res.json()) as { data?: string | null; metadata?: string };
+      return { data: json.data ?? null, metadata: json.metadata ?? "" };
+    }
+  } catch {
+    // fall through to the SDK read
+  }
+  return sdkReadCodeIn(txSig);
+}
+
+export async function tableExists(hint: string): Promise<boolean> {
+  return accountExists(tablePda(hint));
+}
+
+export function getTablePdaRef(hint: string): PublicKey {
+  return tablePda(hint);
+}
+
+export async function signerAddress(signer: DomainSignerInput): Promise<string> {
+  return asSolana(signer).publicKey.toBase58();
+}

--- a/packages/core/src/core/dasSource.spec.ts
+++ b/packages/core/src/core/dasSource.spec.ts
@@ -1,0 +1,97 @@
+import { describe, it, expect, vi, beforeEach, afterEach } from "vitest";
+import { dasSource } from "./skillSource.js";
+
+const RPC = "DAS_RPC_URL";
+const SOL = "SOLANA_RPC_URL";
+const SKILLS = "AGENTNET_SKILLS_COLLECTION_PUBKEY";
+const WORKFLOWS = "AGENTNET_WORKFLOWS_COLLECTION_PUBKEY";
+
+function clearEnv() {
+  for (const k of [RPC, SOL, SKILLS, WORKFLOWS]) delete process.env[k];
+}
+
+describe("core/dasSource", () => {
+  beforeEach(clearEnv);
+  afterEach(() => {
+    clearEnv();
+    vi.unstubAllGlobals();
+  });
+
+  it("throws (not silent fallback) when no RPC is configured", async () => {
+    process.env[SKILLS] = "SkiLLCoLLecTion1111111111111111111111111111";
+    await expect(dasSource.listSkills()).rejects.toThrow(/no DAS_RPC_URL/);
+  });
+
+  // (No "no collection mint" test: seed.ts ships default devnet collection ids,
+  // so a collection is always configured unless explicitly overridden.)
+
+  it("builds a getAssetsByGroup(collection) request and parses items into Skill[]", async () => {
+    process.env[RPC] = "https://das.example";
+    process.env[SKILLS] = "SkiLLCoLLecTion1111111111111111111111111111";
+
+    // The skills collection returns one item; the workflows collection (a default)
+    // returns none — so only the skill item is parsed.
+    const fetchMock = vi.fn().mockImplementation(async (_url, opts: any) => {
+      const body = JSON.parse(opts.body);
+      const isSkills = body.params.groupValue === process.env[SKILLS];
+      return {
+        json: async () => ({
+          result: {
+            items: isSkills
+              ? [
+                  {
+                    id: "mintA",
+                    content: { metadata: { name: "alpha", description: "d" }, json_uri: "txid1" },
+                    authorities: [{ address: "creatorA" }],
+                  },
+                ]
+              : [],
+          },
+        }),
+      };
+    });
+    vi.stubGlobal("fetch", fetchMock);
+
+    const skills = await dasSource.listSkills();
+
+    // request shape (first call = skills collection)
+    const body = JSON.parse(fetchMock.mock.calls[0][1].body);
+    expect(body.method).toBe("getAssetsByGroup");
+    expect(body.params.groupKey).toBe("collection");
+    expect(body.params.groupValue).toBe(process.env[SKILLS]);
+
+    // parse shape
+    expect(skills).toEqual([
+      expect.objectContaining({
+        id: "mintA",
+        type: "skill",
+        name: "alpha",
+        description: "d",
+        creator: "creatorA", // from authorities[0] (no Metaplex creators on Token-2022)
+        uriTxid: "txid1",
+        supply: 0,
+      }),
+    ]);
+  });
+
+  it("surfaces an RPC error instead of masking it with the table", async () => {
+    process.env[RPC] = "https://das.example";
+    process.env[SKILLS] = "SkiLLCoLLecTion1111111111111111111111111111";
+    vi.stubGlobal(
+      "fetch",
+      vi.fn().mockResolvedValue({
+        json: async () => ({ error: { code: -32601, message: "method not found" } }),
+      }),
+    );
+
+    await expect(dasSource.listSkills()).rejects.toThrow(/getAssetsByGroup failed/);
+  });
+
+  it("returns an empty list visibly (not a table fallback) when DAS has no members", async () => {
+    process.env[RPC] = "https://das.example";
+    process.env[SKILLS] = "SkiLLCoLLecTion1111111111111111111111111111";
+    vi.stubGlobal("fetch", vi.fn().mockResolvedValue({ json: async () => ({ result: { items: [] } }) }));
+
+    await expect(dasSource.listSkills()).resolves.toEqual([]);
+  });
+});

--- a/packages/core/src/core/seed.spec.ts
+++ b/packages/core/src/core/seed.spec.ts
@@ -1,0 +1,29 @@
+import { describe, it, expect } from "vitest";
+import {
+  AGENTNET_ROOT_ID,
+  mysessionsHint,
+  reviewsHint,
+  reviewsAgentHint,
+} from "./seed.js";
+
+describe("core/seed", () => {
+  it("should have correct static constants", () => {
+    expect(AGENTNET_ROOT_ID).toBe("agentnet-root");
+  });
+
+  it("should format mysessionsHint correctly", () => {
+    expect(mysessionsHint("11111111111111111111111111111111")).toBe(
+      "mysessions:11111111111111111111111111111111"
+    );
+  });
+
+  it("should format reviewsHint correctly (collection then item)", () => {
+    expect(reviewsHint("SkillsCollection", "SkillMint123")).toBe(
+      "reviews:SkillsCollection:SkillMint123"
+    );
+  });
+
+  it("should format reviewsAgentHint correctly", () => {
+    expect(reviewsAgentHint("AgentWallet123")).toBe("reviews:agent:AgentWallet123");
+  });
+});

--- a/packages/core/src/core/seed.ts
+++ b/packages/core/src/core/seed.ts
@@ -1,0 +1,106 @@
+// The single source of truth for table_hint strings.
+//
+// Readers re-derive PDAs with `iqlabs.utils.toSeedBytes(hint)` →
+// `iqlabs.contract.getTablePda(...)`; writers pass the same hint into
+// `iqlabs.writer.createTable`. Keeping the naming convention in one place
+// prevents silent drift between writer and reader.
+
+/** DbRoot id for every agentnet table. Bootstrap and every caller share this. */
+export const AGENTNET_ROOT_ID = "agentnet-root";
+
+/**
+ * Hint for the per-wallet session list.
+ * input:  wallet address (base58)
+ * output: "mysessions:<wallet>"
+ */
+export function mysessionsHint(wallet: string): string {
+  return `mysessions:${wallet}`;
+}
+
+/**
+ * Hint for reviews on an item NFT inside a collection.
+ *
+ * The collection is the umbrella (skills / workflows / future kinds); the NFT
+ * mint is the individual item under it. Keying by collection THEN item keeps
+ * reviews partitioned per umbrella, so a new collection kind extends the same
+ * structure without a new table shape.
+ *
+ * input:  collection mint (base58), item NFT mint (base58)
+ * output: "reviews:<collectionId>:<nft>"
+ */
+export function reviewsHint(collectionId: string, nft: string): string {
+  return `reviews:${collectionId}:${nft}`;
+}
+
+/**
+ * Hint for reviews (comments + self-posts) on an agent wallet.
+ * input:  agent wallet address (base58)
+ * output: "reviews:agent:<agentWallet>"
+ */
+export function reviewsAgentHint(agentWallet: string): string {
+  return `reviews:agent:${agentWallet}`;
+}
+
+// ===== On-chain program / collection ids (one place — easy to swap) =====
+//
+// Current values are the DEVNET test deployment. Override any of them with the
+// matching env var when you point at a different network / collection. To move
+// to mainnet, change these three (and the program's constants.rs collection).
+
+/** Devnet test ids — the single source. Swap here (or via env) to retarget. */
+export const SKILLS_COLLECTION_MINT = "4exdqNEcXixiMzenEBts2cE7qLmMvcVtHCjsZUGBm4Gt";
+export const WORKFLOWS_COLLECTION_MINT = "ByrnPfd9DcbpuVxm7J7xo2gnWxNfuTAdvZUPds7ctYN4";
+/** agent-workflow-nft gate program — publish_workflow / buy_workflow. */
+export const WORKFLOW_GATE_PROGRAM_ID = "3ptXj4yuaQG51WTA3SZZ37jGvYFgMhgXnSKWJLASJNkt";
+
+/**
+ * The TokenGroup mint skills are enrolled into. Env override wins; otherwise the
+ * configured devnet test collection.
+ */
+export function getSkillsCollectionMint(): string | null {
+  return process.env.AGENTNET_SKILLS_COLLECTION_PUBKEY || SKILLS_COLLECTION_MINT;
+}
+
+/**
+ * The TokenGroup mint workflows are enrolled into. Env override wins; otherwise
+ * the configured devnet test collection.
+ */
+export function getWorkflowsCollectionMint(): string | null {
+  return process.env.AGENTNET_WORKFLOWS_COLLECTION_PUBKEY || WORKFLOWS_COLLECTION_MINT;
+}
+
+/** The workflow gate program id (env override wins). */
+export function getWorkflowGateProgramId(): string {
+  return process.env.AGENTNET_WORKFLOW_GATE_PROGRAM_ID || WORKFLOW_GATE_PROGRAM_ID;
+}
+
+/**
+ * The umbrella collection mint for an item type — the ONE place that maps
+ * "skill" / "workflow" → its collection. There are only these two collections;
+ * every item of a given type shares the same collection (a skill is one big
+ * collection, a workflow another). New kinds get a branch here, nowhere else.
+ *
+ * Returns "" when the collection isn't configured yet — reviewsHint still
+ * produces a stable key, so reads/writes work before bootstrap.
+ */
+export function collectionFor(type: "skill" | "workflow" | undefined): string {
+  return (type === "workflow" ? getWorkflowsCollectionMint() : getSkillsCollectionMint()) ?? "";
+}
+
+// ===== Table column declarations =====
+//
+// The SDK's writeRow validates every row key against the table's declared
+// columns (`unknown key: <k>` otherwise), so these MUST be the full superset of
+// every key any writer puts in a review row.
+
+// Trimmed per notes.md: `subject` is the table key (not stored) and
+// `isSelfNote` is derived (author == subject) at read time. `meta` is one
+// optional column holding a JSON blob for future/experimental fields.
+export const REVIEW_COLUMNS = [
+  "id",
+  "author",
+  "text",
+  "gitLink",
+  "timestamp",
+  "meta",
+];

--- a/packages/core/src/core/skillSource.spec.ts
+++ b/packages/core/src/core/skillSource.spec.ts
@@ -1,0 +1,65 @@
+import { describe, it, expect, vi, beforeEach, afterEach } from "vitest";
+import { dasSource } from "./skillSource.js";
+
+// dasSource enumerates the TokenGroup collections via a DAS RPC. We mock fetch
+// and the collection-mint config (env) to drive it without a real RPC.
+describe("core/skillSource — dasSource", () => {
+  const origEnv = { ...process.env };
+
+  beforeEach(() => {
+    vi.restoreAllMocks();
+    process.env.DAS_RPC_URL = "https://das.example/rpc";
+    process.env.AGENTNET_SKILLS_COLLECTION_PUBKEY = "SkillsCollection";
+    delete process.env.AGENTNET_WORKFLOWS_COLLECTION_PUBKEY;
+  });
+
+  afterEach(() => {
+    process.env = { ...origEnv };
+  });
+
+  it("maps DAS items to Skill rows (id from item.id)", async () => {
+    // The skills collection returns these items; the workflows collection (now a
+    // default) returns none — so we only see the skill items.
+    vi.stubGlobal(
+      "fetch",
+      vi.fn().mockImplementation(async (_url, opts: any) => {
+        const body = JSON.parse(opts.body);
+        const isSkills = body.params.groupValue === "SkillsCollection";
+        return {
+          json: async () => ({
+            result: {
+              items: isSkills
+                ? [
+                    { id: "skill1", content: { metadata: { name: "A" } }, authorities: [{ address: "w1" }] },
+                    { id: "skill2", content: { metadata: {} } },
+                  ]
+                : [],
+            },
+          }),
+        };
+      }),
+    );
+
+    const skills = await dasSource.listSkills();
+    expect(skills.map((s) => s.id)).toEqual(["skill1", "skill2"]);
+    expect(skills[0].type).toBe("skill");
+    expect(skills[0].creator).toBe("w1");
+  });
+
+  it("throws on a DAS error instead of hiding it", async () => {
+    vi.stubGlobal(
+      "fetch",
+      vi.fn().mockResolvedValue({ json: async () => ({ error: { code: -1, message: "nope" } }) }),
+    );
+    await expect(dasSource.listSkills()).rejects.toThrow(/DAS getAssetsByGroup failed/);
+  });
+
+  it("throws when no RPC is configured", async () => {
+    delete process.env.DAS_RPC_URL;
+    delete process.env.SOLANA_RPC_URL;
+    await expect(dasSource.listSkills()).rejects.toThrow(/no DAS_RPC_URL/);
+  });
+
+  // (No "no collection mints" test: seed.ts now ships default devnet collection
+  // ids, so a collection is always configured unless explicitly overridden.)
+});

--- a/packages/core/src/core/skillSource.ts
+++ b/packages/core/src/core/skillSource.ts
@@ -1,0 +1,94 @@
+// SkillSource — the enumeration seam for "which skills/workflows exist".
+//
+// skill-nft-structure.md §2 is emphatic: "No skills registry table. The NFT
+// collection IS the skill list." The canonical truth is each mint's on-chain
+// TokenMetadata (uri + category/hashtags traits) + its `supply`, enumerated by
+// scanning the TokenGroup umbrella collection via DAS.
+//
+// There is no `skills:index` cache table anymore — the collection scan is the
+// only source. Until a DAS provider proves it indexes the Token-2022 group
+// extension under `getAssetsByGroup` (see the probe + the warning on dasSource),
+// this returns whatever DAS gives (an empty list when collections are unminted
+// is a real, visible answer — not a hidden failure). The seam stays so a
+// gateway enumerator can replace it later without changing search/reviews.
+
+import type { Skill } from "./types.js";
+
+export interface SkillSource {
+  /** Enumerate all known skills/workflows (id set + cached metadata snapshot). */
+  listSkills(limit?: number): Promise<Skill[]>;
+}
+
+/**
+ * DAS (Digital Asset Standard) source — enumerates the TokenGroup umbrella
+ * collections via a DAS RPC's `getAssetsByGroup`. This is the §2 "collection IS
+ * the skill list" reader — the single source of truth for enumeration.
+ *
+ * ⚠️ UNVERIFIED ASSUMPTION: DAS `groupKey:"collection"` is sourced from a
+ * Metaplex Token-Metadata `collection`, NOT the Token-2022 `TokenGroup`
+ * extension our mints use. Whether a given DAS provider surfaces Token-2022
+ * group membership under that key is unconfirmed — it may return nothing. It
+ * does NOT hide that: it throws on misconfig, surfaces RPC errors, and returns
+ * exactly what DAS gives. Settle the assumption with a devnet probe.
+ */
+export const dasSource: SkillSource = {
+  async listSkills(limit = 1000): Promise<Skill[]> {
+    const rpcUrl = process.env.DAS_RPC_URL || process.env.SOLANA_RPC_URL;
+    const { getSkillsCollectionMint, getWorkflowsCollectionMint } = await import("./seed.js");
+    const skillsCollection = getSkillsCollectionMint();
+    const workflowsCollection = getWorkflowsCollectionMint();
+
+    if (!rpcUrl) {
+      throw new Error("dasSource: no DAS_RPC_URL / SOLANA_RPC_URL configured");
+    }
+    if (!skillsCollection && !workflowsCollection) {
+      throw new Error(
+        "dasSource: no collection mints configured (AGENTNET_SKILLS_COLLECTION_PUBKEY / _WORKFLOWS_)",
+      );
+    }
+
+    const skills: Skill[] = [];
+
+    async function fetchGroup(group: string, type: "skill" | "workflow") {
+      const response = await fetch(rpcUrl!, {
+        method: "POST",
+        headers: { "Content-Type": "application/json" },
+        body: JSON.stringify({
+          jsonrpc: "2.0",
+          id: "1",
+          method: "getAssetsByGroup",
+          params: { groupKey: "collection", groupValue: group, page: 1, limit },
+        }),
+      });
+
+      const json = await response.json();
+      if (json.error) {
+        throw new Error(`DAS getAssetsByGroup failed for ${group}: ${JSON.stringify(json.error)}`);
+      }
+      for (const item of json.result?.items ?? []) {
+        // DAS gives item.id (mint) + light content. Drift-prone fields (supply,
+        // traits) are re-read from the mint by search.ts; we fill the id set.
+        skills.push({
+          id: item.id,
+          type,
+          name: item.content?.metadata?.name || "Unknown",
+          description: item.content?.metadata?.description || "",
+          // Token-2022 has no Metaplex `creators`; fall back to the asset
+          // authority (= update authority). May be empty — caller tolerates.
+          creator: item.authorities?.[0]?.address || "",
+          category: "", // hydrated by search verifyTraits if needed
+          hashtags: [], // hydrated by search verifyTraits if needed
+          price: "0",
+          supply: 0, // hydrated by getMintSupply
+          uriTxid: item.content?.json_uri || "",
+          createdAt: 0,
+        });
+      }
+    }
+
+    if (skillsCollection) await fetchGroup(skillsCollection, "skill");
+    if (workflowsCollection) await fetchGroup(workflowsCollection, "workflow");
+
+    return skills.slice(0, limit);
+  },
+};

--- a/packages/core/src/core/types.ts
+++ b/packages/core/src/core/types.ts
@@ -1,0 +1,85 @@
+// Domain types shared across every module.
+//
+// We do NOT re-declare a signer type. `SignerInput` from iqlabs-sdk already
+// covers Node `Keypair`, web3.js `Signer`, and browser `WalletSigner`, so we
+// just re-export it.
+
+export type { SignerInput } from "@iqlabs-official/solana-sdk/utils";
+
+/** Session metadata row stored in `mysessions/[wallet]`. */
+export interface Session {
+  sessionId: string;
+  modelType: "claude" | "codex";
+  createdAt: number;
+  updatedAt: number;
+  title?: string;
+}
+
+/** Skill NFT metadata. */
+export interface Skill {
+  id: string; // NFT mint address
+  type?: "skill" | "workflow"; // distinguishes between skills and workflows in search
+  name: string;
+  description: string;
+  creator: string; // wallet address
+  category: string;
+  hashtags?: string[];
+  price?: string; // lamports as decimal string (bigint isn't JSON-serializable)
+  supply: number; // mint supply = popularity
+  uriTxid: string; // codeIn txid holding the skill text
+  createdAt: number;
+}
+
+/** Workflow NFT metadata — a skill bundle with gates. */
+export interface Workflow {
+  id: string; // NFT mint address
+  type?: "skill" | "workflow";
+  name: string;
+  description: string;
+  creator: string;
+  requiredSkills: string[]; // skill mint addresses required to unlock
+  createdAt: number;
+}
+
+/**
+ * Note (comment) on `notes/[skillNFT]` or `notes/[agentWallet]`.
+ *
+ * STORED columns: id · author · text · gitLink? · timestamp · meta?. The
+ * `subject` (= the table key) and `isSelfNote` (= author == subject) are NOT
+ * stored — they're derived at read time (notes.md §3 "no flag, derive from
+ * author"), so they're optional here and only present on read results.
+ */
+export interface Note {
+  id: string; // unique id (author + timestamp + nonce)
+  author: string; // wallet address
+  text: string;
+  gitLink?: string; // optional github/on-chain-git link (URL tells on/off-chain)
+  timestamp: number;
+  meta?: Record<string, unknown>; // optional free-form extras (one column, JSON)
+  subject?: string; // derived on read: the table key (skill mint / agent wallet)
+  isSelfNote?: boolean; // derived on read: author == subject (owner post)
+}
+
+/**
+ * Agent reputation snapshot stored in `reputation:<wallet>` table.
+ *
+ * NOT a computed score (notes.md: "Not a rating/score"). Standing = `totalSupply`
+ * — "famous agent = sum of supply across the skills that agent created"
+ * (skill-nft-structure.md). `notesReceived` is informational only.
+ */
+export interface Reputation {
+  wallet: string;
+  skillsPublished: number;
+  totalSupply: number; // sum of on-chain supply across agent's skills = fame
+  notesReceived: number; // informational count, never a score
+  updatedAt: number;
+}
+
+/** Generic row type for table reads. */
+export type Row = Record<string, unknown>;
+
+/** Read options for table queries. */
+export interface ReadOptions {
+  limit?: number;
+  before?: string;
+}

--- a/packages/core/src/index.ts
+++ b/packages/core/src/index.ts
@@ -12,6 +12,50 @@ export type {
   StorageAdapter,
 } from "./runtime/contract.js";
 
+// ─── On-chain marketplace layer (from Step-0 core PR: nft/search/notes/etc.) ──
+// chain + seed + domain types
+export type { SignerInput, Session, Skill, Workflow, Note, Row, ReadOptions } from "./core/types.js";
+export {
+  init as initChain,
+  ensureDbRoot,
+  createTable,
+  writeRow,
+  readRows,
+  readRowsByPda,
+  codeIn,
+  readCodeIn,
+  tableExists,
+  getTablePdaRef,
+  signerAddress,
+} from "./core/chain.js";
+export { AGENTNET_ROOT_ID, mysessionsHint, reviewsHint, reviewsAgentHint } from "./core/seed.js";
+// skill / workflow NFTs (Token-2022 + code-in)
+export {
+  publishSkill,
+  buySkill,
+  createSkillMint,
+  mintSkillToken,
+  getMintSupply,
+  readSkillMintMetadata,
+  readSkillText,
+} from "./nft/index.js";
+export type { PublishSkillInput, BuySkillInput } from "./nft/skill.js";
+export type { SkillMintMetadata } from "./nft/token2022.js";
+export { resolveMinter, tryMinterPubkey, resetMinterCache } from "./nft/minter.js";
+// notes (reviews)
+export { postNote, readNotes, deleteNote, postAgentNote, readAgentNotes, getBalance } from "./notes/index.js";
+export type { PostNoteInput, ReadNotesOptions, PostAgentNoteInput } from "./notes/index.js";
+// search + the enumeration seam
+export { searchSkills } from "./search/index.js";
+export type { SearchFilters, SortBy, SearchOptions } from "./search/index.js";
+export { dasSource } from "./core/skillSource.js";
+export type { SkillSource } from "./core/skillSource.js";
+// reputation (derived live from supply + reviews)
+export { getReputation, getLeaderboard } from "./reputation/index.js";
+export type { Reputation } from "./core/types.js";
+// skill-market MCP surface (autonomous buy)
+export { createAgentMcpServer, getAgentNetTools, handleToolCall } from "./skill-market/index.js";
+
 export { createRuntime } from "./runtime/index.js";
 export { detectCli } from "./runtime/detect.js";
 export type { CliStatus, CliReport } from "./runtime/detect.js";

--- a/packages/core/src/nft/checkFormat.spec.ts
+++ b/packages/core/src/nft/checkFormat.spec.ts
@@ -1,0 +1,94 @@
+import { describe, it, expect } from "vitest";
+import { checkFormat, checkWorkflowFormat, FormatError } from "./checkFormat.js";
+
+const VALID = `---
+name: my-skill
+description: A useful skill that teaches agents to reason step by step clearly
+category: ai
+hashtags: [reasoning, planning]
+---
+
+This skill teaches step-by-step reasoning for AI agents over many lines of text.
+`;
+
+describe("nft/checkFormat — checkFormat", () => {
+  it("passes a valid skill", () => {
+    const r = checkFormat(VALID);
+    expect(r.ok).toBe(true);
+    expect(r.errors).toHaveLength(0);
+  });
+
+  it("errors when name/description are missing (no frontmatter)", () => {
+    const r = checkFormat("just text, no frontmatter");
+    expect(r.ok).toBe(false);
+    expect(r.errors.some((e) => e.field === "name")).toBe(true);
+    expect(r.errors.some((e) => e.field === "description")).toBe(true);
+  });
+
+  it("errors on a non-kebab-case name", () => {
+    const r = checkFormat(VALID.replace("name: my-skill", "name: MySkill"));
+    expect(r.errors.some((e) => e.field === "name")).toBe(true);
+  });
+
+  it("errors on a too-short description", () => {
+    const r = checkFormat(VALID.replace(/description: .*/, "description: short"));
+    expect(r.errors.some((e) => e.field === "description")).toBe(true);
+  });
+
+  it("does NOT error on a long skill (codeIn auto-chunks; no size rule)", () => {
+    const r = checkFormat(VALID + "x".repeat(5000));
+    expect(r.errors.some((e) => e.field === "size")).toBe(false);
+    expect(r.ok).toBe(true);
+  });
+
+  it("warns when category is missing", () => {
+    const r = checkFormat(VALID.replace("category: ai\n", ""));
+    expect(r.warnings.some((w) => w.field === "category")).toBe(true);
+  });
+
+  it("warns on bad hashtags (uppercase / spaces)", () => {
+    const r = checkFormat(VALID.replace("hashtags: [reasoning, planning]", "hashtags: [Reasoning, has space]"));
+    expect(r.warnings.some((w) => w.field === "hashtags")).toBe(true);
+  });
+});
+
+describe("nft/checkFormat — checkWorkflowFormat", () => {
+  const VALID_WF = `---
+name: my-workflow
+description: A workflow that chains a few skills into one repeatable job flow
+category: ai
+type: workflow
+requiredSkills: [So11111111111111111111111111111111111111112]
+---
+
+Run skill A, then B, then C to complete the job end to end here.
+`;
+
+  it("passes a valid workflow", () => {
+    const r = checkWorkflowFormat(VALID_WF);
+    expect(r.ok).toBe(true);
+  });
+
+  it("errors when type is not workflow", () => {
+    const r = checkWorkflowFormat(VALID_WF.replace("type: workflow", "type: skill"));
+    expect(r.errors.some((e) => e.field === "type")).toBe(true);
+  });
+
+  it("errors when requiredSkills is empty", () => {
+    const r = checkWorkflowFormat(VALID_WF.replace(/requiredSkills: .*/, "requiredSkills: []"));
+    expect(r.errors.some((e) => e.field === "requiredSkills")).toBe(true);
+  });
+
+  it("errors on invalid base58 in requiredSkills", () => {
+    const r = checkWorkflowFormat(VALID_WF.replace(/requiredSkills: .*/, "requiredSkills: [not-a-mint]"));
+    expect(r.errors.some((e) => e.field === "requiredSkills")).toBe(true);
+  });
+});
+
+describe("nft/checkFormat — FormatError", () => {
+  it("carries the issues and a readable message", () => {
+    const err = new FormatError([{ field: "name", severity: "error", message: "missing" }]);
+    expect(err.issues).toHaveLength(1);
+    expect(err.message).toContain("[name]");
+  });
+});

--- a/packages/core/src/nft/checkFormat.ts
+++ b/packages/core/src/nft/checkFormat.ts
@@ -1,0 +1,190 @@
+// Skill / workflow format check — ONE function, no pluggable adapters.
+//
+// publishSkill / publishWorkflow call checkFormat() / checkWorkflowFormat() before
+// touching the chain. There is no swappable validator: the rules below ARE the
+// format. (Frontmatter is parsed with plain string splitting — no eval / YAML lib —
+// to avoid RCE from untrusted skill content. CWE-78 / CWE-150.)
+
+export type Severity = "error" | "warning" | "info";
+
+export interface Issue {
+  field: string;
+  severity: Severity;
+  message: string;
+}
+
+export interface FormatResult {
+  ok: boolean; // false when errors.length > 0
+  errors: Issue[];
+  warnings: Issue[];
+  infos: Issue[];
+}
+
+/** Thrown by publishSkill / publishWorkflow when the format check fails. */
+export class FormatError extends Error {
+  constructor(public readonly issues: Issue[]) {
+    super(`Skill format check failed: ${issues.map((i) => `[${i.field}] ${i.message}`).join("; ")}`);
+    this.name = "FormatError";
+  }
+}
+
+function emptyResult(): FormatResult {
+  return { ok: true, errors: [], warnings: [], infos: [] };
+}
+
+function add(result: FormatResult, field: string, severity: Severity, message: string): void {
+  if (severity === "error") {
+    result.errors.push({ field, severity, message });
+    result.ok = false;
+  } else if (severity === "warning") {
+    result.warnings.push({ field, severity, message });
+  } else {
+    result.infos.push({ field, severity, message });
+  }
+}
+
+// ── frontmatter parser (basic string splitting, no eval) ────────────────────────
+
+interface Frontmatter {
+  name?: string;
+  description?: string;
+  type?: string;
+  requiredSkills?: string[];
+  license?: string;
+  repository?: string;
+  category?: string;
+  hashtags?: string[];
+  [key: string]: unknown;
+}
+
+function parse(skillMd: string): { frontmatter: Frontmatter; body: string } {
+  const lines = skillMd.split("\n");
+  if (!lines[0]?.trim().startsWith("---")) return { frontmatter: {}, body: skillMd };
+
+  let closeIdx = -1;
+  for (let i = 1; i < lines.length; i++) {
+    if (lines[i].trim() === "---") { closeIdx = i; break; }
+  }
+  if (closeIdx === -1) return { frontmatter: {}, body: skillMd };
+
+  const frontmatter: Frontmatter = {};
+  for (const line of lines.slice(1, closeIdx)) {
+    const colon = line.indexOf(":");
+    if (colon === -1) continue;
+    const key = line.slice(0, colon).trim();
+    const raw = line.slice(colon + 1).trim();
+    if (!key) continue;
+    if (raw.startsWith("[") && raw.endsWith("]")) {
+      frontmatter[key] = raw.slice(1, -1).split(",").map((s) => s.trim().replace(/^['"]|['"]$/g, "")).filter(Boolean);
+    } else {
+      frontmatter[key] = raw.replace(/^['"]|['"]$/g, "");
+    }
+  }
+  return { frontmatter, body: lines.slice(closeIdx + 1).join("\n").trimStart() };
+}
+
+const KEBAB_RE = /^[a-z0-9][a-z0-9._-]*[a-z0-9]$|^[a-z0-9]$/;
+const HASHTAG_RE = /^[a-z0-9][a-z0-9-]*[a-z0-9]$|^[a-z0-9]$/;
+
+function isValidSpdx(license: string): boolean {
+  return license.trim().length > 0 && !/[\n\r ]/.test(license.trim());
+}
+function isValidUrl(value: string): boolean {
+  try {
+    const u = new URL(value);
+    return u.protocol === "http:" || u.protocol === "https:";
+  } catch {
+    return false;
+  }
+}
+function isValidBase58(s: string): boolean {
+  return /^[1-9A-HJ-NP-Za-km-z]{32,44}$/.test(s);
+}
+
+// ── the format check (all rules, one place) ────────────────────────────────────
+
+/**
+ * Check a skill's SKILL.md format. NO size limit (codeIn auto-chunks). Rules:
+ *   name        — required; 1–64 chars; kebab-case            (error)
+ *   description — required; ≥20 chars                          (error); >500 (warning)
+ *   body        — <50 chars                                    (info)
+ *   license     — present but not SPDX-like                    (warning)
+ *   repository  — present but not an http(s) URL               (warning)
+ *   category    — missing                                      (warning, search trait)
+ *   hashtags    — uppercase / spaces / bad chars               (warning)
+ */
+export function checkFormat(skillMd: string): FormatResult {
+  const result = emptyResult();
+  const { frontmatter, body } = parse(skillMd);
+
+  const name = typeof frontmatter.name === "string" ? frontmatter.name : "";
+  if (!name.trim()) {
+    add(result, "name", "error", '"name" is required and must be a non-empty string');
+  } else if (name.length < 1 || name.length > 64) {
+    add(result, "name", "error", `"name" must be 1–64 characters (got ${name.length})`);
+  } else if (!KEBAB_RE.test(name)) {
+    add(result, "name", "error", '"name" must be kebab-case (lowercase letters, digits, dots, hyphens)');
+  }
+
+  const description = typeof frontmatter.description === "string" ? frontmatter.description : "";
+  if (!description.trim()) {
+    add(result, "description", "error", '"description" is required and must be a non-empty string');
+  } else if (description.length < 20) {
+    add(result, "description", "error", `"description" is too short (${description.length} chars); minimum is 20`);
+  } else if (description.length > 500) {
+    add(result, "description", "warning", `"description" is long (${description.length} chars); keep it under 500`);
+  }
+
+  if (body.trim().length < 50) {
+    add(result, "body", "info", `Skill body is very short (${body.trim().length} chars); consider expanding it`);
+  }
+
+  const license = frontmatter.license;
+  if (typeof license === "string" && !isValidSpdx(license)) {
+    add(result, "license", "warning", `"license" value "${license}" does not look like a valid SPDX identifier`);
+  }
+  const repository = frontmatter.repository;
+  if (typeof repository === "string" && !isValidUrl(repository)) {
+    add(result, "repository", "warning", `"repository" value "${repository}" is not a valid http(s) URL`);
+  }
+
+  if (!frontmatter.category) {
+    add(result, "category", "warning", '"category" is recommended for on-chain search trait filtering');
+  }
+  if (Array.isArray(frontmatter.hashtags)) {
+    for (const tag of frontmatter.hashtags) {
+      if (!HASHTAG_RE.test(String(tag).replace(/^#/, ""))) {
+        add(result, "hashtags", "warning", `Hashtag "${tag}" should be lowercase, no spaces, alphanumeric/hyphens only`);
+      }
+    }
+  }
+
+  return result;
+}
+
+/**
+ * Check a workflow's SKILL.md format — the skill rules above PLUS:
+ *   type           — must be exactly "workflow"               (error)
+ *   requiredSkills — non-empty array of valid base58 mints    (error)
+ */
+export function checkWorkflowFormat(skillMd: string): FormatResult {
+  const result = checkFormat(skillMd);
+  const { frontmatter } = parse(skillMd);
+
+  if (frontmatter.type !== "workflow") {
+    add(result, "type", "error", '"type" must be exactly "workflow"');
+  }
+  const req = frontmatter.requiredSkills;
+  if (!Array.isArray(req)) {
+    add(result, "requiredSkills", "error", '"requiredSkills" must be an array of skill mint addresses');
+  } else if (req.length === 0) {
+    add(result, "requiredSkills", "error", '"requiredSkills" cannot be empty for a workflow');
+  } else {
+    const invalid = req.filter((k) => !isValidBase58(String(k)));
+    if (invalid.length > 0) {
+      add(result, "requiredSkills", "error", `requiredSkills has invalid mint addresses: ${invalid.join(", ")}`);
+    }
+  }
+
+  return result;
+}

--- a/packages/core/src/nft/index.ts
+++ b/packages/core/src/nft/index.ts
@@ -1,0 +1,4 @@
+export { publishSkill, buySkill } from "./skill.js";
+export type { PublishSkillInput, BuySkillInput } from "./skill.js";
+export { createSkillMint, mintSkillToken, getMintSupply, readSkillMintMetadata, readSkillText } from "./token2022.js";
+export type { SkillMintMetadata } from "./token2022.js";

--- a/packages/core/src/nft/minter.spec.ts
+++ b/packages/core/src/nft/minter.spec.ts
@@ -1,0 +1,61 @@
+import { describe, it, expect, beforeEach, afterEach } from "vitest";
+import { Keypair } from "@solana/web3.js";
+import { resolveMinter, tryMinterPubkey, resetMinterCache } from "./minter.js";
+
+const SECRET = "AGENTNET_MINTER_SECRET";
+const PUBKEY = "AGENTNET_MINTER_PUBKEY";
+
+describe("nft/minter", () => {
+  beforeEach(() => {
+    delete process.env[SECRET];
+    delete process.env[PUBKEY];
+    resetMinterCache();
+  });
+
+  afterEach(() => {
+    delete process.env[SECRET];
+    delete process.env[PUBKEY];
+    resetMinterCache();
+  });
+
+  it("resolveMinter returns the override when given one", () => {
+    const kp = Keypair.generate();
+    expect(resolveMinter(kp)).toBe(kp);
+  });
+
+  it("resolveMinter throws when nothing is configured", () => {
+    expect(() => resolveMinter()).toThrow(/not configured/);
+  });
+
+  it("resolveMinter parses a JSON byte-array secret from env", () => {
+    const kp = Keypair.generate();
+    process.env[SECRET] = JSON.stringify(Array.from(kp.secretKey));
+    expect(resolveMinter().publicKey.toBase58()).toBe(kp.publicKey.toBase58());
+  });
+
+  it("resolveMinter rejects a non-array secret", () => {
+    process.env[SECRET] = "not-an-array";
+    expect(() => resolveMinter()).toThrow(/JSON byte array/);
+  });
+
+  it("tryMinterPubkey returns null when unconfigured (publish stays open)", () => {
+    expect(tryMinterPubkey()).toBeNull();
+  });
+
+  it("tryMinterPubkey prefers an explicit pubkey override", () => {
+    const kp = Keypair.generate();
+    expect(tryMinterPubkey(kp.publicKey)?.toBase58()).toBe(kp.publicKey.toBase58());
+  });
+
+  it("tryMinterPubkey reads AGENTNET_MINTER_PUBKEY without needing the secret", () => {
+    const kp = Keypair.generate();
+    process.env[PUBKEY] = kp.publicKey.toBase58();
+    expect(tryMinterPubkey()?.toBase58()).toBe(kp.publicKey.toBase58());
+  });
+
+  it("tryMinterPubkey derives the pubkey from the secret when only the secret is set", () => {
+    const kp = Keypair.generate();
+    process.env[SECRET] = JSON.stringify(Array.from(kp.secretKey));
+    expect(tryMinterPubkey()?.toBase58()).toBe(kp.publicKey.toBase58());
+  });
+});

--- a/packages/core/src/nft/minter.ts
+++ b/packages/core/src/nft/minter.ts
@@ -1,0 +1,82 @@
+// Protocol minter (Path A authority model).
+//
+// Token-2022 `mintTo` requires the mint authority's signature, so a buyer cannot
+// self-mint a creator-authored mint. We resolve this without a custom on-chain
+// program by handing each skill mint's authority to ONE protocol minter keypair
+// at publish time (createSkillMint adds a setAuthority handoff, signed by the
+// creator alone). The minter then co-signs every buy/unlock `mintTo`.
+//
+// Tradeoff: centralized — whoever holds the minter key controls all supply
+// issuance. Acceptable for devnet bring-up; swap for a PDA-authority program
+// later if trustless minting is required (see plans/skill-nft-structure.md §4).
+//
+// Configuration (no key is ever hard-coded):
+//   AGENTNET_MINTER_SECRET  — JSON byte array of the minter Keypair secret
+//                             (the format `solana-keygen` writes). Required to
+//                             buy/unlock; the holder co-signs mintTo.
+//   AGENTNET_MINTER_PUBKEY  — optional base58 pubkey. Lets a publisher set the
+//                             mint authority WITHOUT holding the secret (the
+//                             secret lives only on the minting service).
+//
+// Both can be overridden per-call (tests, multi-tenant) by passing a Keypair /
+// PublicKey directly — same injection style as the validation reviewFn.
+
+import { Keypair, PublicKey } from "@solana/web3.js";
+
+const ENV_SECRET = "AGENTNET_MINTER_SECRET";
+const ENV_PUBKEY = "AGENTNET_MINTER_PUBKEY";
+
+let cachedKeypair: Keypair | null = null;
+
+function parseSecret(raw: string): Keypair {
+  const trimmed = raw.trim();
+  if (!trimmed.startsWith("[")) {
+    throw new Error(
+      `${ENV_SECRET} must be a JSON byte array (solana-keygen format), e.g. "[12,34,...]"`,
+    );
+  }
+  return Keypair.fromSecretKey(Uint8Array.from(JSON.parse(trimmed)));
+}
+
+/**
+ * Resolve the protocol minter Keypair (the mint-authority signer for mintTo).
+ * Throws if neither an override nor AGENTNET_MINTER_SECRET is available — buy/
+ * unlock cannot proceed without the authority's signature.
+ */
+export function resolveMinter(override?: Keypair): Keypair {
+  if (override) return override;
+  if (cachedKeypair) return cachedKeypair;
+
+  const raw = process.env[ENV_SECRET];
+  if (!raw) {
+    throw new Error(
+      `Protocol minter not configured: set ${ENV_SECRET} (JSON byte array) or pass a minter Keypair. ` +
+        `Token-2022 mintTo needs the mint authority's signature.`,
+    );
+  }
+  cachedKeypair = parseSecret(raw);
+  return cachedKeypair;
+}
+
+/**
+ * Resolve the protocol minter's PUBLIC key — the authority a new mint is handed
+ * to at publish time. Prefers an explicit override, then AGENTNET_MINTER_PUBKEY
+ * (so a publisher need not hold the secret), then derives it from the secret.
+ * Returns null when nothing is configured: createSkillMint then leaves authority
+ * with the creator (buy stays blocked, but publish still works).
+ */
+export function tryMinterPubkey(override?: PublicKey): PublicKey | null {
+  if (override) return override;
+
+  const pk = process.env[ENV_PUBKEY];
+  if (pk) return new PublicKey(pk);
+
+  const raw = process.env[ENV_SECRET];
+  if (!raw) return null;
+  return parseSecret(raw).publicKey;
+}
+
+/** Test hook — clear the cached keypair so env changes take effect. */
+export function resetMinterCache(): void {
+  cachedKeypair = null;
+}

--- a/packages/core/src/nft/readSkillText.spec.ts
+++ b/packages/core/src/nft/readSkillText.spec.ts
@@ -1,0 +1,54 @@
+import { describe, it, expect, vi, beforeEach } from "vitest";
+import { readSkillText } from "./token2022.js";
+import * as chain from "../core/chain.js";
+import * as splToken from "@solana/spl-token";
+
+// readSkillText joins readSkillMintMetadata (getTokenMetadata) → readCodeIn.
+vi.mock("../core/chain.js", () => ({
+  signerAddress: vi.fn(),
+  readCodeIn: vi.fn(),
+}));
+
+vi.mock("./minter.js", () => ({
+  resolveMinter: vi.fn(),
+  tryMinterPubkey: vi.fn(),
+}));
+
+vi.mock("@solana/spl-token", async (importOriginal) => {
+  const actual = await importOriginal<typeof import("@solana/spl-token")>();
+  return { ...actual, getTokenMetadata: vi.fn() };
+});
+
+const MINT = "TokenzQdBNbLqP5VEhdkAS6EPFLC1PHnBqCXEpPvZeJ";
+
+describe("nft/readSkillText", () => {
+  beforeEach(() => vi.clearAllMocks());
+
+  it("resolves mint → uri (txid) → inscribed body text", async () => {
+    vi.mocked(splToken.getTokenMetadata).mockResolvedValue({
+      name: "my-skill",
+      symbol: "MY",
+      uri: "txid123",
+      additionalMetadata: [],
+    } as any);
+    vi.mocked(chain.readCodeIn).mockResolvedValue({
+      data: "# SKILL body text",
+      metadata: "",
+    });
+
+    const text = await readSkillText({} as any, MINT);
+
+    expect(text).toBe("# SKILL body text");
+    // the uri recovered from the mint is what readCodeIn is asked for
+    expect(chain.readCodeIn).toHaveBeenCalledWith("txid123");
+  });
+
+  it("returns null when the mint has no metadata", async () => {
+    vi.mocked(splToken.getTokenMetadata).mockResolvedValue(null as any);
+
+    const text = await readSkillText({} as any, MINT);
+
+    expect(text).toBeNull();
+    expect(chain.readCodeIn).not.toHaveBeenCalled();
+  });
+});

--- a/packages/core/src/nft/skill.spec.ts
+++ b/packages/core/src/nft/skill.spec.ts
@@ -1,0 +1,94 @@
+import { describe, it, expect, vi, beforeEach } from "vitest";
+import { Keypair, PublicKey } from "@solana/web3.js";
+import { publishSkill, buySkill } from "./skill.js";
+import { FormatError } from "./checkFormat.js";
+import * as chain from "../core/chain.js";
+import * as token2022 from "./token2022.js";
+
+vi.mock("../core/chain.js", () => ({
+  ensureDbRoot: vi.fn().mockResolvedValue("mockDbRootSig"),
+  codeIn: vi.fn().mockResolvedValue("mockCodeInSig"),
+  signerAddress: vi.fn().mockImplementation((signer) =>
+    Promise.resolve(signer.publicKey?.toBase58() || "11111111111111111111111111111111"),
+  ),
+}));
+
+vi.mock("../core/seed.js", () => ({
+  getSkillsCollectionMint: vi.fn().mockReturnValue(null),
+  getWorkflowGateProgramId: vi.fn().mockReturnValue("3ptXj4yuaQG51WTA3SZZ37jGvYFgMhgXnSKWJLASJNkt"),
+}));
+
+vi.mock("./token2022.js", async () => {
+  const { PublicKey } = await import("@solana/web3.js");
+  return {
+    createSkillMint: vi.fn().mockResolvedValue(new PublicKey("11111111111111111111111111111111")),
+  };
+});
+
+describe("nft/skill", () => {
+  let mockConn: any;
+  let signer: Keypair;
+
+  beforeEach(() => {
+    mockConn = {
+      getLatestBlockhash: vi.fn().mockResolvedValue({ blockhash: "11111111111111111111111111111111", lastValidBlockHeight: 1 }),
+      sendRawTransaction: vi.fn().mockResolvedValue("mockTxSig"),
+      confirmTransaction: vi.fn().mockResolvedValue({}),
+      getAccountInfo: vi.fn().mockResolvedValue({ data: new Uint8Array() }), // ATA exists
+    };
+    signer = Keypair.generate();
+    vi.clearAllMocks();
+  });
+
+  const VALID_SKILL = `---
+name: super-skill
+description: A useful skill that teaches agents to reason step by step
+category: ai
+hashtags: [reasoning]
+---
+
+This skill teaches agents to reason clearly and break down complex problems.
+`;
+
+  it("publishes a skill (mint authority = gate PDA, then publish_item with no prereqs)", async () => {
+    const mintAddr = await publishSkill(mockConn as any, signer, {
+      name: "super-skill",
+      description: "A useful skill that teaches agents to reason step by step",
+      text: VALID_SKILL,
+      category: "ai",
+      hashtags: ["reasoning"],
+    });
+
+    expect(typeof mintAddr).toBe("string");
+    expect(chain.ensureDbRoot).toHaveBeenCalled();
+    expect(chain.codeIn).toHaveBeenCalledWith(signer, VALID_SKILL, "super-skill.md", "text/markdown");
+    // createSkillMint gets a pre-made mint keypair + a PDA mint authority.
+    const call = vi.mocked(token2022.createSkillMint).mock.calls[0][2] as any;
+    expect(call.mintKeypair).toBeInstanceOf(Keypair);
+    expect(call.minterAuthority).toBeInstanceOf(PublicKey);
+    // and publish_item was sent.
+    expect(mockConn.sendRawTransaction).toHaveBeenCalled();
+  });
+
+  it("buys a skill via buy_item (no client price/minter — gate is a no-op for skills)", async () => {
+    const sig = await buySkill(mockConn as any, signer, {
+      skillId: "So11111111111111111111111111111111111111112",
+      buyerWallet: signer.publicKey.toBase58(),
+      creatorWallet: "11111111111111111111111111111111",
+    });
+
+    expect(sig).toBe("mockTxSig");
+    expect(mockConn.sendRawTransaction).toHaveBeenCalled();
+  });
+
+  it("throws FormatError when the format check rejects", async () => {
+    await expect(
+      publishSkill(mockConn as any, signer, {
+        name: "test",
+        description: "test",
+        text: "Just some text with no frontmatter.",
+      }),
+    ).rejects.toThrow(FormatError);
+    expect(chain.ensureDbRoot).not.toHaveBeenCalled();
+  });
+});

--- a/packages/core/src/nft/skill.ts
+++ b/packages/core/src/nft/skill.ts
@@ -1,0 +1,125 @@
+// Skill NFT operations: publish (code-in → mint, authority = gate PDA) and buy
+// (the gate program mints under its PDA authority — no protocol-minter keypair).
+//
+// A skill is an "item" with NO prerequisites (required_skills = []). Publish/buy
+// go through the same gate program as workflows; the gate loop just runs zero
+// times for a skill. See nft/workflowGate.ts + the agent-workflow-nft program.
+
+import {
+  PublicKey,
+  Keypair,
+  TransactionInstruction,
+  type Connection,
+} from "@solana/web3.js";
+import {
+  getAssociatedTokenAddressSync,
+  createAssociatedTokenAccountInstruction,
+  TOKEN_2022_PROGRAM_ID,
+} from "@solana/spl-token";
+import type { SignerInput } from "@iqlabs-official/solana-sdk/utils";
+import { codeIn, signerAddress, ensureDbRoot } from "../core/chain.js";
+import { getSkillsCollectionMint } from "../core/seed.js";
+import { createSkillMint } from "./token2022.js";
+import { checkFormat, FormatError } from "./checkFormat.js";
+import { publishItemIx, buyItemIx, itemMintAuthorityPda } from "./workflowGate.js";
+import { sendTx } from "./workflow.js";
+
+export interface PublishSkillInput {
+  name: string;
+  description: string;
+  text: string; // SKILL.md content (codeIn auto-chunks if large)
+  category?: string; // e.g. "clean-code"
+  hashtags?: string[]; // e.g. ["refactoring"]
+  price?: bigint; // lamports (0 = free)
+}
+
+/**
+ * Publish a skill. The skill mint's authority is the gate program's mint-auth PDA
+ * (so only buy_item can mint it), and its config (price, empty required_skills) is
+ * registered on-chain via publish_item.
+ */
+export async function publishSkill(
+  conn: Connection,
+  signer: SignerInput,
+  input: PublishSkillInput,
+): Promise<string> {
+  const format = checkFormat(input.text);
+  if (!format.ok) {
+    throw new FormatError(format.errors);
+  }
+
+  await ensureDbRoot(signer);
+
+  // code-in the skill text
+  const skillTxid = await codeIn(signer, input.text, `${input.name}.md`, "text/markdown");
+
+  // Pre-generate the mint → derive the gate PDA that will own the mint authority.
+  const skillMintKp = Keypair.generate();
+  const skillMint = skillMintKp.publicKey;
+  const mintAuthority = itemMintAuthorityPda(skillMint);
+
+  const collectionStr = getSkillsCollectionMint();
+  const collectionMint = collectionStr ? new PublicKey(collectionStr) : undefined;
+
+  await createSkillMint(conn, signer, {
+    name: input.name,
+    symbol: input.name.substring(0, 8).toUpperCase(),
+    uri: skillTxid,
+    category: input.category,
+    hashtags: input.hashtags,
+    collectionMint,
+    mintKeypair: skillMintKp,
+    minterAuthority: mintAuthority, // gate PDA holds the mint authority
+  });
+
+  // Register the item config on-chain. A skill has NO prerequisites.
+  const creator = new PublicKey(await signerAddress(signer));
+  const ix = publishItemIx({
+    creator,
+    itemMint: skillMint,
+    requiredSkills: [],
+    price: input.price ?? 0n,
+  });
+  await sendTx(conn, signer, [ix]);
+
+  return skillMint.toBase58();
+}
+
+export interface BuySkillInput {
+  skillId: string; // skill mint address
+  buyerWallet: string; // wallet buying the skill
+  creatorWallet: string; // paid the price (read from the item config on-chain)
+}
+
+/**
+ * Buy a skill (star = soulbound purchase = equip). Calls buy_item: there is no
+ * prerequisite gate for a skill, so the program pays the creator (if priced) and
+ * mints 1 token under its PDA authority. No protocol-minter keypair needed.
+ */
+export async function buySkill(
+  conn: Connection,
+  signer: SignerInput,
+  input: BuySkillInput,
+): Promise<string> {
+  const buyer = new PublicKey(input.buyerWallet);
+  const skillMint = new PublicKey(input.skillId);
+
+  // buy_item needs the buyer's skill ATA to exist; create it if missing.
+  const ixs: TransactionInstruction[] = [];
+  const buyerAta = getAssociatedTokenAddressSync(skillMint, buyer, false, TOKEN_2022_PROGRAM_ID);
+  if ((await conn.getAccountInfo(buyerAta)) === null) {
+    const payer = new PublicKey(await signerAddress(signer));
+    ixs.push(
+      createAssociatedTokenAccountInstruction(payer, buyerAta, buyer, skillMint, TOKEN_2022_PROGRAM_ID),
+    );
+  }
+  ixs.push(
+    buyItemIx({
+      buyer,
+      creator: new PublicKey(input.creatorWallet),
+      itemMint: skillMint,
+      requiredSkills: [], // skills have no gate
+    }),
+  );
+  return sendTx(conn, signer, ixs);
+}

--- a/packages/core/src/nft/token2022.spec.ts
+++ b/packages/core/src/nft/token2022.spec.ts
@@ -1,0 +1,71 @@
+import { describe, it, expect, vi, beforeEach } from "vitest";
+import { Connection, Keypair, PublicKey, Transaction } from "@solana/web3.js";
+import { createSkillMint, mintSkillToken } from "./token2022.js";
+import * as splToken from "@solana/spl-token";
+
+vi.mock("@solana/spl-token", async (importOriginal) => {
+  const actual = await importOriginal<typeof import("@solana/spl-token")>();
+  const { PublicKey } = await import("@solana/web3.js");
+  return {
+    ...actual,
+    createInitializeMint2Instruction: vi.fn().mockReturnValue(new (require("@solana/web3.js").TransactionInstruction)({ keys: [], programId: new PublicKey("11111111111111111111111111111111"), data: Buffer.alloc(0) })),
+    createInitializeNonTransferableMintInstruction: vi.fn().mockReturnValue(new (require("@solana/web3.js").TransactionInstruction)({ keys: [], programId: new PublicKey("11111111111111111111111111111111"), data: Buffer.alloc(0) })),
+    createInitializeMetadataPointerInstruction: vi.fn().mockReturnValue(new (require("@solana/web3.js").TransactionInstruction)({ keys: [], programId: new PublicKey("11111111111111111111111111111111"), data: Buffer.alloc(0) })),
+    createMintToInstruction: vi.fn().mockImplementation((_mint, _ata, authority) => new (require("@solana/web3.js").TransactionInstruction)({ keys: [{ pubkey: authority, isSigner: true, isWritable: false }], programId: new PublicKey("11111111111111111111111111111111"), data: Buffer.alloc(0) })),
+    createAssociatedTokenAccountInstruction: vi.fn().mockReturnValue(new (require("@solana/web3.js").TransactionInstruction)({ keys: [], programId: new PublicKey("11111111111111111111111111111111"), data: Buffer.alloc(0) })),
+    getAssociatedTokenAddressSync: vi.fn().mockReturnValue(new PublicKey("11111111111111111111111111111111")),
+    getMintLen: vi.fn().mockReturnValue(170),
+  };
+});
+
+describe("nft/token2022", () => {
+  let mockConn: any;
+  let signer: Keypair;
+
+  beforeEach(() => {
+    mockConn = {
+      getMinimumBalanceForRentExemption: vi.fn().mockResolvedValue(1000000),
+      getLatestBlockhash: vi.fn().mockResolvedValue({ blockhash: "11111111111111111111111111111111", lastValidBlockHeight: 1 }),
+      sendRawTransaction: vi.fn().mockResolvedValue("mockMintSig"),
+      confirmTransaction: vi.fn().mockResolvedValue({}),
+      getAccountInfo: vi.fn().mockResolvedValue(null), // simulate no ATA
+    };
+    signer = Keypair.generate();
+    vi.clearAllMocks();
+  });
+
+  it("should create a skill mint and return its address", async () => {
+    const mintPubkey = await createSkillMint(mockConn as any, signer, {
+      name: "TestSkill",
+      symbol: "TEST",
+      uri: "mockTxId",
+    });
+
+    expect(mintPubkey).toBeInstanceOf(PublicKey);
+    expect(mockConn.sendRawTransaction).toHaveBeenCalled();
+    expect(splToken.createInitializeNonTransferableMintInstruction).toHaveBeenCalled();
+  });
+
+  it("should mint a skill token to the recipient", async () => {
+    // Simulate ATA already exists
+    mockConn.getAccountInfo.mockResolvedValueOnce({ data: new Uint8Array() });
+    
+    const sig = await mintSkillToken(mockConn as any, signer, "11111111111111111111111111111111", "11111111111111111111111111111111", Keypair.generate());
+
+    expect(sig).toBe("mockMintSig");
+    expect(splToken.createMintToInstruction).toHaveBeenCalled();
+    // ATA creation should not be called since it exists
+    expect(splToken.createAssociatedTokenAccountInstruction).not.toHaveBeenCalled();
+  });
+
+  it("should create ATA if it does not exist before minting", async () => {
+    // getAccountInfo returns null for missing accounts (does not throw)
+    mockConn.getAccountInfo.mockResolvedValueOnce(null);
+
+    const sig = await mintSkillToken(mockConn as any, signer, "11111111111111111111111111111111", "11111111111111111111111111111111", Keypair.generate());
+
+    expect(sig).toBe("mockMintSig");
+    expect(splToken.createAssociatedTokenAccountInstruction).toHaveBeenCalled();
+    expect(splToken.createMintToInstruction).toHaveBeenCalled();
+  });
+});

--- a/packages/core/src/nft/token2022.ts
+++ b/packages/core/src/nft/token2022.ts
@@ -1,0 +1,423 @@
+// Token-2022 mint helpers. Creates non-transferable soulbound tokens.
+//
+// One mint per skill; supply = popularity (on-chain counter); uri = code-in txid.
+
+import {
+  SystemProgram,
+  PublicKey,
+  Transaction,
+  Keypair,
+  type Connection,
+} from "@solana/web3.js";
+import {
+  createInitializeMint2Instruction,
+  createInitializeNonTransferableMintInstruction,
+  createInitializeMetadataPointerInstruction,
+  createMintToInstruction,
+  createSetAuthorityInstruction,
+  createAssociatedTokenAccountInstruction,
+  getAssociatedTokenAddressSync,
+  getMint,
+  getTokenMetadata,
+  AuthorityType,
+  ExtensionType,
+  getMintLen,
+  LENGTH_SIZE,
+  TYPE_SIZE,
+} from "@solana/spl-token";
+import {
+  pack,
+  createInitializeInstruction as createInitializeMetadataInstruction,
+  createUpdateFieldInstruction,
+  type TokenMetadata,
+} from "@solana/spl-token-metadata";
+import { type SignerInput, type WalletSigner } from "@iqlabs-official/solana-sdk/utils";
+import { signerAddress, readCodeIn } from "../core/chain.js";
+import { resolveMinter, tryMinterPubkey } from "./minter.js";
+
+import { TOKEN_2022_PROGRAM_ID } from "@solana/spl-token";
+
+// additional_metadata field keys (skill-nft-structure.md §1 traits → search.md).
+// Stored on-chain in the TokenMetadata extension so search can filter by trait
+// and a skill's text resolves from the mint's `uri` (no registry table needed).
+const FIELD_CATEGORY = "category";
+const FIELD_HASHTAGS = "hashtags";
+
+interface MintConfig {
+  name: string;
+  symbol: string;
+  uri: string; // code-in txid (IQLabs on-chain path) — TokenMetadata.uri
+  category?: string; // e.g. "clean-code", "design" — additional_metadata trait
+  hashtags?: string[]; // e.g. ["refactoring", "testing"] — additional_metadata trait
+  /**
+   * Protocol minter to receive mint authority (Path A). Defaults to the env
+   * minter (AGENTNET_MINTER_PUBKEY / _SECRET). When null/unset, authority stays
+   * with the creator and buy/unlock remain blocked.
+   */
+  minterAuthority?: PublicKey;
+  collectionMint?: PublicKey; // new field for token group enrollment
+  /**
+   * Use this keypair for the mint (instead of a fresh random one). Pass it when
+   * the caller needs the mint address BEFORE creation — e.g. to derive a PDA that
+   * will be the mint authority (workflow gate). The caller co-signs.
+   */
+  mintKeypair?: Keypair;
+}
+
+/** On-chain skill traits read back from the mint's TokenMetadata extension. */
+export interface SkillMintMetadata {
+  name: string;
+  symbol: string;
+  uri: string; // code-in txid → resolve skill text via readCodeIn
+  category?: string;
+  hashtags?: string[];
+}
+
+/**
+ * Create a Token-2022 mint for a skill (skill-nft-structure.md §1/§2).
+ *
+ * Returns: mint address
+ *
+ * Extensions, all native Token-2022:
+ *   - NonTransferable   → soulbound (§1)
+ *   - MetadataPointer   → points at the mint itself (self-hosted metadata)
+ *   - TokenMetadata     → uri = code-in txid (§2 "NFT uri = IQLabs on-chain
+ *                         path"); category + hashtags as additional_metadata
+ *                         traits (§1 → search.md trait filter)
+ *
+ * So the mint is self-describing: a reader resolves the skill text from
+ * `uri` and filters by on-chain traits — no off-chain registry table (§2
+ * "No skills registry table"). Caller signs; mint authority = creator.
+ *
+ * ⚠️ KNOWN LIMITATION (buy flow): mint authority = creator here, but `buySkill`
+ * has the buyer sign the mintTo. On-chain mintTo requires the mint authority's
+ * signature, so a buyer cannot self-mint a creator-authored mint — the buy tx
+ * fails unless the creator co-signs. Open design decision (custom program with a
+ * PDA mint authority, a protocol minter keypair, or creator co-sign). Only the
+ * mint step of buy is blocked; publish/search/reputation/notes/validation work.
+ */
+export async function createSkillMint(
+  conn: Connection,
+  signer: SignerInput,
+  config: MintConfig,
+): Promise<PublicKey> {
+  const creator = await signerAddress(signer);
+  const creatorPk = new PublicKey(creator);
+  const mintKeypair = config.mintKeypair ?? Keypair.generate();
+  const mint = mintKeypair.publicKey;
+
+  // Build the TokenMetadata payload. uri = code-in txid; traits go in
+  // additional_metadata so search can filter on-chain (added via updateField
+  // below — additionalMetadata in the initialize ix is ignored by the program).
+  const additionalMetadata: [string, string][] = [];
+  if (config.category) additionalMetadata.push([FIELD_CATEGORY, config.category]);
+  if (config.hashtags && config.hashtags.length > 0) {
+    additionalMetadata.push([FIELD_HASHTAGS, JSON.stringify(config.hashtags)]);
+  }
+  const metadata: TokenMetadata = {
+    mint,
+    name: config.name,
+    symbol: config.symbol,
+    uri: config.uri,
+    additionalMetadata,
+  };
+
+  // If enrolling into a collection, we need the GroupMemberPointer and TokenGroupMember extensions.
+  // The member enrollment must be signed by the group's update authority (the protocol minter).
+  const minter = config.collectionMint ? resolveMinter() : null;
+  const minterPk = config.minterAuthority ?? tryMinterPubkey();
+
+  const extensions = [ExtensionType.NonTransferable, ExtensionType.MetadataPointer];
+  if (config.collectionMint) {
+    extensions.push(ExtensionType.GroupMemberPointer);
+  }
+
+  const preInitMintLen = getMintLen(extensions);
+  
+  let groupMemberLen = 0;
+  if (config.collectionMint) {
+    const totalExtensions = [...extensions, ExtensionType.TokenGroupMember];
+    groupMemberLen = getMintLen(totalExtensions) - preInitMintLen;
+  }
+
+  const metadataLen = TYPE_SIZE + LENGTH_SIZE + pack(metadata).length;
+  const lamports = await conn.getMinimumBalanceForRentExemption(preInitMintLen + metadataLen + groupMemberLen);
+
+  const tx = new Transaction().add(
+    // 1. Create the mint account (only base extension space; metadata and groupMember reallocs in)
+    SystemProgram.createAccount({
+      fromPubkey: creatorPk,
+      newAccountPubkey: mint,
+      lamports,
+      space: preInitMintLen,
+      programId: TOKEN_2022_PROGRAM_ID,
+    }),
+    // 2. MetadataPointer → the mint itself holds its metadata
+    createInitializeMetadataPointerInstruction(mint, creatorPk, mint, TOKEN_2022_PROGRAM_ID),
+  );
+
+  if (config.collectionMint) {
+    // GroupMemberPointer is a pre-init extension → must come before initMint2.
+    const { createInitializeGroupMemberPointerInstruction } = await import("@solana/spl-token");
+    tx.add(
+      createInitializeGroupMemberPointerInstruction(
+        mint,
+        creatorPk,
+        mint, // memberAddress is the mint itself
+        TOKEN_2022_PROGRAM_ID
+      ),
+    );
+  }
+
+  tx.add(
+    // 3. NonTransferable extension (soulbound)
+    createInitializeNonTransferableMintInstruction(mint, TOKEN_2022_PROGRAM_ID),
+    // 4. Initialize the mint (0 decimals for soulbound items). MUST come before
+    //    metadata init (the metadata program requires an initialized mint).
+    createInitializeMint2Instruction(
+      mint,
+      0, // decimals
+      creatorPk, // mint authority
+      creatorPk, // freeze authority
+      TOKEN_2022_PROGRAM_ID,
+    ),
+  );
+
+  if (config.collectionMint && minter) {
+    const { createInitializeMemberInstruction } = await import("@solana/spl-token-group");
+    tx.add(
+      createInitializeMemberInstruction({
+        programId: TOKEN_2022_PROGRAM_ID,
+        member: mint,
+        memberMint: mint,
+        memberMintAuthority: creatorPk,
+        group: config.collectionMint,
+        groupUpdateAuthority: minter.publicKey,
+      })
+    );
+  }
+
+  tx.add(
+    // 5. TokenMetadata: name/symbol/uri (uri = code-in txid)
+    createInitializeMetadataInstruction({
+      programId: TOKEN_2022_PROGRAM_ID,
+      metadata: mint,
+      updateAuthority: creatorPk,
+      mint,
+      mintAuthority: creatorPk,
+      name: config.name,
+      symbol: config.symbol,
+      uri: config.uri,
+    }),
+  );
+
+  // 6. Write each trait (category, hashtags) as an additional_metadata field.
+  for (const [field, value] of additionalMetadata) {
+    tx.add(
+      createUpdateFieldInstruction({
+        programId: TOKEN_2022_PROGRAM_ID,
+        metadata: mint,
+        updateAuthority: creatorPk,
+        field,
+        value,
+      }),
+    );
+  }
+
+  // 7. Path A authority handoff: give MINT authority to the protocol minter so
+  //    buyers can later mint via the minter's co-signature (Token-2022 mintTo
+  //    needs the authority's sig).
+  if (minterPk && !minterPk.equals(creatorPk)) {
+    tx.add(
+      createSetAuthorityInstruction(
+        mint,
+        creatorPk, // current mint authority
+        AuthorityType.MintTokens,
+        minterPk, // new mint authority = protocol minter
+        [],
+        TOKEN_2022_PROGRAM_ID,
+      ),
+    );
+  }
+
+  // Sign and send
+  const signerFull = signer as any; // cast to access signing
+  const { blockhash, lastValidBlockHeight } = await conn.getLatestBlockhash();
+  tx.recentBlockhash = blockhash;
+  tx.feePayer = creatorPk;
+
+  if (minter) {
+    tx.partialSign(minter);
+  }
+
+  if ("secretKey" in signerFull) {
+    // Keypair-like
+    tx.sign(signerFull, mintKeypair);
+  } else if ("signTransaction" in signerFull) {
+    // WalletSigner: mintKeypair partial-signs first, then wallet signs
+    tx.partialSign(mintKeypair);
+    const signed = await (signerFull as WalletSigner).signTransaction(tx);
+    const sig = await conn.sendRawTransaction(signed.serialize());
+    await conn.confirmTransaction({ signature: sig, blockhash, lastValidBlockHeight });
+    return mint;
+  }
+
+  const sig = await conn.sendRawTransaction(tx.serialize());
+  await conn.confirmTransaction({ signature: sig, blockhash, lastValidBlockHeight });
+
+  return mint;
+}
+
+/**
+ * Read a skill's on-chain metadata (uri + traits) from the mint's TokenMetadata
+ * extension — the §2 path back from NFT → content. `uri` is the code-in txid;
+ * pass it to `readCodeIn` to get the skill text. category/hashtags are the
+ * search traits. Returns null if the mint has no metadata.
+ */
+export async function readSkillMintMetadata(
+  conn: Connection,
+  skillMintAddr: string,
+): Promise<SkillMintMetadata | null> {
+  const md = await getTokenMetadata(
+    conn,
+    new PublicKey(skillMintAddr),
+    "confirmed",
+    TOKEN_2022_PROGRAM_ID,
+  );
+  if (!md) return null;
+
+  const fields = new Map(md.additionalMetadata);
+  const rawHashtags = fields.get(FIELD_HASHTAGS);
+  let hashtags: string[] | undefined;
+  if (rawHashtags) {
+    try {
+      const parsed = JSON.parse(rawHashtags);
+      if (Array.isArray(parsed)) hashtags = parsed;
+    } catch {
+      // Stored malformed — surface nothing rather than crash the reader.
+    }
+  }
+
+  return {
+    name: md.name,
+    symbol: md.symbol,
+    uri: md.uri,
+    category: fields.get(FIELD_CATEGORY),
+    hashtags,
+  };
+}
+
+/**
+ * Read a published skill's BODY text — the full NFT→content round-trip
+ * (skill-nft-structure.md §2). Joins the two halves that otherwise sit
+ * disconnected: `readSkillMintMetadata` (mint → uri=txid) then `readCodeIn`
+ * (txid → inscribed SKILL.md text). Returns null if the mint has no metadata
+ * or the inscription can't be resolved.
+ *
+ * This is the "show me this NFT's letter" call — search/detail views use it to
+ * surface the actual skill content, not just the indexed name/description.
+ */
+export async function readSkillText(
+  conn: Connection,
+  skillMintAddr: string,
+): Promise<string | null> {
+  const md = await readSkillMintMetadata(conn, skillMintAddr);
+  if (!md?.uri) return null;
+  const { data } = await readCodeIn(md.uri);
+  return data;
+}
+
+/**
+ * Free-issue one skill token to a wallet (admin / airdrop path — no payment).
+ * `buySkill` is the paid equivalent; this exists for issuing without a charge.
+ *
+ * Path A: mint authority is the protocol minter, so the minter co-signs the
+ * mintTo. `signer` pays fees (and creates the recipient ATA). Increments supply
+ * by 1; the token is NonTransferable so it stays in the recipient forever.
+ */
+export async function mintSkillToken(
+  conn: Connection,
+  signer: SignerInput,
+  skillMintAddr: string,
+  recipientWallet: string,
+  minterOverride?: Keypair,
+): Promise<string> {
+  const payer = await signerAddress(signer);
+  const payerPk = new PublicKey(payer);
+  const mintPk = new PublicKey(skillMintAddr);
+  const recipientPk = new PublicKey(recipientWallet);
+  const minter = resolveMinter(minterOverride);
+
+  // Get or create ATA for recipient
+  const ata = getAssociatedTokenAddressSync(mintPk, recipientPk, false, TOKEN_2022_PROGRAM_ID);
+
+  const tx = new Transaction();
+
+  // Create ATA if it doesn't exist (returns null for missing accounts, never throws)
+  const ataInfo = await conn.getAccountInfo(ata);
+  if (ataInfo === null) {
+    tx.add(
+      createAssociatedTokenAccountInstruction(
+        payerPk,
+        ata,
+        recipientPk,
+        mintPk,
+        TOKEN_2022_PROGRAM_ID,
+      ),
+    );
+  }
+
+  // Mint 1 token to the ATA — authority = protocol minter (co-signs below).
+  tx.add(
+    createMintToInstruction(
+      mintPk,
+      ata,
+      minter.publicKey, // mint authority
+      1, // amount (1 token for soulbound)
+      [],
+      TOKEN_2022_PROGRAM_ID,
+    ),
+  );
+
+  const signerFull = signer as any;
+  const { blockhash, lastValidBlockHeight } = await conn.getLatestBlockhash();
+  tx.recentBlockhash = blockhash;
+  tx.feePayer = payerPk;
+  tx.partialSign(minter);
+
+  if ("secretKey" in signerFull) {
+    tx.partialSign(signerFull);
+  } else if ("signTransaction" in signerFull) {
+    const signed = await (signerFull as WalletSigner).signTransaction(tx);
+    const sig = await conn.sendRawTransaction(signed.serialize());
+    await conn.confirmTransaction({ signature: sig, blockhash, lastValidBlockHeight });
+    return sig;
+  }
+
+  const sig = await conn.sendRawTransaction(tx.serialize());
+  await conn.confirmTransaction({ signature: sig, blockhash, lastValidBlockHeight });
+  return sig;
+}
+
+/**
+ * Read live supply (popularity) from the on-chain mint account.
+ *
+ * The mint is the single source of truth for popularity — search/reputation
+ * hydrate `supply` from here (the DAS scan snapshot doesn't carry live supply).
+ */
+export async function getMintSupply(
+  conn: Connection,
+  skillMintAddr: string,
+): Promise<number> {
+  try {
+    const mint = await getMint(
+      conn,
+      new PublicKey(skillMintAddr),
+      "confirmed",
+      TOKEN_2022_PROGRAM_ID,
+    );
+    return Number(mint.supply);
+  } catch {
+    return 0;
+  }
+}

--- a/packages/core/src/nft/workflow.spec.ts
+++ b/packages/core/src/nft/workflow.spec.ts
@@ -1,0 +1,97 @@
+import { describe, it, expect, vi, beforeEach } from "vitest";
+import { Keypair, PublicKey } from "@solana/web3.js";
+import { publishWorkflow, unlockWorkflow } from "./workflow.js";
+import { FormatError } from "./checkFormat.js";
+import * as chain from "../core/chain.js";
+import * as token2022 from "./token2022.js";
+
+vi.mock("../core/chain.js", () => ({
+  ensureDbRoot: vi.fn().mockResolvedValue("mockDbRootSig"),
+  codeIn: vi.fn().mockResolvedValue("mockCodeInSig"),
+  signerAddress: vi.fn().mockImplementation((signer) =>
+    Promise.resolve(signer.publicKey?.toBase58() || "11111111111111111111111111111111"),
+  ),
+}));
+
+vi.mock("../core/seed.js", () => ({
+  getWorkflowsCollectionMint: vi.fn().mockReturnValue(null),
+  getWorkflowGateProgramId: vi.fn().mockReturnValue("3ptXj4yuaQG51WTA3SZZ37jGvYFgMhgXnSKWJLASJNkt"),
+}));
+
+vi.mock("./token2022.js", async () => {
+  const { PublicKey } = await import("@solana/web3.js");
+  return {
+    createSkillMint: vi.fn().mockResolvedValue(new PublicKey("11111111111111111111111111111111")),
+  };
+});
+
+describe("nft/workflow", () => {
+  let mockConn: any;
+  let signer: Keypair;
+
+  beforeEach(() => {
+    mockConn = {
+      getLatestBlockhash: vi.fn().mockResolvedValue({ blockhash: "11111111111111111111111111111111", lastValidBlockHeight: 1 }),
+      sendRawTransaction: vi.fn().mockResolvedValue("mockTxSig"),
+      confirmTransaction: vi.fn().mockResolvedValue({}),
+      getAccountInfo: vi.fn().mockResolvedValue({ data: new Uint8Array() }), // ATA exists
+    };
+    signer = Keypair.generate();
+    vi.clearAllMocks();
+  });
+
+  const VALID_WORKFLOW_MD = `---
+name: test-workflow
+description: This is a test workflow that chains skills
+type: workflow
+requiredSkills: [So11111111111111111111111111111111111111112]
+category: ai
+---
+
+Workflow body here, long enough to pass the body length check easily.`;
+
+  it("publishes a workflow (mint authority = gate PDA, then publish_workflow ix)", async () => {
+    const mintAddr = await publishWorkflow(mockConn as any, signer, {
+      name: "test-workflow",
+      description: "This is a test workflow that chains skills",
+      text: VALID_WORKFLOW_MD,
+      requiredSkills: ["So11111111111111111111111111111111111111112"],
+      category: "ai",
+    });
+
+    expect(typeof mintAddr).toBe("string");
+    expect(chain.ensureDbRoot).toHaveBeenCalled();
+    expect(chain.codeIn).toHaveBeenCalledWith(signer, VALID_WORKFLOW_MD, "test-workflow.md", "text/markdown");
+    // createSkillMint is called with a pre-made mint keypair + a PDA mint authority.
+    const call = vi.mocked(token2022.createSkillMint).mock.calls[0][2] as any;
+    expect(call.mintKeypair).toBeInstanceOf(Keypair);
+    expect(call.minterAuthority).toBeInstanceOf(PublicKey);
+    // and the publish_workflow ix was sent.
+    expect(mockConn.sendRawTransaction).toHaveBeenCalled();
+  });
+
+  it("rejects publish if the workflow MD is invalid (type not workflow)", async () => {
+    const invalidMd = VALID_WORKFLOW_MD.replace("type: workflow", "type: skill");
+    await expect(
+      publishWorkflow(mockConn as any, signer, {
+        name: "test-workflow",
+        description: "This is a test workflow that chains skills",
+        text: invalidMd,
+        requiredSkills: ["So11111111111111111111111111111111111111112"],
+        category: "ai",
+      }),
+    ).rejects.toThrow(FormatError);
+  });
+
+  it("unlock builds a buy_workflow tx (gate is on-chain — no client balance check)", async () => {
+    const sig = await unlockWorkflow(mockConn as any, signer, {
+      workflowId: "So11111111111111111111111111111111111111112",
+      buyerWallet: signer.publicKey.toBase58(),
+      creatorWallet: "11111111111111111111111111111111",
+      requiredSkills: ["So11111111111111111111111111111111111111112"],
+    });
+
+    expect(sig).toBe("mockTxSig");
+    expect(mockConn.sendRawTransaction).toHaveBeenCalled();
+  });
+});

--- a/packages/core/src/nft/workflow.ts
+++ b/packages/core/src/nft/workflow.ts
@@ -1,0 +1,150 @@
+import {
+  PublicKey,
+  Transaction,
+  TransactionInstruction,
+  Keypair,
+  type Connection,
+} from "@solana/web3.js";
+import {
+  getAssociatedTokenAddressSync,
+  createAssociatedTokenAccountInstruction,
+  TOKEN_2022_PROGRAM_ID,
+} from "@solana/spl-token";
+import type { SignerInput } from "@iqlabs-official/solana-sdk/utils";
+
+import { codeIn, signerAddress, ensureDbRoot } from "../core/chain.js";
+import { getWorkflowsCollectionMint } from "../core/seed.js";
+import { createSkillMint } from "./token2022.js";
+import { checkWorkflowFormat, FormatError } from "./checkFormat.js";
+import {
+  publishItemIx,
+  buyItemIx,
+  itemMintAuthorityPda,
+} from "./workflowGate.js";
+
+export interface PublishWorkflowInput {
+  name: string;
+  description: string;
+  text: string; // SKILL.md content (must include type: workflow & requiredSkills)
+  requiredSkills: string[];
+  category?: string;
+  hashtags?: string[];
+  price?: bigint;
+}
+
+/**
+ * Publish a workflow. The workflow mint's authority is set to the gate program's
+ * mint-auth PDA (so only buy_workflow can mint it), and the prerequisites are
+ * registered on-chain via publish_workflow.
+ */
+export async function publishWorkflow(
+  conn: Connection,
+  signer: SignerInput,
+  input: PublishWorkflowInput,
+): Promise<string> {
+  const format = checkWorkflowFormat(input.text);
+  if (!format.ok) {
+    throw new FormatError(format.errors);
+  }
+
+  await ensureDbRoot(signer);
+
+  // code-in the workflow recipe
+  const workflowTxid = await codeIn(signer, input.text, `${input.name}.md`, "text/markdown");
+
+  // Pre-generate the mint so we know its address → derive the gate PDA that will
+  // OWN the mint authority. Only the gate program can then mint this workflow.
+  const workflowMintKp = Keypair.generate();
+  const workflowMint = workflowMintKp.publicKey;
+  const mintAuthority = itemMintAuthorityPda(workflowMint);
+
+  const collectionStr = getWorkflowsCollectionMint();
+  const collectionMint = collectionStr ? new PublicKey(collectionStr) : undefined;
+
+  await createSkillMint(conn, signer, {
+    name: input.name,
+    symbol: input.name.substring(0, 8).toUpperCase(),
+    uri: workflowTxid,
+    category: input.category,
+    hashtags: input.hashtags,
+    collectionMint,
+    mintKeypair: workflowMintKp,
+    minterAuthority: mintAuthority, // gate PDA holds the mint authority
+  });
+
+  // Register the prerequisites on-chain (config PDA). The program verifies each
+  // required skill is an official-collection member and rejects duplicates.
+  const creator = new PublicKey(await signerAddress(signer));
+  const ix = publishItemIx({
+    creator,
+    itemMint: workflowMint,
+    requiredSkills: input.requiredSkills.map((s) => new PublicKey(s)),
+    price: input.price ?? 0n,
+  });
+  await sendTx(conn, signer, [ix]);
+
+  return workflowMint.toBase58();
+}
+
+export interface UnlockWorkflowInput {
+  workflowId: string;
+  buyerWallet: string;
+  creatorWallet: string;
+  requiredSkills: string[]; // the workflow's prerequisite skill mints (in order)
+}
+
+/**
+ * Buy (unlock) a workflow via the gate program. There is NO client-side balance
+ * check anymore — the program enforces it on-chain (buy_workflow reverts if the
+ * buyer is missing any required skill), and pays the creator + mints the workflow
+ * token under the program's mint-authority PDA. The buyer signs and pays fees.
+ */
+export async function unlockWorkflow(
+  conn: Connection,
+  signer: SignerInput,
+  input: UnlockWorkflowInput,
+): Promise<string> {
+  const buyer = new PublicKey(input.buyerWallet);
+  const workflowMint = new PublicKey(input.workflowId);
+  const requiredSkills = input.requiredSkills.map((s) => new PublicKey(s));
+
+  // buy_workflow needs the buyer's workflow ATA to exist; create it if missing.
+  const ixs: TransactionInstruction[] = [];
+  const buyerAta = getAssociatedTokenAddressSync(workflowMint, buyer, false, TOKEN_2022_PROGRAM_ID);
+  if ((await conn.getAccountInfo(buyerAta)) === null) {
+    const payer = new PublicKey(await signerAddress(signer));
+    ixs.push(
+      createAssociatedTokenAccountInstruction(payer, buyerAta, buyer, workflowMint, TOKEN_2022_PROGRAM_ID),
+    );
+  }
+  ixs.push(
+    buyItemIx({ buyer, creator: new PublicKey(input.creatorWallet), itemMint: workflowMint, requiredSkills }),
+  );
+  return sendTx(conn, signer, ixs);
+}
+
+// Sign (Keypair or WalletSigner) + send + confirm a set of instructions. The
+// signer is also the fee payer. Shared by skill.ts (the gate flow is identical).
+export async function sendTx(
+  conn: Connection,
+  signer: SignerInput,
+  ixs: TransactionInstruction[],
+): Promise<string> {
+  const payerPk = new PublicKey(await signerAddress(signer));
+  const tx = new Transaction().add(...ixs);
+  const { blockhash, lastValidBlockHeight } = await conn.getLatestBlockhash();
+  tx.recentBlockhash = blockhash;
+  tx.feePayer = payerPk;
+
+  const s = signer as any;
+  let raw: Uint8Array;
+  if ("secretKey" in s) {
+    tx.partialSign(s);
+    raw = tx.serialize();
+  } else {
+    raw = (await s.signTransaction(tx)).serialize();
+  }
+  const sig = await conn.sendRawTransaction(raw);
+  await conn.confirmTransaction({ signature: sig, blockhash, lastValidBlockHeight });
+  return sig;
+}

--- a/packages/core/src/nft/workflowGate.ts
+++ b/packages/core/src/nft/workflowGate.ts
@@ -1,0 +1,103 @@
+// Calls into the agent-workflow-nft on-chain gate program (raw web3.js, no anchor).
+//
+// ONE model for skills AND workflows: every item is minted only through this
+// program (the item mint's authority is a program PDA), so a token can't be minted
+// without going through buy_item. An item's required_skills is empty for a skill
+// (anyone can buy) and filled for a workflow (buyer must hold every listed skill).
+
+import {
+  PublicKey,
+  SystemProgram,
+  TransactionInstruction,
+} from "@solana/web3.js";
+import {
+  getAssociatedTokenAddressSync,
+  TOKEN_2022_PROGRAM_ID,
+} from "@solana/spl-token";
+import { getWorkflowGateProgramId } from "../core/seed.js";
+
+// Anchor instruction discriminators (sha256("global:<name>")[0..8]) — from the IDL.
+const DISC_PUBLISH = Buffer.from([125, 80, 203, 31, 0, 230, 147, 33]); // publish_item
+const DISC_BUY = Buffer.from([80, 82, 193, 201, 216, 27, 70, 184]); // buy_item
+
+const ITEM_SEED = Buffer.from("item");
+const MINT_AUTH_SEED = Buffer.from("mint-auth");
+
+function programId(): PublicKey {
+  return new PublicKey(getWorkflowGateProgramId());
+}
+
+/** Config PDA holding an item's required_skills: ["item", itemMint]. */
+export function itemConfigPda(itemMint: PublicKey): PublicKey {
+  return PublicKey.findProgramAddressSync([ITEM_SEED, itemMint.toBuffer()], programId())[0];
+}
+
+/** The program's mint-authority PDA for an item: ["mint-auth", itemMint]. */
+export function itemMintAuthorityPda(itemMint: PublicKey): PublicKey {
+  return PublicKey.findProgramAddressSync([MINT_AUTH_SEED, itemMint.toBuffer()], programId())[0];
+}
+
+/**
+ * publish_item instruction — store creator, price, and required_skills in the
+ * config PDA. required_skills empty = a skill; filled = a workflow (each required
+ * skill mint is passed as a remaining account so the program can verify it).
+ */
+export function publishItemIx(args: {
+  creator: PublicKey;
+  itemMint: PublicKey;
+  requiredSkills: PublicKey[];
+  price: bigint;
+}): TransactionInstruction {
+  // data: disc(8) + vec<pubkey>(4 len + 32*n) + u64 price(8 LE)
+  const n = args.requiredSkills.length;
+  const data = Buffer.alloc(8 + 4 + 32 * n + 8);
+  let o = 0;
+  DISC_PUBLISH.copy(data, o); o += 8;
+  data.writeUInt32LE(n, o); o += 4;
+  for (const s of args.requiredSkills) { s.toBuffer().copy(data, o); o += 32; }
+  data.writeBigUInt64LE(args.price, o);
+
+  const keys = [
+    { pubkey: args.creator, isSigner: true, isWritable: true },
+    { pubkey: args.itemMint, isSigner: false, isWritable: false },
+    { pubkey: itemConfigPda(args.itemMint), isSigner: false, isWritable: true },
+    { pubkey: SystemProgram.programId, isSigner: false, isWritable: false },
+    // remaining: the skill mints, one per required_skill (none for a skill).
+    ...args.requiredSkills.map((m) => ({ pubkey: m, isSigner: false, isWritable: false })),
+  ];
+  return new TransactionInstruction({ programId: programId(), keys, data });
+}
+
+/**
+ * buy_item instruction — the gate. For a workflow, the buyer's skill token
+ * accounts are passed as remaining accounts (one per required skill, same order as
+ * config.required_skills); the program checks each holds ≥1, then mints the item
+ * token. For a skill (empty required_skills) there are no remaining accounts.
+ */
+export function buyItemIx(args: {
+  buyer: PublicKey;
+  creator: PublicKey;
+  itemMint: PublicKey;
+  requiredSkills: PublicKey[];
+}): TransactionInstruction {
+  const buyerItemAta = getAssociatedTokenAddressSync(
+    args.itemMint, args.buyer, false, TOKEN_2022_PROGRAM_ID,
+  );
+  const keys = [
+    { pubkey: args.buyer, isSigner: true, isWritable: true },
+    { pubkey: args.creator, isSigner: false, isWritable: true },
+    { pubkey: itemConfigPda(args.itemMint), isSigner: false, isWritable: false },
+    { pubkey: args.itemMint, isSigner: false, isWritable: true },
+    { pubkey: itemMintAuthorityPda(args.itemMint), isSigner: false, isWritable: false },
+    { pubkey: buyerItemAta, isSigner: false, isWritable: true },
+    { pubkey: TOKEN_2022_PROGRAM_ID, isSigner: false, isWritable: false },
+    { pubkey: SystemProgram.programId, isSigner: false, isWritable: false },
+    // remaining: the buyer's skill token accounts (ATAs), one per required skill.
+    ...args.requiredSkills.map((m) => ({
+      pubkey: getAssociatedTokenAddressSync(m, args.buyer, false, TOKEN_2022_PROGRAM_ID),
+      isSigner: false,
+      isWritable: false,
+    })),
+  ];
+  return new TransactionInstruction({ programId: programId(), keys, data: DISC_BUY });
+}

--- a/packages/core/src/notes/balance.spec.ts
+++ b/packages/core/src/notes/balance.spec.ts
@@ -1,0 +1,60 @@
+import { describe, it, expect, vi, beforeEach } from "vitest";
+import { PublicKey } from "@solana/web3.js";
+import { getBalance } from "./balance.js";
+import { TokenAccountNotFoundError } from "@solana/spl-token";
+import * as splToken from "@solana/spl-token";
+
+vi.mock("@solana/spl-token", async (importOriginal) => {
+  const actual = await importOriginal<typeof import("@solana/spl-token")>();
+  const { PublicKey } = await import("@solana/web3.js");
+  return {
+    ...actual,
+    getAssociatedTokenAddressSync: vi.fn().mockReturnValue(new PublicKey("11111111111111111111111111111111")),
+    getAccount: vi.fn(),
+  };
+});
+
+describe("notes/balance", () => {
+  let mockConn: any;
+
+  beforeEach(() => {
+    mockConn = {};
+    vi.clearAllMocks();
+  });
+
+  it("should return the balance when account exists", async () => {
+    vi.mocked(splToken.getAccount).mockResolvedValueOnce({ amount: 10n } as any);
+    
+    const balance = await getBalance(
+      mockConn,
+      new PublicKey("11111111111111111111111111111111"),
+      new PublicKey("11111111111111111111111111111111")
+    );
+    
+    expect(balance).toBe(10n);
+  });
+
+  it("should return 0n if account is not found", async () => {
+    vi.mocked(splToken.getAccount).mockRejectedValueOnce(new TokenAccountNotFoundError());
+    
+    const balance = await getBalance(
+      mockConn,
+      new PublicKey("11111111111111111111111111111111"),
+      new PublicKey("11111111111111111111111111111111")
+    );
+    
+    expect(balance).toBe(0n);
+  });
+
+  it("should throw for other errors", async () => {
+    vi.mocked(splToken.getAccount).mockRejectedValueOnce(new Error("RPC Error"));
+    
+    await expect(
+      getBalance(
+        mockConn,
+        new PublicKey("11111111111111111111111111111111"),
+        new PublicKey("11111111111111111111111111111111")
+      )
+    ).rejects.toThrow("RPC Error");
+  });
+});

--- a/packages/core/src/notes/balance.ts
+++ b/packages/core/src/notes/balance.ts
@@ -1,0 +1,32 @@
+// Check token balance for gating (notes, reputation, etc).
+
+import { PublicKey, type Connection } from "@solana/web3.js";
+import {
+  getAssociatedTokenAddressSync,
+  getAccount,
+  TokenAccountNotFoundError,
+} from "@solana/spl-token";
+
+const TOKEN_2022_PROGRAM_ID = new PublicKey("TokenzQdBNbLqP5VEhdkAS6EPFLC1PHnBqCXEpPvZeJ");
+
+export async function getBalance(
+  conn: Connection,
+  skillMint: PublicKey,
+  wallet: PublicKey,
+): Promise<bigint> {
+  try {
+    const ata = getAssociatedTokenAddressSync(
+      skillMint,
+      wallet,
+      false,
+      TOKEN_2022_PROGRAM_ID,
+    );
+    const account = await getAccount(conn, ata, "confirmed", TOKEN_2022_PROGRAM_ID);
+    return account.amount;
+  } catch (err) {
+    if (err instanceof TokenAccountNotFoundError) {
+      return 0n;
+    }
+    throw err;
+  }
+}

--- a/packages/core/src/notes/index.ts
+++ b/packages/core/src/notes/index.ts
@@ -1,0 +1,3 @@
+export { postNote, readNotes, deleteNote, postAgentNote, readAgentNotes } from "./notes.js";
+export type { PostNoteInput, ReadNotesOptions, PostAgentNoteInput } from "./notes.js";
+export { getBalance } from "./balance.js";

--- a/packages/core/src/notes/notes.spec.ts
+++ b/packages/core/src/notes/notes.spec.ts
@@ -1,0 +1,152 @@
+import { describe, it, expect, vi, beforeEach } from "vitest";
+import { Connection, Keypair } from "@solana/web3.js";
+import { postNote, readNotes, deleteNote, postAgentNote, readAgentNotes } from "./notes.js";
+import * as chain from "../core/chain.js";
+import * as balance from "./balance.js";
+
+const AUTHOR = "11111111111111111111111111111111";
+
+vi.mock("../core/chain.js", () => ({
+  readRows: vi.fn().mockResolvedValue([{ id: "note1" }]),
+  writeRow: vi.fn().mockResolvedValue("mockWriteSig"),
+  ensureTable: vi.fn().mockResolvedValue(null),
+  signerAddress: vi.fn().mockResolvedValue("11111111111111111111111111111111"),
+}));
+
+vi.mock("./balance.js", () => ({
+  getBalance: vi.fn(),
+}));
+
+describe("notes/notes", () => {
+  let mockConn: any;
+  let signer: Keypair;
+
+  beforeEach(() => {
+    mockConn = {};
+    signer = Keypair.generate();
+    vi.clearAllMocks();
+  });
+
+  it("should post a note if balance is >= 1", async () => {
+    vi.mocked(balance.getBalance).mockResolvedValue(1n);
+
+    const noteId = await postNote(mockConn as any, signer, {
+      collectionId: "SkillsCollection",
+      skillId: "11111111111111111111111111111111",
+      text: "This is a test note",
+    });
+
+    expect(noteId).toContain("note:11111111111111111111111111111111:");
+    expect(chain.writeRow).toHaveBeenCalled();
+  });
+
+  it("writes a trimmed row: no subject/isSelfNote, optional meta included", async () => {
+    vi.mocked(balance.getBalance).mockResolvedValue(1n);
+
+    await postNote(mockConn as any, signer, {
+      collectionId: "SkillsCollection",
+      skillId: "11111111111111111111111111111111",
+      text: "hi",
+      meta: { tag: "v1" },
+    });
+
+    const rowJson = vi.mocked(chain.writeRow).mock.calls[0][2] as string;
+    const row = JSON.parse(rowJson);
+    expect(row).not.toHaveProperty("subject"); // table key, not stored
+    expect(row).not.toHaveProperty("isSelfNote"); // derived on read
+    expect(row.meta).toEqual({ tag: "v1" });
+    expect(row).toHaveProperty("text", "hi");
+  });
+
+  it("should throw if balance is < 1", async () => {
+    vi.mocked(balance.getBalance).mockResolvedValue(0n);
+
+    await expect(
+      postNote(mockConn as any, signer, {
+        collectionId: "SkillsCollection",
+        skillId: "11111111111111111111111111111111",
+        text: "This is a test note",
+      })
+    ).rejects.toThrow(/Must own ≥1 skill token/);
+  });
+
+  it("should read notes and derive subject + isSelfNote", async () => {
+    const skillId = "11111111111111111111111111111111";
+    vi.mocked(chain.readRows).mockResolvedValueOnce([
+      { id: "note1", author: "someBuyer", text: "great", timestamp: 1 },
+    ] as any);
+
+    const notes = await readNotes("SkillsCollection", skillId);
+    expect(notes.length).toBe(1);
+    expect(notes[0].id).toBe("note1");
+    expect(notes[0].subject).toBe(skillId); // derived from the table key
+    expect(notes[0].isSelfNote).toBe(false); // author != subject
+    expect(chain.readRows).toHaveBeenCalled();
+  });
+
+  it("should throw on deleteNote for now", async () => {
+    await expect(deleteNote(mockConn as any, signer, "note1")).rejects.toThrow("not yet implemented");
+  });
+
+  // ===== agent notes =====
+
+  it("self-note: author == agentWallet writes without a balance check", async () => {
+    const noteId = await postAgentNote(mockConn as any, signer, {
+      agentWallet: AUTHOR, // signer is the owner → self-note
+      text: "I built these",
+    });
+
+    expect(noteId).toContain(`note:${AUTHOR}:`);
+    expect(chain.writeRow).toHaveBeenCalled();
+    expect(balance.getBalance).not.toHaveBeenCalled(); // owner skips the gate
+  });
+
+  it("comment on agent: allowed when author holds one of the agent's skills", async () => {
+    vi.mocked(balance.getBalance).mockResolvedValue(1n);
+    const source = {
+      listSkills: vi.fn().mockResolvedValue([
+        { id: AUTHOR, creator: "agentWalletX" },
+      ]),
+    };
+
+    const noteId = await postAgentNote(mockConn as any, signer, {
+      agentWallet: "agentWalletX",
+      text: "great agent",
+      source,
+    });
+
+    expect(noteId).toContain(`note:${AUTHOR}:`);
+    expect(chain.writeRow).toHaveBeenCalled();
+  });
+
+  it("comment on agent: rejected when author holds none of the agent's skills", async () => {
+    vi.mocked(balance.getBalance).mockResolvedValue(0n);
+    const source = {
+      listSkills: vi.fn().mockResolvedValue([
+        { id: AUTHOR, creator: "agentWalletX" },
+      ]),
+    };
+
+    await expect(
+      postAgentNote(mockConn as any, signer, {
+        agentWallet: "agentWalletX",
+        text: "spam",
+        source,
+      }),
+    ).rejects.toThrow(/Must hold ≥1 of agentWalletX's skills/);
+  });
+
+  it("readAgentNotes selfOnly returns only the owner's posts, newest first", async () => {
+    vi.mocked(chain.readRows).mockResolvedValue([
+      { id: "n1", author: "agentX", timestamp: 100 },
+      { id: "n2", author: "someoneElse", timestamp: 200 },
+      { id: "n3", author: "agentX", timestamp: 300 },
+    ] as any);
+
+    const all = await readAgentNotes("agentX");
+    expect(all.map((n) => n.id)).toEqual(["n3", "n2", "n1"]); // sorted desc
+
+    const self = await readAgentNotes("agentX", { selfOnly: true });
+    expect(self.map((n) => n.id)).toEqual(["n3", "n1"]);
+  });
+});

--- a/packages/core/src/notes/notes.ts
+++ b/packages/core/src/notes/notes.ts
@@ -1,0 +1,210 @@
+// On-chain notes (notes.md). Two subjects, same row shape:
+//   - notes/[skillNFT]   — comments on a skill, gated by holding the skill token
+//   - notes/[agentWallet] — comments on an agent + the owner's self-notes (blog)
+//
+// Read: anyone (public tables keyed by subject address).
+// Write gate (notes.md §2): see postNote / postAgentNote. Gates are CLIENT-SIDE
+// — the deployed IQ contract's native gate can't verify a Token-2022 mint (see
+// the long note in postNote), and "holds any of an agent's skills" is a multi-
+// mint OR the single-mint gate can't express anyway.
+
+import { PublicKey, type Connection } from "@solana/web3.js";
+import type { SignerInput } from "@iqlabs-official/solana-sdk/utils";
+import {
+  readRows,
+  writeRow,
+  ensureTable,
+  signerAddress,
+} from "../core/chain.js";
+import { reviewsHint, reviewsAgentHint, REVIEW_COLUMNS } from "../core/seed.js";
+import { dasSource, type SkillSource } from "../core/skillSource.js";
+import type { Note, Row } from "../core/types.js";
+import { getBalance } from "./balance.js";
+
+/** The stored row shape — derived fields (subject/isSelfNote) are NOT included. */
+interface StoredNote {
+  id: string;
+  author: string;
+  text: string;
+  gitLink?: string;
+  timestamp: number;
+  meta?: Record<string, unknown>;
+}
+
+/** Build the trimmed row + a collision-resistant id (author:ts:nonce). */
+function buildNote(
+  author: string,
+  text: string,
+  gitLink?: string,
+  meta?: Record<string, unknown>,
+): StoredNote {
+  const nonce = Math.random().toString(36).slice(2, 8);
+  const row: StoredNote = {
+    id: `note:${author}:${Date.now()}:${nonce}`,
+    author,
+    text,
+    timestamp: Date.now(),
+  };
+  if (gitLink !== undefined) row.gitLink = gitLink;
+  if (meta !== undefined) row.meta = meta;
+  return row;
+}
+
+/**
+ * Map stored rows → Note[], deriving the non-stored fields from the subject
+ * (the table key): `subject` = subject, `isSelfNote` = author == subject.
+ * Drops non-row entries (metadata shapes from readTableRows have no `id`).
+ */
+function hydrateNotes(rows: Row[], subject: string): Note[] {
+  return (rows as unknown as Note[])
+    .filter((n) => typeof n.id === "string")
+    .map((n) => ({ ...n, subject, isSelfNote: n.author === subject }));
+}
+
+export interface PostNoteInput {
+  collectionId: string; // umbrella collection mint (skills / workflows / …)
+  skillId: string; // item NFT mint address (= the table subject, under the collection)
+  text: string;
+  gitLink?: string;
+  meta?: Record<string, unknown>;
+}
+
+export async function postNote(
+  conn: Connection,
+  signer: SignerInput,
+  input: PostNoteInput,
+): Promise<string> {
+  const author = await signerAddress(signer);
+
+  // Write gate: caller must hold ≥1 of the skill's Token-2022 soulbound token
+  // (notes.md §2 — "wallets that hold that skill's token").
+  //
+  // ⚠️ Enforced CLIENT-SIDE only. coding-info §B3 assumed the IQ contract's
+  // native `gate_opt` would enforce this on-chain for free, but that path is
+  // structurally incompatible with Token-2022: the SDK derives the gate ATA with
+  // the LEGACY token program id in the seeds (utils/ata.js), while skill mints
+  // live under the Token-2022 program. The holder's real (2022) ATA address
+  // never matches → resolveSignerAta throws "missing signer_ata" on EVERY write,
+  // even for legit holders, making a natively-gated table unusable. Until the
+  // SDK/contract resolves a Token-2022 ATA (or gates by collection metadata),
+  // the table is open and this check is the guard. An attacker calling writeRow
+  // directly bypasses it — real enforcement needs SDK Token-2022 support.
+  const balance = await getBalance(
+    conn,
+    new PublicKey(input.skillId),
+    new PublicKey(author),
+  );
+  if (balance < 1n) {
+    throw new Error(`Must own ≥1 skill token to post note (balance: ${balance})`);
+  }
+
+  const hint = reviewsHint(input.collectionId, input.skillId);
+  const note = buildNote(author, input.text, input.gitLink, input.meta);
+
+  // Open table (no native gate — see the Token-2022 incompatibility above).
+  await ensureTable(signer, hint, REVIEW_COLUMNS, "id");
+  await writeRow(signer, hint, JSON.stringify(note));
+  return note.id;
+}
+
+export interface ReadNotesOptions {
+  limit?: number;
+}
+
+export async function readNotes(
+  collectionId: string,
+  skillId: string,
+  options?: ReadNotesOptions,
+): Promise<Note[]> {
+  const hint = reviewsHint(collectionId, skillId);
+  const rows = await readRows(hint, { limit: options?.limit ?? 100 });
+  return hydrateNotes(rows, skillId);
+}
+
+// ===== Agent notes (notes/[agentWallet]) — self-notes + others' comments =====
+
+export interface PostAgentNoteInput {
+  agentWallet: string; // subject — the agent's wallet (the notes/[agentWallet] table key)
+  text: string;
+  gitLink?: string;
+  meta?: Record<string, unknown>;
+  /** Skill source to enumerate the agent's skills for the comment gate. */
+  source?: SkillSource;
+}
+
+/**
+ * Write a note onto an agent's profile (notes.md §1/§2/§3).
+ *
+ * Two flavors, told apart by author (notes.md §3 — "no flag, derive from
+ * author"):
+ *   - SELF-NOTE  (author == agentWallet): the owner posting on their own
+ *     profile ("I built this", blog). Always allowed.
+ *   - COMMENT    (author != agentWallet): someone else. Gated per notes.md §2's
+ *     open decision (§4) — we require the author to hold ≥1 of the agent's
+ *     published skills (sybil bar: commenters must have bought in, same
+ *     rationale as skill comments). If the agent has no skills, only self-notes
+ *     are possible.
+ *
+ * The gate is CLIENT-SIDE (see the module header for why a native gate can't
+ * apply here). Returns the note id.
+ */
+export async function postAgentNote(
+  conn: Connection,
+  signer: SignerInput,
+  input: PostAgentNoteInput,
+): Promise<string> {
+  const author = await signerAddress(signer);
+  const isSelfNote = author === input.agentWallet;
+
+  if (!isSelfNote) {
+    // Comment gate: must hold ≥1 of any skill this agent created.
+    const source = input.source ?? dasSource;
+    const agentSkills = (await source.listSkills()).filter(
+      (s) => s.creator === input.agentWallet,
+    );
+    const authorPk = new PublicKey(author);
+    const balances = await Promise.all(
+      agentSkills.map((s) => getBalance(conn, new PublicKey(s.id), authorPk)),
+    );
+    const holdsAny = balances.some((b) => b >= 1n);
+    if (!holdsAny) {
+      throw new Error(
+        `Must hold ≥1 of ${input.agentWallet}'s skills to comment on this agent`,
+      );
+    }
+  }
+
+  const hint = reviewsAgentHint(input.agentWallet);
+  const note = buildNote(author, input.text, input.gitLink, input.meta);
+
+  // Open table (no native gate — see the module header).
+  await ensureTable(signer, hint, REVIEW_COLUMNS, "id");
+  await writeRow(signer, hint, JSON.stringify(note));
+  return note.id;
+}
+
+/**
+ * Read an agent's notes (self-notes + comments). `selfOnly` returns just the
+ * owner's posts (the blog view); default returns everything, newest first.
+ */
+export async function readAgentNotes(
+  agentWallet: string,
+  options?: ReadNotesOptions & { selfOnly?: boolean },
+): Promise<Note[]> {
+  const hint = reviewsAgentHint(agentWallet);
+  const rows = await readRows(hint, { limit: options?.limit ?? 100 });
+  let notes = hydrateNotes(rows, agentWallet); // subject + isSelfNote derived
+  if (options?.selfOnly) {
+    notes = notes.filter((n) => n.isSelfNote);
+  }
+  return notes.sort((a, b) => b.timestamp - a.timestamp);
+}
+
+export async function deleteNote(
+  conn: Connection,
+  signer: SignerInput,
+  noteId: string,
+): Promise<void> {
+  // Future: implement via deletion marker row or separate deletion table
+  throw new Error("deleteNote not yet implemented");
+}

--- a/packages/core/src/reputation/index.ts
+++ b/packages/core/src/reputation/index.ts
@@ -1,0 +1,1 @@
+export { getReputation, getLeaderboard } from "./reputation.js";

--- a/packages/core/src/reputation/reputation.spec.ts
+++ b/packages/core/src/reputation/reputation.spec.ts
@@ -1,0 +1,85 @@
+import { describe, it, expect, vi, beforeEach, afterEach } from "vitest";
+import { getReputation, getLeaderboard } from "./reputation.js";
+import * as chain from "../core/chain.js";
+import { dasSource } from "../core/skillSource.js";
+import { getMintSupply } from "../nft/token2022.js";
+import { reviewsHint, collectionFor } from "../core/seed.js";
+
+vi.mock("../core/chain.js", () => ({
+  readRows: vi.fn(),
+}));
+
+// Skill enumeration comes from the DAS collection scan; each test stubs it.
+vi.mock("../core/skillSource.js", () => ({
+  dasSource: { listSkills: vi.fn() },
+}));
+
+// Live supply is hydrated from the mint; each test sets its own id→supply map.
+vi.mock("../nft/token2022.js", () => ({
+  getMintSupply: vi.fn(),
+}));
+
+function mockSupply(map: Record<string, number>) {
+  vi.mocked(getMintSupply).mockImplementation((_conn: any, id: string) =>
+    Promise.resolve(map[id] ?? 0),
+  );
+}
+
+describe("reputation/reputation", () => {
+  let mockConn: any;
+  const origEnv = { ...process.env };
+
+  beforeEach(() => {
+    mockConn = {};
+    vi.clearAllMocks();
+    // No collection configured → collectionFor returns "" → review key is
+    // "reviews::<id>". That's a stable key the test reads back below.
+    delete process.env.AGENTNET_SKILLS_COLLECTION_PUBKEY;
+    delete process.env.AGENTNET_WORKFLOWS_COLLECTION_PUBKEY;
+  });
+
+  afterEach(() => {
+    process.env = { ...origEnv };
+  });
+
+  it("computes reputation from skills (supply) + reviews (count), not a score", async () => {
+    vi.mocked(dasSource.listSkills).mockResolvedValue([
+      { id: "skill1", type: "skill", creator: "walletA", supply: 5 } as any,
+      { id: "skill2", type: "skill", creator: "walletA", supply: 2 } as any,
+      { id: "skill3", type: "skill", creator: "walletB", supply: 10 } as any,
+    ]);
+    // Review hint uses the configured collection — build it the same way the code
+    // does, so it matches regardless of the default collection id.
+    const coll = collectionFor("skill");
+    vi.mocked(chain.readRows).mockImplementation(async (hint: string) => {
+      if (hint === reviewsHint(coll, "skill1")) return [{ id: "n1" }, { id: "n2" }] as any;
+      if (hint === reviewsHint(coll, "skill2")) return [{ id: "n3" }] as any;
+      return [];
+    });
+    mockSupply({ skill1: 5, skill2: 2, skill3: 10 });
+
+    const rep = await getReputation(mockConn, "walletA");
+
+    // Standing = totalSupply (fame); notes informational.
+    expect(rep.wallet).toBe("walletA");
+    expect(rep.skillsPublished).toBe(2);
+    expect(rep.totalSupply).toBe(7);
+    expect(rep.notesReceived).toBe(3);
+    expect(rep).not.toHaveProperty("score");
+  });
+
+  it("generates a leaderboard ranked by totalSupply", async () => {
+    vi.mocked(dasSource.listSkills).mockResolvedValue([
+      { id: "skill1", type: "skill", creator: "walletA", supply: 5 } as any,
+      { id: "skill2", type: "skill", creator: "walletB", supply: 10 } as any,
+    ]);
+    vi.mocked(chain.readRows).mockResolvedValue([] as any);
+    mockSupply({ skill1: 5, skill2: 10 });
+
+    const leaderboard = await getLeaderboard(mockConn, 10);
+
+    expect(leaderboard.length).toBe(2);
+    expect(leaderboard[0].wallet).toBe("walletB"); // totalSupply 10
+    expect(leaderboard[1].wallet).toBe("walletA"); // totalSupply 5
+  });
+});

--- a/packages/core/src/reputation/reputation.ts
+++ b/packages/core/src/reputation/reputation.ts
@@ -1,0 +1,90 @@
+// Agent reputation. Per the spec this is NOT a stored/computed score:
+//   - notes.md: "Not a rating/score — just text written on-chain"
+//   - skill-nft-structure.md: "Famous agent = sum of `supply` across the skills
+//     that agent created"
+// So an agent's standing IS `totalSupply` (sum of their skills' on-chain supply),
+// derived live from the mints + a review count. There is NO reputation table —
+// nothing to write or keep in sync; every read recomputes from the chain.
+
+import type { Connection } from "@solana/web3.js";
+import { readRows } from "../core/chain.js";
+import { reviewsHint, collectionFor } from "../core/seed.js";
+import { dasSource, type SkillSource } from "../core/skillSource.js";
+import type { Reputation, Skill } from "../core/types.js";
+import { getMintSupply } from "../nft/token2022.js";
+
+export async function getReputation(
+  conn: Connection,
+  wallet: string,
+  source: SkillSource = dasSource,
+): Promise<Reputation> {
+  // Enumerate skills via the collection scan, filter by creator.
+  const mySkills = (await source.listSkills()).filter(
+    (s) => s.creator === wallet,
+  );
+
+  const skillsPublished = mySkills.length;
+  // totalSupply = the documented "fame" metric, read live from each mint.
+  const supplies = await Promise.all(
+    mySkills.map((s) => getMintSupply(conn, s.id)),
+  );
+  const totalSupply = supplies.reduce((acc, n) => acc + n, 0);
+
+  // Count reviews across all creator's skills (informational, not a score).
+  let notesReceived = 0;
+  for (const skill of mySkills) {
+    const reviews = await readRows(reviewsHint(collectionFor(skill.type), skill.id), { limit: 1000 });
+    notesReceived += reviews.filter((n) => typeof n.id === "string").length;
+  }
+
+  return {
+    wallet,
+    skillsPublished,
+    totalSupply,
+    notesReceived,
+    updatedAt: Date.now(),
+  };
+}
+
+export async function getLeaderboard(
+  conn: Connection,
+  limit = 20,
+  source: SkillSource = dasSource,
+): Promise<Reputation[]> {
+  // Enumerate skills via the collection scan, group by creator. Drop entries
+  // with no creator so we don't group under undefined.
+  const skills = (await source.listSkills()).filter(
+    (s) => typeof s.creator === "string",
+  );
+
+  // Group by creator
+  const creatorMap = new Map<string, Skill[]>();
+  for (const skill of skills) {
+    if (!creatorMap.has(skill.creator)) {
+      creatorMap.set(skill.creator, []);
+    }
+    creatorMap.get(skill.creator)!.push(skill);
+  }
+
+  // Rank by totalSupply (the documented fame metric). Reviews omitted here to
+  // avoid N+1 reads — they're informational, not part of ranking anyway.
+  const entries: Reputation[] = [];
+  for (const [wallet, creatorSkills] of creatorMap.entries()) {
+    const skillsPublished = creatorSkills.length;
+    const supplies = await Promise.all(
+      creatorSkills.map((s) => getMintSupply(conn, s.id)),
+    );
+    const totalSupply = supplies.reduce((acc, n) => acc + n, 0);
+    entries.push({
+      wallet,
+      skillsPublished,
+      totalSupply,
+      notesReceived: 0,
+      updatedAt: Date.now(),
+    });
+  }
+
+  return entries
+    .sort((a, b) => b.totalSupply - a.totalSupply)
+    .slice(0, limit);
+}

--- a/packages/core/src/search/index.ts
+++ b/packages/core/src/search/index.ts
@@ -1,0 +1,2 @@
+export { searchSkills } from "./search.js";
+export type { SearchFilters, SortBy, SearchOptions } from "./search.js";

--- a/packages/core/src/search/search.spec.ts
+++ b/packages/core/src/search/search.spec.ts
@@ -1,0 +1,123 @@
+import { describe, it, expect, vi, beforeEach } from "vitest";
+import { searchSkills } from "./search.js";
+import type { SkillSource } from "../core/skillSource.js";
+
+// Live supply is hydrated from the mint; echo the per-id supply set below.
+const SUPPLY_BY_ID: Record<string, number> = { A: 10, B: 50, C: 5 };
+// On-chain trait override used by the verifyTraits test.
+const META_BY_ID: Record<string, { category?: string; hashtags?: string[] }> = {};
+vi.mock("../nft/token2022.js", () => ({
+  getMintSupply: vi.fn((_conn: any, id: string) =>
+    Promise.resolve(SUPPLY_BY_ID[id] ?? 0),
+  ),
+  readSkillMintMetadata: vi.fn((_conn: any, id: string) =>
+    Promise.resolve(META_BY_ID[id] ?? null),
+  ),
+}));
+
+const mockSkills = [
+  { id: "A", name: "Apple", description: "red fruit", category: "food", hashtags: ["sweet"], supply: 10, createdAt: 100, type: "skill" },
+  { id: "B", name: "Banana", description: "yellow fruit", category: "food", hashtags: ["sweet", "potassium"], supply: 50, createdAt: 200, type: "skill" },
+  { id: "C", name: "Carrot", description: "orange veg", category: "veg", hashtags: ["crunchy"], supply: 5, createdAt: 300, type: "workflow" },
+];
+
+// A fresh copy each call (search mutates supply/traits in place during hydration).
+const fakeSource = (): SkillSource => ({
+  listSkills: vi.fn().mockResolvedValue(mockSkills.map((s) => ({ ...s }))),
+});
+
+describe("search/search", () => {
+  let mockConn: any;
+
+  beforeEach(() => {
+    mockConn = {}; // Connection is not actually used in our mock implementation
+    vi.clearAllMocks();
+  });
+
+  it("should return all skills without filters, sorted by supply by default", async () => {
+    const results = await searchSkills(mockConn, { source: fakeSource() });
+
+    expect(results.length).toBe(3);
+    // sorted by supply descending: 50, 10, 5
+    expect(results[0].id).toBe("B");
+    expect(results[1].id).toBe("A");
+    expect(results[2].id).toBe("C");
+  });
+
+  it("should filter by keyword in name or description", async () => {
+    const results = await searchSkills(mockConn, { source: fakeSource(), filters: { keyword: "fruit" } });
+
+    expect(results.length).toBe(2);
+    expect(results.some((s) => s.id === "A")).toBe(true);
+    expect(results.some((s) => s.id === "B")).toBe(true);
+  });
+
+  it("should filter by category", async () => {
+    const results = await searchSkills(mockConn, { source: fakeSource(), filters: { category: "food" } });
+
+    expect(results.length).toBe(2);
+    expect(results.some((s) => s.id === "A")).toBe(true);
+    expect(results.some((s) => s.id === "B")).toBe(true);
+  });
+
+  it("should filter by hashtags", async () => {
+    const results = await searchSkills(mockConn, { source: fakeSource(), filters: { hashtags: ["crunchy"] } });
+    expect(results.length).toBe(1);
+    expect(results[0].id).toBe("C");
+  });
+
+  it("should filter by type", async () => {
+    const skills = await searchSkills(mockConn, { source: fakeSource(), filters: { type: "skill" } });
+    expect(skills.length).toBe(2);
+    expect(skills.map((s) => s.id)).toEqual(expect.arrayContaining(["A", "B"]));
+
+    const workflows = await searchSkills(mockConn, { source: fakeSource(), filters: { type: "workflow" } });
+    expect(workflows.length).toBe(1);
+    expect(workflows[0].id).toBe("C");
+  });
+
+  it("should sort by name", async () => {
+    const results = await searchSkills(mockConn, { source: fakeSource(), sortBy: "name" });
+
+    expect(results.length).toBe(3);
+    expect(results[0].id).toBe("A");
+    expect(results[1].id).toBe("B");
+    expect(results[2].id).toBe("C");
+  });
+
+  it("should sort by recent", async () => {
+    const results = await searchSkills(mockConn, { source: fakeSource(), sortBy: "recent" });
+
+    expect(results.length).toBe(3);
+    // descending by createdAt: 300, 200, 100
+    expect(results[0].id).toBe("C");
+    expect(results[1].id).toBe("B");
+    expect(results[2].id).toBe("A");
+  });
+
+  it("uses the provided source for enumeration", async () => {
+    const source = { listSkills: vi.fn().mockResolvedValue([{ ...mockSkills[2] }]) };
+
+    const results = await searchSkills(mockConn, { source });
+
+    expect(source.listSkills).toHaveBeenCalled();
+    expect(results.map((s) => s.id)).toEqual(["C"]);
+  });
+
+  it("verifyTraits re-reads category from the mint, overriding the stale snapshot", async () => {
+    // Chain says A is actually "tech", not the snapshot "food".
+    META_BY_ID["A"] = { category: "tech", hashtags: ["sweet"] };
+
+    const cached = await searchSkills(mockConn, { source: fakeSource(), filters: { category: "tech" } });
+    expect(cached.length).toBe(0); // snapshot copy still says "food"
+
+    const verified = await searchSkills(mockConn, {
+      source: fakeSource(),
+      filters: { category: "tech" },
+      verifyTraits: true,
+    });
+    expect(verified.map((s) => s.id)).toEqual(["A"]);
+
+    delete META_BY_ID["A"];
+  });
+});

--- a/packages/core/src/search/search.ts
+++ b/packages/core/src/search/search.ts
@@ -1,0 +1,123 @@
+// Search skills by keyword, category, hashtags; sort by supply or recency.
+//
+// Enumeration goes through a SkillSource (core/skillSource.ts) — by default the
+// DAS collection scan, swappable for a gateway enumerator later. The mint stays
+// the source of truth: `supply` is always hydrated from the mint, and with
+// `verifyTraits` category/hashtags are re-read from on-chain metadata instead of
+// the enumerator's snapshot.
+//
+// Per search.md the full design also has a SEMANTIC layer that maps a
+// vocabulary-mismatch query onto an existing category/hashtag (e.g. "hotdog" →
+// #convenience-store) via an off-chain embedding index (search.md §3). That
+// embedding index is a separate off-chain component and is NOT built here — this
+// module implements the on-chain half: trait filter + supply sort. Keyword match
+// below is literal substring, not semantic.
+
+import type { Connection } from "@solana/web3.js";
+import type { Skill } from "../core/types.js";
+import { dasSource, type SkillSource } from "../core/skillSource.js";
+import { getMintSupply, readSkillMintMetadata } from "../nft/token2022.js";
+
+export interface SearchFilters {
+  keyword?: string;
+  category?: string;
+  hashtags?: string[];
+  type?: "skill" | "workflow";
+}
+
+export type SortBy = "supply" | "name" | "recent";
+
+export interface SearchOptions {
+  filters?: SearchFilters;
+  sortBy?: SortBy;
+  limit?: number;
+  /** Enumeration source. Defaults to the DAS collection scan. */
+  source?: SkillSource;
+  /**
+   * Re-read category/hashtags from each mint's on-chain TokenMetadata before
+   * filtering, instead of trusting the enumerator's snapshot. Costs one extra
+   * RPC per candidate; use when the snapshot may be stale relative to the chain.
+   */
+  verifyTraits?: boolean;
+}
+
+export async function searchSkills(
+  conn: Connection,
+  options?: SearchOptions,
+): Promise<Skill[]> {
+  const limit = options?.limit ?? 50;
+  const sortBy = options?.sortBy ?? "supply";
+  const filters = options?.filters ?? {};
+  // Enumerate via the DAS collection scan (the only source). Returns an empty
+  // list until the collections are minted / devnet-proven (see skillSource.ts).
+  const source = options?.source ?? dasSource;
+
+  let skills = await source.listSkills();
+
+  // Optionally trust the chain over the cache for traits (category/hashtags).
+  if (options?.verifyTraits) {
+    await Promise.all(
+      skills.map(async (s) => {
+        const md = await readSkillMintMetadata(conn, s.id);
+        if (md) {
+          s.category = md.category ?? s.category;
+          s.hashtags = md.hashtags ?? s.hashtags;
+        }
+      }),
+    );
+  }
+
+  // Filter by keyword (name + description). Fields may be absent on a sparse
+  // row, so coalesce before lowercasing.
+  if (filters.keyword) {
+    const kw = filters.keyword.toLowerCase();
+    skills = skills.filter(
+      (s) =>
+        (s.name ?? "").toLowerCase().includes(kw) ||
+        (s.description ?? "").toLowerCase().includes(kw),
+    );
+  }
+
+  // Filter by category (exact)
+  if (filters.category) {
+    skills = skills.filter((s) => s.category === filters.category);
+  }
+
+  // Filter by hashtags (any match)
+  if (filters.hashtags && filters.hashtags.length > 0) {
+    skills = skills.filter((s) => {
+      const skillHashtags = s.hashtags ?? [];
+      return filters.hashtags!.some((tag) => skillHashtags.includes(tag));
+    });
+  }
+
+  // Filter by type
+  if (filters.type) {
+    skills = skills.filter((s) => {
+      // If type is not explicitly set in frontmatter, we treat it as a "skill"
+      const t = s.type ?? "skill";
+      return t === filters.type;
+    });
+  }
+
+  // Hydrate live supply from the mint (indexed supply is stale — always 0).
+  // Done after filtering so we only fetch for the matched set.
+  if (sortBy === "supply") {
+    await Promise.all(
+      skills.map(async (s) => {
+        s.supply = await getMintSupply(conn, s.id);
+      }),
+    );
+  }
+
+  // Sort
+  if (sortBy === "supply") {
+    skills.sort((a, b) => Number(b.supply) - Number(a.supply));
+  } else if (sortBy === "name") {
+    skills.sort((a, b) => (a.name ?? "").localeCompare(b.name ?? ""));
+  } else if (sortBy === "recent") {
+    skills.sort((a, b) => b.createdAt - a.createdAt);
+  }
+
+  return skills.slice(0, limit);
+}

--- a/packages/core/src/skill-market/index.spec.ts
+++ b/packages/core/src/skill-market/index.spec.ts
@@ -1,0 +1,75 @@
+import { describe, it, expect, vi, beforeEach } from "vitest";
+import { getAgentNetTools, handleToolCall } from "./index.js";
+import { searchSkills } from "../search/search.js";
+import { buySkill } from "../nft/skill.js";
+import { Keypair } from "@solana/web3.js";
+
+vi.mock("../search/search.js", () => ({
+  searchSkills: vi.fn(),
+}));
+
+vi.mock("../nft/skill.js", () => ({
+  buySkill: vi.fn(),
+}));
+
+vi.mock("../core/chain.js", () => ({
+  signerAddress: vi.fn().mockResolvedValue("mockSignerAddress"),
+}));
+
+describe("skill-market", () => {
+  let mockConn: any;
+  let signer: Keypair;
+
+  beforeEach(() => {
+    mockConn = {};
+    signer = Keypair.generate();
+    vi.clearAllMocks();
+  });
+
+  it("should list available tools", () => {
+    const tools = getAgentNetTools();
+    expect(tools).toHaveLength(2);
+    expect(tools.map(t => t.name)).toEqual(["search_skills", "buy_skill"]);
+  });
+
+  it("should handle search_skills tool call and return empty if no results", async () => {
+    vi.mocked(searchSkills).mockResolvedValue([]);
+    const result = await handleToolCall(mockConn, signer, "defaultCreator", "search_skills", {});
+    expect(result.content[0].text).toContain("No matching skills found");
+    expect(searchSkills).toHaveBeenCalledWith(mockConn, { filters: { keyword: undefined, category: undefined, type: undefined } });
+  });
+
+  it("should handle search_skills with results", async () => {
+    vi.mocked(searchSkills).mockResolvedValue([
+      { id: "skill1", name: "React", description: "desc", creator: "creator", category: "frontend", type: "skill", supply: 10, uriTxid: "tx1", createdAt: 100 }
+    ]);
+    const result = await handleToolCall(mockConn, signer, "defaultCreator", "search_skills", { keyword: "React", type: "skill" });
+    expect(result.content[0].text).toContain("Found 1 results");
+    expect(result.content[0].text).toContain("skill1");
+    expect(searchSkills).toHaveBeenCalledWith(mockConn, { filters: { keyword: "React", category: undefined, type: "skill" } });
+  });
+
+  it("should handle buy_skill tool call", async () => {
+    vi.mocked(buySkill).mockResolvedValue("mockTxSig");
+    const result = await handleToolCall(mockConn, signer, "defaultCreator", "buy_skill", { skillId: "skill1" });
+    expect(result.content[0].text).toContain("Successfully purchased");
+    expect(result.content[0].text).toContain("mockTxSig");
+    // Price is read from the item's on-chain config now — the client doesn't pass it.
+    expect(buySkill).toHaveBeenCalledWith(mockConn, signer, {
+      skillId: "skill1",
+      buyerWallet: "mockSignerAddress",
+      creatorWallet: "defaultCreator",
+    });
+  });
+
+  it("should handle buy_skill errors", async () => {
+    vi.mocked(buySkill).mockRejectedValue(new Error("Insufficient funds"));
+    const result = await handleToolCall(mockConn, signer, "defaultCreator", "buy_skill", { skillId: "skill1" });
+    expect(result.isError).toBe(true);
+    expect(result.content[0].text).toContain("Insufficient funds");
+  });
+
+  it("should throw on unknown tool", async () => {
+    await expect(handleToolCall(mockConn, signer, "defaultCreator", "unknown_tool", {})).rejects.toThrow("Unknown tool");
+  });
+});

--- a/packages/core/src/skill-market/index.ts
+++ b/packages/core/src/skill-market/index.ts
@@ -1,0 +1,180 @@
+import { Server } from "@modelcontextprotocol/sdk/server/index.js";
+import {
+  CallToolRequestSchema,
+  ListToolsRequestSchema,
+} from "@modelcontextprotocol/sdk/types.js";
+import type { Connection } from "@solana/web3.js";
+import type { SignerInput } from "@iqlabs-official/solana-sdk/utils";
+import { searchSkills } from "../search/search.js";
+import { buySkill } from "../nft/skill.js";
+import { signerAddress } from "../core/chain.js";
+
+/**
+ * Create the tools array for the MCP Server.
+ */
+export function getAgentNetTools() {
+  return [
+    {
+      name: "search_skills",
+      description: "Search the AgentNet marketplace for available skills and workflows.",
+      inputSchema: {
+        type: "object",
+        properties: {
+          keyword: {
+            type: "string",
+            description: "Optional keyword to search in skill names and descriptions.",
+          },
+          category: {
+            type: "string",
+            description: "Optional category to filter skills by (e.g. 'ai', 'frontend').",
+          },
+          type: {
+            type: "string",
+            enum: ["skill", "workflow"],
+            description: "Whether to search for individual skills or workflow bundles.",
+          },
+        },
+      },
+    },
+    {
+      name: "buy_skill",
+      description: "Purchase and equip a skill or workflow from the marketplace.",
+      inputSchema: {
+        type: "object",
+        properties: {
+          skillId: {
+            type: "string",
+            description: "The base58 mint address of the skill to buy.",
+          },
+          price: {
+            type: "number",
+            description: "The price of the skill in lamports. Defaults to 0 if not specified.",
+          },
+          creatorWallet: {
+            type: "string",
+            description: "The wallet address of the skill creator (to receive payment). If unknown, leave undefined.",
+          },
+        },
+        required: ["skillId"],
+      },
+    },
+  ];
+}
+
+/**
+ * Handle a tool call request.
+ */
+export async function handleToolCall(
+  conn: Connection,
+  signer: SignerInput,
+  defaultCreatorWallet: string,
+  name: string,
+  args: any
+) {
+  if (name === "search_skills") {
+    const keyword = args?.keyword as string | undefined;
+    const category = args?.category as string | undefined;
+    const typeFilter = args?.type as "skill" | "workflow" | undefined;
+
+    const skills = await searchSkills(conn, {
+      filters: { keyword, category, type: typeFilter },
+    });
+
+    if (skills.length === 0) {
+      return {
+        content: [{ type: "text", text: "No matching skills found." }],
+      };
+    }
+
+    const formatted = skills
+      .map(
+        (s) =>
+          `- ID: ${s.id}\n  Name: ${s.name}\n  Type: ${s.type ?? "skill"}\n  Category: ${s.category}\n  Creator: ${s.creator}\n  Description: ${s.description}`,
+      )
+      .join("\n\n");
+
+    return {
+      content: [{ type: "text", text: `Found ${skills.length} results:\n\n${formatted}` }],
+    };
+  }
+
+  if (name === "buy_skill") {
+    const skillId = args?.skillId as string;
+    if (!skillId) {
+      throw new Error("Missing required argument: skillId");
+    }
+    
+    // Price is read from the item's on-chain config (set at publish) — the client
+    // doesn't pass it, so it can't be forged.
+    const creatorWallet = (args?.creatorWallet as string) || defaultCreatorWallet;
+    const buyerWallet = await signerAddress(signer);
+
+    try {
+      const txSig = await buySkill(conn, signer, {
+        skillId,
+        buyerWallet,
+        creatorWallet,
+      });
+
+      return {
+        content: [
+          {
+            type: "text",
+            text: `Successfully purchased and equipped skill ${skillId}.\nTransaction Signature: ${txSig}`,
+          },
+        ],
+      };
+    } catch (err: any) {
+      return {
+        isError: true,
+        content: [
+          {
+            type: "text",
+            text: `Failed to buy skill: ${err.message}`,
+          },
+        ],
+      };
+    }
+  }
+
+  throw new Error(`Unknown tool: ${name}`);
+}
+
+/**
+ * Creates an MCP Server instance that exposes AgentNet capabilities to autonomous agents.
+ * The server must be connected to a transport (e.g. StdioServerTransport) by the caller.
+ *
+ * @param conn Solana RPC connection
+ * @param signer The agent's wallet signer (used for executing transactions like buying skills)
+ * @param defaultCreatorWallet The default wallet to send creator shares to (if not known)
+ */
+export function createAgentMcpServer(
+  conn: Connection,
+  signer: SignerInput,
+  defaultCreatorWallet: string,
+): Server {
+  const server = new Server(
+    {
+      name: "agentnet-marketplace",
+      version: "0.0.1",
+    },
+    {
+      capabilities: {
+        tools: {},
+      },
+    },
+  );
+
+  server.setRequestHandler(ListToolsRequestSchema, async () => {
+    return {
+      tools: getAgentNetTools(),
+    };
+  });
+
+  server.setRequestHandler(CallToolRequestSchema, async (request) => {
+    const { name, arguments: args } = request.params;
+    return await handleToolCall(conn, signer, defaultCreatorWallet, name, args);
+  });
+
+  return server;
+}

--- a/packages/core/src/skill-market/skill-shopping.md
+++ b/packages/core/src/skill-market/skill-shopping.md
@@ -1,0 +1,24 @@
+---
+name: skill-shopping
+description: A workflow instructing an agent how to browse and buy skills from the AgentNet marketplace
+type: workflow
+category: system
+hashtags: [shopping, mcp, autonomous]
+---
+
+# Autonomous Skill Shopping
+
+When you are given a task that requires a capability you do not currently possess, you can autonomously search the AgentNet marketplace and acquire the necessary skills. 
+
+## How it works:
+
+1. **Identify the missing capability**: If you are asked to "analyze a solana token" or "post a tweet" and you don't know how to do that, you need a skill.
+2. **Search the marketplace**: Use the `search_skills` tool. 
+   - You can search by `keyword` (e.g. "twitter", "solana") or `category`.
+   - The tool will return a list of available skills with their descriptions, prices, and `id` (mint address).
+3. **Evaluate the options**: Read the descriptions to find the skill that best matches your need. Note the `id` of the skill you want.
+4. **Buy the skill**: Use the `buy_skill` tool with the selected `skillId`.
+   - If the skill has a price, provide it. Otherwise, defaults to 0 (free).
+   - Once purchased, the skill will be soulbound to your wallet, and you will have permanent access to its capabilities.
+
+By following this process, you can continuously expand your capabilities and complete complex workflows autonomously!

--- a/plans/STATUS.md
+++ b/plans/STATUS.md
@@ -1,0 +1,300 @@
+# AgentNet — Status Map
+
+> An honest status for the next developer. Clearly separates **what's verified /
+> what's built but not wired / what doesn't exist yet**. No overclaiming.
+> Explains what the code actually does, file by file.
+
+Last updated: at the first code PR. All `src/` code lands in that PR (before it, the repo had only plans).
+
+---
+
+## 1. At a glance — what actually works
+
+```mermaid
+flowchart TB
+    subgraph DONE["VERIFIED (tests PASS)"]
+        ENGINE["runtime engine<br/>claude + codex spawn·capture·resume"]
+        CRYPTO["session encryption<br/>wallet sig→key, append-only log"]
+        STORE["4 storage backends<br/>local·icloud·custom·gdrive"]
+        UICHAT["VSCode chat UI<br/>chat·session list·delete·model select"]
+    end
+    subgraph WIRED_NOT["BUILT but not wired into the UI"]
+        ONBOARD["onboarding flow<br/>(login·detectCli·STORAGE_OPTIONS all exist)"]
+        CLOUDPICK["storage picker<br/>(gdrive OAuth done, just not called)"]
+    end
+    subgraph MISSING["NOT built yet (no parts either)"]
+        PHANTOM["real Phantom wallet<br/>(currently a fake keypair)"]
+        ONCHAIN["on-chain layer<br/>skill NFT·reputation·session index"]
+        OTHERAPPS["other apps<br/>mobile·standalone CLI·web"]
+    end
+
+    UICHAT -->|"real call"| ENGINE
+    ENGINE --> CRYPTO --> STORE
+    UICHAT -.->|"still fake wallet"| PHANTOM
+    UICHAT -.->|"not called"| ONBOARD
+    ONBOARD -.-> CLOUDPICK
+
+    style DONE fill:#e6ffe6,stroke:#3a3
+    style WIRED_NOT fill:#fff8e0,stroke:#cc3
+    style MISSING fill:#ffe6e6,stroke:#c33
+```
+
+**One-line summary:** the engine, encryption, storage, and chat UI **actually work**.
+What's missing is one chunk — "**a real identity (Phantom) + wiring the onboarding**" —
+and after that, the **on-chain layer**.
+
+---
+
+## 2. What does what — honest, file by file
+
+### 2.1 Engine (`src/runtime/`) — all working, no stubs
+
+| File | What it does | Status |
+|---|---|---|
+| `contract.ts` | The contract (interfaces). Engine and every UI import only this. Defines AgentRuntime, Wallet, StorageAdapter, ChatMessage, etc. As long as this doesn't change, UI/engine can be built independently. | OK |
+| `index.ts` | createRuntime(wallet, storage) — the engine itself. spawn→parse→emit message→auto-encrypt & save on turn end. Messages seen before the sessionId arrives are queued, then flushed. | OK |
+| `spawn.ts` | Spawns claude/codex in two different ways. claude = one long-lived process (stdin stream-json); codex = `exec` per turn, resumed via `exec resume <threadId>`. | OK both |
+| `convert/claude.ts` | claude stream-json line → ChatMessage. system/init=sessionId, assistant=text, result=turn end. | OK |
+| `convert/codex.ts` | codex `exec --json` line → ChatMessage. thread.started=sessionId, item.completed=message, turn.completed=turn end. | OK |
+| `convert/types.ts` | Shared output shape `ParseResult` for both parsers. | OK |
+| `detect.ts` | detectCli() — checks codex/claude install + login status. Meant for onboarding, but the UI doesn't call it yet. | OK (unused) |
+
+### 2.2 Identity & encryption (`src/core/`) — working
+
+| File | What it does | Status |
+|---|---|---|
+| `crypto.ts` | Derives an X25519 key from the wallet's signMessage (deterministic — same wallet = same key = decrypts on any device) → encrypts/decrypts session blobs. Uses iqlabs-sdk. | OK |
+| `paths.ts` | Single source of truth for `~/.agentnet/` local paths. Override via AGENTNET_HOME (test isolation). | OK |
+
+### 2.3 Storage & sessions (`src/account/`) — working (only gdrive needs config)
+
+| File | What it does | Status |
+|---|---|---|
+| `sessionLog.ts` | Single source of the storage format. One message = one encrypted line (JSONL). Append-only. | OK |
+| `store.ts` | SessionStore — appendMessage (add one line) / load (decrypt + reassemble) / listMine / remove. | OK |
+| `login.ts` | initialize (first setup), login (read config, restore storage), switchStorage, logout, getStorageInfo. | OK |
+| `storage/adapter.ts` | Storage registry. kind (local/gdrive/icloud/custom)→builder. STORAGE_OPTIONS. | OK |
+| `storage/manual.ts` | Local files. Real append. | OK |
+| `storage/icloud.ts` | iCloud Drive folder. Real append. macOS only. | OK |
+| `storage/custom.ts` | User's own HTTP endpoint (S3/WebDAV). PUT/GET/DELETE. | OK |
+| `storage/gdrive.ts` | Google Drive appDataFolder. | OK — needs GOOGLE_CLIENT_ID |
+| `storage/oauth.ts` | Google OAuth (PKCE + auto refresh). Tokens stored locally only (~/.agentnet/tokens/). | OK, complete |
+
+### 2.4 UI (`surfaces/vscode/`) — chat done, no onboarding
+
+| File | What it does | Status |
+|---|---|---|
+| `extension.ts` | webview↔runtime bridge. Calls the real createRuntime (not a mock). But wallet = fake keypair, storage = pinned to local. | partial |
+| `webview.ts` | Chat HTML/JS. Chat, session list, delete, model dropdown, claude/codex tabs, IME, relative time. | OK |
+
+---
+
+## 3. "Built but not wired" — exactly what
+
+The parts are all built; `extension.ts` just doesn't call them yet:
+
+```mermaid
+flowchart LR
+    EXT["extension.ts<br/>(current)"] -->|"now"| FAKE["fake wallet + manualStorage()"]
+    EXT -.->|"should wire"| READY["already-built parts"]
+    subgraph READY["built parts (just need to be called)"]
+        L["login() / initialize()"]
+        D["detectCli()"]
+        S["STORAGE_OPTIONS / switchStorage()"]
+        G["gdrive OAuth (googleLogin)"]
+    end
+    style FAKE fill:#ffe6e6,stroke:#c33
+    style READY fill:#fff8e0,stroke:#cc3
+```
+
+So it's **not "there's no implementation" — it's "what's built isn't connected to the
+screen yet".** Build the onboarding screen (wallet → CLI check → storage pick) and call
+the parts above.
+
+---
+
+## 4. What genuinely doesn't exist yet
+
+1. **Real Phantom wallet (UI)** — currently a local keypair (`testWallet()` in
+   `src/account/keypairWallet.ts`). The `Wallet` interface now includes on-chain
+   signing (publicKey + signTransaction + signAllTransactions, via iqlabs
+   `WalletSigner`), so on-chain code can already run against `testWallet`. What's
+   missing is only the *interactive* front-end (Phantom deep-link / mobile wallet).
+   - Note: sessions saved now are encrypted with the test key. Once a real wallet is attached they won't decrypt (different key). Discard test sessions at that switch.
+2. **On-chain layer** — skill NFT, reputation (notes), mysessions on-chain index. Only design docs (plans/), zero code.
+3. **Other apps** — mobile / standalone CLI / web. Only VSCode exists.
+4. **Local↔cloud session dedup** — only one storage at a time today. No conflict policy for parallel use yet.
+
+---
+
+## 5. How to verify (try it yourself)
+
+```bash
+pnpm install
+pnpm test:run          # engine: claude+codex capture→encrypt→append→reload. Should print PASS.
+# VSCode: open surfaces/vscode and hit F5 → check chat, session list, delete
+```
+
+- Tests use a temp AGENTNET_HOME, so they never pollute the real ~/.agentnet.
+- Only real gdrive needs Google OAuth creds (Desktop-app). local/icloud/custom work with no config.
+
+> ⚠️ **gdrive needs zo's Google OAuth client creds — ASK ZO.** Drive sync/sign-in
+> silently fails without them (cloud writes are best-effort and swallow errors, so a
+> missing client_id looks like "nothing uploaded"). The creds come from a Google Cloud
+> **Desktop-app** OAuth client (not secret for installed apps). Provide them via EITHER:
+> - env: `GOOGLE_CLIENT_ID` / `GOOGLE_CLIENT_SECRET`, OR
+> - `~/.agentnet/config.json`: add `"google_client_id"` / `"google_client_secret"` keys
+>   (preferred — a VSCode-launched extension gets no shell env). See `oauth.ts` `configCreds()`.
+>
+> Sessions on Drive are PRIVATE (owner-only, we set no public/anyone permission) AND
+> AES-GCM encrypted with the wallet key — not public, unreadable even if seen.
+
+---
+
+## 6. What's next — Two Tracks
+
+Everything above is the **shared foundation** both tracks stand on (engine +
+encryption + storage). From here the work forks into two independent tracks that
+**converge on one wallet**.
+
+```mermaid
+flowchart TB
+    BASE["foundation (this repo so far)<br/>runtime engine · session encryption · 4 storage backends · VSCode chat · wallet w/ on-chain signing"]
+    BASE --> T1["Track 1 — identity & multi-device sessions<br/>(off-chain, wallet-based)"]
+    BASE --> T2["Track 2 — on-chain AgentNet<br/>(skill NFT · reputation)"]
+    T1 --> CONV["converge: wallet = agent<br/>sessions + skills + reputation on one wallet"]
+    T2 --> CONV
+    style BASE fill:#e6ffe6,stroke:#3a3
+    style T1 fill:#e6f0ff,stroke:#36c
+    style T2 fill:#f0e6ff,stroke:#93c
+    style CONV fill:#fff8e0,stroke:#cc3
+```
+
+### Track 1 — Wallet identity & multi-device session sync (off-chain)
+
+Connect a wallet, and the **same session syncs (encrypted) from your cloud** on any
+device or app. "Wallet = identity; sessions follow the wallet."
+
+```mermaid
+flowchart LR
+    W["connect Phantom wallet"] --> KEY["signature → encryption key<br/>(done: core/crypto)"]
+    KEY --> SESS["encrypt / decrypt session<br/>(done)"]
+    SESS --> CLOUD["sync to your cloud<br/>(gdrive/icloud, done)"]
+    CLOUD --> MULTI["another device, same wallet → restore"]
+    style W fill:#ffe6e6,stroke:#c33
+    style MULTI fill:#e6f0ff,stroke:#36c
+```
+
+| # | Task | Why / What | Depends on |
+|---|---|---|---|
+| **T1-1** | **Real Phantom wallet UI** | Replace `testWallet()` with interactive wallet signing. VSCode via deep-link / external-browser callback; mobile via wallet-app. Only needs to satisfy the `Wallet` interface — engine doesn't change. *(On-chain signing is already in the interface; this is just the interactive front-end.)* | parts: interface ready |
+| **T1-2** | **Wire the onboarding screen** | Plug already-built `login()` / `detectCli()` / `STORAGE_OPTIONS` into the UI: connect wallet → CLI check → storage picker (Apple/Google/local/custom) → save config. | parts exist |
+| **T1-3** | **Make storage selection real** | Currently pinned to `manualStorage` → switch to the storage the user picked. gdrive needs `GOOGLE_CLIENT_ID`. | parts exist |
+| **T1-4** | **Multi-device verification** | Save on device A → `login` with same wallet on device B → confirm restore. (Same wallet = same key = decrypts; works by design, needs a real test.) | T1-1,2,3 |
+| **T1-5** | **Build other apps** | VSCode-like app for mobile / standalone CLI. All reuse the same `src/`; only the surface is new. | T1-1 |
+| **T1-6** | **Local↔cloud dedup + cloud flush** | (a) Overlapping local + cloud records: last-write-wins by file ts (v1) → smarter merge later. (b) **Perf:** `mirror.ts` re-uploads the full session to append-less clouds (gdrive/custom) every turn → O(N²) for long sessions. Fix by batching cloud writes (flush every N turns/T sec; local stays per-turn). Low priority — correct today, only matters for long sessions. | T1-4 |
+
+**End state:** connect a wallet on your phone → yesterday's VSCode conversation is
+there, and the storage holds the encrypted session, neatly synced.
+
+### Track 2 — On-chain AgentNet (skill NFT · reputation)
+
+The wallet (= an agent) **publishes / searches / buys skill NFTs** and leaves
+**reputation notes** on-chain. **Unblocked now:** the `Wallet` interface has
+on-chain signing, and `testWallet()` signs real Solana txs — so Track 2 can start
+on devnet without waiting for the real Phantom UI (Track 1).
+
+```mermaid
+flowchart LR
+    AG["wallet = agent"] --> SK["skill NFT<br/>(Token-2022 soulbound)"]
+    SK --> PUB["publish: code-in text + mint"]
+    SK --> BUY["buy: pay + mint, supply++ = popularity"]
+    SK --> SEARCH["search: category/hashtag + sort by supply"]
+    AG --> NOTE["reputation notes<br/>(on-chain write, skill-holder gated)"]
+    style AG fill:#f0e6ff,stroke:#93c
+    style SK fill:#f0e6ff,stroke:#93c
+```
+
+| # | Task | Reference doc | Status |
+|---|---|---|---|
+| **T2-1** | core/ on-chain part — table seeds (mysessions, etc.) + IQLabs chain wrapper | [`coding-info.md`](coding-info.md) | ✅ `src/core/` (types, seed, chain) |
+| **T2-2** | **Publish skill NFT** — code-in text + Token-2022 mint (soulbound) | [`skill-nft-structure.md`](skill-nft-structure.md) | ✅ `nft/skill.publishSkill` + indexes to `skills:index` |
+| **T2-3** | **Buy skill** — pay + mint + supply++ (popularity) | 〃 | ⚠️ partial — payment + ATA built; **mint step blocked** (see limitation) |
+| **T2-4** | **Search** — category/hashtag (trait) filter + sort by supply | [`search.md`](search.md) | ✅ trait filter + live-supply sort; **semantic layer (§3) not built** |
+| **T2-5** | **Reputation notes** — on-chain write, skill-holder gate | [`notes.md`](notes.md) | ✅ notes (native Token-gate on table) + reputation = totalSupply (no invented score) |
+| **T2-6** | **Validation gate** — quality / maliciousness check before publish | [`skill-validation-adapter.md`](skill-validation-adapter.md) | ✅ `nft/validation/` (compat/strict/onchain/security) |
+| **T2-7** | **Workflow NFT** — skill-bundle recipe, requiredSkills gate | [`workflow-nft.md`](workflow-nft.md) | ✅ `nft/workflow` (prereq gate; same mint limitation) |
+| **T2-8** | Expose as MCP tools — agent autonomous buy | coding-info Step 7 | ✅ `mcp/server` (search_skills, buy_skill) |
+
+> ⚠️ **Known limitation — buy mint step (T2-3 / T2-7).** Each skill mint is created
+> with the **creator** as mint authority (per [`skill-nft-structure.md`](skill-nft-structure.md)
+> §1, "own mint authority = its creator"), but `buySkill`/`unlockWorkflow` have the
+> **buyer** sign the `mintTo`. On-chain, `mintTo` requires the mint authority's
+> signature → a buyer cannot self-mint a creator-authored mint, so the mint step of
+> buy fails on devnet. Everything *around* it works: payment routing, ATA creation,
+> prerequisite gate, publish, indexing, search, reputation, validation, MCP.
+>
+> **The plans never resolved this.** README/about (the buy row, "🔨 new wrapper")
+> frame buy as a **client-side wrapper** — `SystemProgram.transfer` + `mintTo` in one
+> tx — which is exactly the code here, and exactly what can't work (buyer ≠ authority).
+> The §4 sequence diagram's `P = Program` is ambiguous: it reads most naturally as the
+> **Token-2022 program** executing `mintTo`, not a bespoke contract, and it silently
+> skips *who signs as mint authority*. So this is an **open design decision, not a
+> coded plan** — pick one:
+>   1. **Custom program** — a contract whose PDA is the mint authority mints via CPI
+>      atomically with payment (trustless; largest effort; **not** in IQ SDK).
+>   2. **Protocol minter keypair** — a known service key holds authority, co-signs each
+>      buy (ships fast; centralized).
+>   3. **Creator co-sign** — creator must be online per purchase (impractical).
+>
+> Until one lands, buy is built-but-blocked at the mint instruction.
+>
+> Other guards added: `getAccountInfo === null` for ATA existence (not try/catch);
+> table created before first write (`ensureTable`, else SDK throws "table not found");
+> row keys constrained to declared columns (SDK throws "unknown key" otherwise);
+> `price` serialized as string (BigInt isn't JSON-serializable);
+> non-row reads filtered out (readTableRows also returns metadata-shaped entries);
+> IQ fee skipped when treasury is the System-Program sentinel (else funds burn);
+> `supply` hydrated live from the mint (indexed copy is always 0).
+
+> 📐 **Alignment fixes (brought code back to the spec).**
+> - **Reputation is not a score.** notes.md says "Not a rating/score"; an agent's
+>   standing = `totalSupply` ("famous agent = sum of supply"). Removed the invented
+>   `totalSupply*3 + skillsPublished*10 + notesReceived` formula; leaderboard ranks
+>   by `totalSupply`; `notesReceived` is informational only.
+> - **Skill registry split from the audit table.** Publish/search/reputation now use
+>   `skills:index`, not `audit:skills` — the audit/"Q-table" (search.md) is a separate
+>   thing (security results shown alongside), not the discovery index. *(The truly
+>   canonical source is the skill **collection** scanned by trait; the index table is
+>   the interim until DAS/collection-scan lands.)*
+> - **Note gating is now IQ-native.** The notes table is created with a Token
+>   `gate_opt` (hold ≥1 of the skill mint); the contract enforces it on every write.
+>   The old client-side `getBalance` stays only as a fast friendly pre-check. *(Workflow
+>   prereq stays a manual multi-mint AND-check — the single-mint table gate can't
+>   express "hold all of X, Y, Z".)*
+> - **Still open:** search's **semantic** query→trait mapping (search.md §3) is an
+>   off-chain embedding index — not built; current keyword match is literal substring.
+
+**End state:** the designer agent (wallet) buys and equips skills, leaves reputation
+on the good ones, popular skills sort by supply — all on the same wallet as sessions.
+
+### Why two tracks
+
+```mermaid
+flowchart TB
+    subgraph WALLET["one wallet = one agent"]
+        S["sessions (Track 1, off-chain encrypted)"]
+        K["skills (Track 2, on-chain NFT)"]
+        R["reputation (Track 2, on-chain notes)"]
+    end
+    style WALLET fill:#fff8e0,stroke:#cc3
+```
+
+- **Track 1** (sessions) is **off-chain** — conversations encrypted, only the wallet reads them.
+- **Track 2** (skills · reputation) is **on-chain** — public, buy/sell/sort.
+- Both hang off the **same wallet**: connect your wallet → your whole agent (sessions + skills + reputation) comes with it.
+- The tracks are **independent** (on-chain code never touches the session pipeline), so they run in parallel.
+
+**Immediate next moves:**
+- **Track 2** is unblocked — start on-chain (T2-1/T2-2) against `testWallet` on devnet now.
+- **Track 1** — wire the onboarding/storage picker (T1-2/T1-3, parts exist); real Phantom UI (T1-1) when ready.

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -13,9 +13,21 @@ importers:
       '@anthropic-ai/claude-agent-sdk':
         specifier: ^0.3.170
         version: 0.3.170(@anthropic-ai/sdk@0.104.1(zod@4.4.3))(@modelcontextprotocol/sdk@1.29.0(zod@4.4.3))(zod@4.4.3)
+      '@modelcontextprotocol/sdk':
+        specifier: ^1.29.0
+        version: 1.29.0(zod@4.4.3)
       '@openai/codex-sdk':
         specifier: ^0.139.0
         version: 0.139.0
+      '@solana/spl-token':
+        specifier: ^0.4.14
+        version: 0.4.14(@solana/web3.js@1.98.4(bufferutil@4.1.0)(typescript@5.9.3)(utf-8-validate@6.0.6))(bufferutil@4.1.0)(fastestsmallesttextencoderdecoder@1.0.22)(typescript@5.9.3)(utf-8-validate@6.0.6)
+      '@solana/spl-token-group':
+        specifier: ^0.0.7
+        version: 0.0.7(@solana/web3.js@1.98.4(bufferutil@4.1.0)(typescript@5.9.3)(utf-8-validate@6.0.6))(fastestsmallesttextencoderdecoder@1.0.22)(typescript@5.9.3)
+      '@solana/spl-token-metadata':
+        specifier: ^0.1.6
+        version: 0.1.6(@solana/web3.js@1.98.4(bufferutil@4.1.0)(typescript@5.9.3)(utf-8-validate@6.0.6))(fastestsmallesttextencoderdecoder@1.0.22)(typescript@5.9.3)
       dompurify:
         specifier: ^3.4.9
         version: 3.4.9
@@ -44,6 +56,9 @@ importers:
       typescript:
         specifier: ^5.6.0
         version: 5.9.3
+      vitest:
+        specifier: ^4.1.8
+        version: 4.1.8(@types/node@20.19.42)(vite@7.3.5(@types/node@20.19.42)(jiti@2.7.0)(lightningcss@1.32.0)(tsx@4.22.4))
 
   surfaces/localhost:
     dependencies:
@@ -819,9 +834,18 @@ packages:
     cpu: [x64]
     os: [win32]
 
+  '@solana/buffer-layout-utils@0.2.0':
+    resolution: {integrity: sha512-szG4sxgJGktbuZYDg2FfNmkMi0DYQoVjN2h7ta1W1hPrwzarcFLBq9UpX1UjNXsNpT9dn+chgprtWGioUAr4/g==}
+    engines: {node: '>= 10'}
+
   '@solana/buffer-layout@4.0.1':
     resolution: {integrity: sha512-E1ImOIAD1tBZFRdjeM4/pzTiTApC0AOBGwyAMS4fwIodCWArzJ3DWdoh8cKxeFM2fElkxBh2Aqts1BPC373rHA==}
     engines: {node: '>=5.10'}
+
+  '@solana/codecs-core@2.0.0-rc.1':
+    resolution: {integrity: sha512-bauxqMfSs8EHD0JKESaNmNuNvkvHSuN3bbWAF5RjOfDu2PugxHrvRebmYauvSumZ3cTfQ4HJJX6PG5rN852qyQ==}
+    peerDependencies:
+      typescript: '>=5'
 
   '@solana/codecs-core@2.3.0':
     resolution: {integrity: sha512-oG+VZzN6YhBHIoSKgS5ESM9VIGzhWjEHEGNPSibiDTxFhsFWxNaz8LbMDPjBUE69r9wmdGLkrQ+wVPbnJcZPvw==}
@@ -829,11 +853,38 @@ packages:
     peerDependencies:
       typescript: '>=5.3.3'
 
+  '@solana/codecs-data-structures@2.0.0-rc.1':
+    resolution: {integrity: sha512-rinCv0RrAVJ9rE/rmaibWJQxMwC5lSaORSZuwjopSUE6T0nb/MVg6Z1siNCXhh/HFTOg0l8bNvZHgBcN/yvXog==}
+    peerDependencies:
+      typescript: '>=5'
+
+  '@solana/codecs-numbers@2.0.0-rc.1':
+    resolution: {integrity: sha512-J5i5mOkvukXn8E3Z7sGIPxsThRCgSdgTWJDQeZvucQ9PT6Y3HiVXJ0pcWiOWAoQ3RX8e/f4I3IC+wE6pZiJzDQ==}
+    peerDependencies:
+      typescript: '>=5'
+
   '@solana/codecs-numbers@2.3.0':
     resolution: {integrity: sha512-jFvvwKJKffvG7Iz9dmN51OGB7JBcy2CJ6Xf3NqD/VP90xak66m/Lg48T01u5IQ/hc15mChVHiBm+HHuOFDUrQg==}
     engines: {node: '>=20.18.0'}
     peerDependencies:
       typescript: '>=5.3.3'
+
+  '@solana/codecs-strings@2.0.0-rc.1':
+    resolution: {integrity: sha512-9/wPhw8TbGRTt6mHC4Zz1RqOnuPTqq1Nb4EyuvpZ39GW6O2t2Q7Q0XxiB3+BdoEjwA2XgPw6e2iRfvYgqty44g==}
+    peerDependencies:
+      fastestsmallesttextencoderdecoder: ^1.0.22
+      typescript: '>=5'
+
+  '@solana/codecs@2.0.0-rc.1':
+    resolution: {integrity: sha512-qxoR7VybNJixV51L0G1RD2boZTcxmwUWnKCaJJExQ5qNKwbpSyDdWfFJfM5JhGyKe9DnPVOZB+JHWXnpbZBqrQ==}
+    peerDependencies:
+      typescript: '>=5'
+
+  '@solana/errors@2.0.0-rc.1':
+    resolution: {integrity: sha512-ejNvQ2oJ7+bcFAYWj225lyRkHnixuAeb7RQCixm+5mH4n1IA4Qya/9Bmfy5RAAHQzxK43clu3kZmL5eF9VGtYQ==}
+    hasBin: true
+    peerDependencies:
+      typescript: '>=5'
 
   '@solana/errors@2.3.0':
     resolution: {integrity: sha512-66RI9MAbwYV0UtP7kGcTBVLxJgUxoZGm8Fbc0ah+lGiAw17Gugco6+9GrJCV83VyF2mDWyYnYM9qdI3yjgpnaQ==}
@@ -842,11 +893,37 @@ packages:
     peerDependencies:
       typescript: '>=5.3.3'
 
+  '@solana/options@2.0.0-rc.1':
+    resolution: {integrity: sha512-mLUcR9mZ3qfHlmMnREdIFPf9dpMc/Bl66tLSOOWxw4ml5xMT2ohFn7WGqoKcu/UHkT9CrC6+amEdqCNvUqI7AA==}
+    peerDependencies:
+      typescript: '>=5'
+
+  '@solana/spl-token-group@0.0.7':
+    resolution: {integrity: sha512-V1N/iX7Cr7H0uazWUT2uk27TMqlqedpXHRqqAbVO2gvmJyT0E0ummMEAVQeXZ05ZhQ/xF39DLSdBp90XebWEug==}
+    engines: {node: '>=16'}
+    peerDependencies:
+      '@solana/web3.js': ^1.95.3
+
+  '@solana/spl-token-metadata@0.1.6':
+    resolution: {integrity: sha512-7sMt1rsm/zQOQcUWllQX9mD2O6KhSAtY1hFR2hfFwgqfFWzSY9E9GDvFVNYUI1F0iQKcm6HmePU9QbKRXTEBiA==}
+    engines: {node: '>=16'}
+    peerDependencies:
+      '@solana/web3.js': ^1.95.3
+
+  '@solana/spl-token@0.4.14':
+    resolution: {integrity: sha512-u09zr96UBpX4U685MnvQsNzlvw9TiY005hk1vJmJr7gMJldoPG1eYU5/wNEyOA5lkMLiR/gOi9SFD4MefOYEsA==}
+    engines: {node: '>=16'}
+    peerDependencies:
+      '@solana/web3.js': ^1.95.5
+
   '@solana/web3.js@1.98.4':
     resolution: {integrity: sha512-vv9lfnvjUsRiq//+j5pBdXig0IQdtzA0BRZ3bXEP4KaIyF1CcaydWqgyzQgfZMNIsWNWmG+AUHwPy4AHOD6gpw==}
 
   '@stablelib/base64@1.0.1':
     resolution: {integrity: sha512-1bnPQqSxSuc3Ii6MhBysoWCg58j97aUjuCSZrGSmDxNqtytIi0k8utUenAwTZN4V5mXXYGsVUI9zeBqy+jBOSQ==}
+
+  '@standard-schema/spec@1.1.0':
+    resolution: {integrity: sha512-l2aFy5jALhniG5HgqrD6jXLi/rUWrKvqN/qJx6yoJsgKhblVd+iqqU4RCXavm/jPityDo5TCvKMnpjKnOriy0w==}
 
   '@swc/helpers@0.5.23':
     resolution: {integrity: sha512-5lSsMOTXURePglDfvuAQUqkGek9Hg2kksOYay2m0+XR++b2NWYL/4sWyuvVBIs8oKnJaxkdi9whaL/sqN13afw==}
@@ -953,8 +1030,14 @@ packages:
   '@types/babel__traverse@7.28.0':
     resolution: {integrity: sha512-8PvcXf70gTDZBgt9ptxJ8elBeBjcLOAcOtoO/mPJjtji1+CdGbHgm77om1GrsPxsiE+uXIpNSK64UYaIwQXd4Q==}
 
+  '@types/chai@5.2.3':
+    resolution: {integrity: sha512-Mw558oeA9fFbv65/y4mHtXDs9bPnFMZAL/jxdPFUpOHHIXX91mcgEHbS5Lahr+pwZFR8A7GQleRWeI6cGFC2UA==}
+
   '@types/connect@3.4.38':
     resolution: {integrity: sha512-K6uROf1LD88uDQqJCktA4yzL1YYAK6NgfsI0v/mTgyPKWsX1CnJ0XPSDhViejru1GcRkLWb8RlzFYJRqGUbaug==}
+
+  '@types/deep-eql@4.0.2':
+    resolution: {integrity: sha512-c9h9dVVMigMPc4bwTvC5dxqtqJZwQPePsWjPlpSOnojbor6pGqdk541lfA7AqFQr5pB1BRdq0juY9db81BwyFw==}
 
   '@types/estree@1.0.9':
     resolution: {integrity: sha512-GhdPgy1el4/ImP05X05Uw4cw2/M93BCUmnEvWZNStlCzEKME4Fkk+YpoA5OiHNQmoS7Cafb8Xa3Pya8m1Qrzeg==}
@@ -994,6 +1077,35 @@ packages:
     peerDependencies:
       vite: ^4.2.0 || ^5.0.0 || ^6.0.0 || ^7.0.0 || ^8.0.0
 
+  '@vitest/expect@4.1.8':
+    resolution: {integrity: sha512-h3nDO677RDLEGlBxyQ5CW8RlMThSKSRLUePLOx09gNIWRL40edgA1GCZSZgf1W55MFAG6/Sw14KeaAnqv0NKdQ==}
+
+  '@vitest/mocker@4.1.8':
+    resolution: {integrity: sha512-LEiN/xe4OSIbKe9HQIp5OC24agGD9J5CnmMgsLohVVoOPWL9a2sBoR6VBx43jQZb7Kr1l4RCuyCJzcAa0+dojw==}
+    peerDependencies:
+      msw: ^2.4.9
+      vite: ^6.0.0 || ^7.0.0 || ^8.0.0
+    peerDependenciesMeta:
+      msw:
+        optional: true
+      vite:
+        optional: true
+
+  '@vitest/pretty-format@4.1.8':
+    resolution: {integrity: sha512-9GasEBxpZ1VYIpqHf/0+YGg121uSNwCKOJqIrTwWP/TB7DmFCiaBpNl3aPZzoLWfWkuqhbH8vJIVobZkvdo2cA==}
+
+  '@vitest/runner@4.1.8':
+    resolution: {integrity: sha512-EmVxeBAfMJvycdjd6Hm+RbFBbA9fKvo0Kx37hNpBYoYeavH3RNsBXWDooR1mgD52dCrxIIuP7UotpfiwOikvcg==}
+
+  '@vitest/snapshot@4.1.8':
+    resolution: {integrity: sha512-acfZboRmAIf05DEKcBQy33VXojFJjtUdLyo7oOmV9kebb2xdU01UknNiPuPZoJZQyO7DF0gZdTGTpeAzET9QPQ==}
+
+  '@vitest/spy@4.1.8':
+    resolution: {integrity: sha512-6EevtBp6OZOPF7bmz36HrGMeP3txgVSrgebWxHOafDXGkhIzfXK14f8KF6MuFfgXXUeHxmpD3BQxkV00/3s5mA==}
+
+  '@vitest/utils@4.1.8':
+    resolution: {integrity: sha512-uOJamYALNhfJ6iolExyQM40yIQwDqYnkKtQ5VCiSe17E33H0aQ/u+1GlRuz4LZBk6Mm3sg90G9hEbmEt37C1Zg==}
+
   accepts@2.0.0:
     resolution: {integrity: sha512-5cvg6CtKwfgdmVqY1WIiXKc3Q1bkRqGLi+2W/6ao+6Y7gu/RCwRuAhGEzh5B4KlszSuTLgZYuqFqo5bImjNKng==}
     engines: {node: '>= 0.6'}
@@ -1021,6 +1133,10 @@ packages:
   any-promise@1.3.0:
     resolution: {integrity: sha512-7UvmKalWRt1wgjL1RrGxoSJW/0QZFIegpeGvZG9kjp8vrRu55XTHbwnqq2GpXm9uLbcuhxm3IqX9OB4MZR1b2A==}
 
+  assertion-error@2.0.1:
+    resolution: {integrity: sha512-Izi8RQcffqCeNVgFigKli1ssklIbpHnCYc6AknXGYoB6grJqyeby7jv12JUQgmTAnIDnbck1uxksT4dzN3PWBA==}
+    engines: {node: '>=12'}
+
   base-x@3.0.11:
     resolution: {integrity: sha512-xz7wQ8xDhdyP7tQxwdteLYeFfS68tSMNCZ/Y37WJ4bhGfKPpqEIlmIyueQHqOyoPhE6xNUqjzRr8ra0eF9VRvA==}
 
@@ -1031,6 +1147,16 @@ packages:
     resolution: {integrity: sha512-honAfLBde0HAFLdNyBEfuuENkF6zR+ozxqxa/2zJKHBe1qzLqyTSeRKpdPEHAP03rlDGyQOPnCSxnVpVqQo9Mg==}
     engines: {node: '>=6.0.0'}
     hasBin: true
+
+  bigint-buffer@1.1.5:
+    resolution: {integrity: sha512-trfYco6AoZ+rKhKnxA0hgX0HAbVP/s808/EuDSe2JDzUnCp/xAsli35Orvk67UrTEcwuxZqYZDmfA2RXJgxVvA==}
+    engines: {node: '>= 10.0.0'}
+
+  bignumber.js@9.3.1:
+    resolution: {integrity: sha512-Ko0uX15oIUS7wJ3Rb30Fs6SkVbLmPBAKdlm7q9+ak9bbIeFf0MwuBsQV6z7+X768/cHsfg+WlysDWJcmthjsjQ==}
+
+  bindings@1.5.0:
+    resolution: {integrity: sha512-p2q/t/mhvuOj/UeLlV6566GD/guowlr0hHxClI0W9m7MWYkL1F0hLo+0Aexs9HSPCtR1SXQ0TD3MMKrXZajbiQ==}
 
   bn.js@5.2.3:
     resolution: {integrity: sha512-EAcmnPkxpntVL+DS7bO1zhcZNvCkxqtkd0ZY53h06GNQ3DEkkGZ/gKgmDv6DdZQGj9BgfSPKtJJ7Dp1GPP8f7w==}
@@ -1090,6 +1216,10 @@ packages:
   caniuse-lite@1.0.30001799:
     resolution: {integrity: sha512-hG1bReV+OUU+MOqK4t/ZWI0tZOyz3rqS9XuhOUz1cIcbwBKjOyJEJuw9ER5JuNyqxNk8u/JUVbGibBOL1yrjFw==}
 
+  chai@6.2.2:
+    resolution: {integrity: sha512-NUPRluOfOiTKBKvWPtSD4PhFvWCqOi0BGStNWs57X9js7XGTprSmFoz5F0tWhR4WPjNeR9jXqdC7/UpSJTnlRg==}
+    engines: {node: '>=18'}
+
   chalk@5.6.2:
     resolution: {integrity: sha512-7NzBL0rN6fMUW+f7A6Io4h40qQlG+xGmtMxfbnH/K7TAtt8JQWVQK+6g0UXKMeVJoyV5EkkNsErQ8pVD3bLHbA==}
     engines: {node: ^12.17.0 || ^14.13 || >=16.0.0}
@@ -1097,6 +1227,10 @@ packages:
   chokidar@4.0.3:
     resolution: {integrity: sha512-Qgzu8kfBvo+cA4962jnP1KkS6Dop5NS6g7R5LFYJr4b8Ub94PPQXUksCw9PvXoeXPRRddRNC5C1JQUR2SMGtnA==}
     engines: {node: '>= 14.16.0'}
+
+  commander@12.1.0:
+    resolution: {integrity: sha512-Vw8qHK3bZM9y/P10u3Vib8o/DdkvA2OtPtZvD871QKjy74Wj1WSKFILMPRPSdUSx5RFK1arlJzEtA4PkFgnbuA==}
+    engines: {node: '>=18'}
 
   commander@14.0.3:
     resolution: {integrity: sha512-H+y0Jo/T1RZ9qPP4Eh1pkcQcLRglraJaSLoyOtHxu6AapkjWVCy2Sit1QQ4x3Dng8qDlSsZEet7g5Pq06MvTgw==}
@@ -1203,6 +1337,9 @@ packages:
     resolution: {integrity: sha512-Zf5H2Kxt2xjTvbJvP2ZWLEICxA6j+hAmMzIlypy4xcBg1vKVnx89Wy0GbS+kf5cwCVFFzdCFh2XSCFNULS6csw==}
     engines: {node: '>= 0.4'}
 
+  es-module-lexer@2.1.0:
+    resolution: {integrity: sha512-n27zTYMjYu1aj4MjCWzSP7G9r75utsaoc8m61weK+W8JMBGGQybd43GstCXZ3WNmSFtGT9wi59qQTW6mhTR5LQ==}
+
   es-object-atoms@1.1.2:
     resolution: {integrity: sha512-HWcBoN6NileqtSydK2FqHbS/LoDd2pqrnQHLyJzBj4kOp/ky2MWMN694xOfkK8/SnUsW2DH7EfyVlydKCsm1Zw==}
     engines: {node: '>= 0.4'}
@@ -1230,6 +1367,9 @@ packages:
   escape-html@1.0.3:
     resolution: {integrity: sha512-NiSupZ4OeuGwr68lGIeym/ksIZMJodUGOSCZ/FSnTxcrekbvqrgdUxlJOMpijaKZVjAJrWrGs/6Jy8OMuyj9ow==}
 
+  estree-walker@3.0.3:
+    resolution: {integrity: sha512-7RUKfXgSMMkzt6ZuXmqapOurLGPPfgj6l9uRZ7lRGolvk0y2yocc35LdcxKC5PQZdn2DMqioAQ2NoWcrTKmm6g==}
+
   etag@1.8.1:
     resolution: {integrity: sha512-aIL5Fx7mawVa300al2BnEE4iNvo1qETxLrPI/o05L7z6go7fCw1J6EQmbK4FmJ2AS7kgVF/KEZWufBfdClMcPg==}
     engines: {node: '>= 0.6'}
@@ -1247,6 +1387,10 @@ packages:
   eventsource@3.0.7:
     resolution: {integrity: sha512-CRT1WTyuQoD771GW56XEZFQ/ZoSfWid1alKGDYMmkt2yl8UXrVR4pspqWNEcqKvVIzg6PAltWjxcSSPrboA4iA==}
     engines: {node: '>=18.0.0'}
+
+  expect-type@1.3.0:
+    resolution: {integrity: sha512-knvyeauYhqjOYvQ66MznSMs83wmHrCycNEN6Ao+2AeYEfxUIkuiVxdEa1qlGEPK+We3n0THiDciYSsCcgW/DoA==}
+    engines: {node: '>=12.0.0'}
 
   express-rate-limit@8.5.2:
     resolution: {integrity: sha512-5Kb34ipNX694DH48vN9irak1Qx30nb0PLYHXfJgw4YEjiC3ZEmZJhwOp+VfiCYwFzvFTdB9QkArYS5kXa2cx2A==}
@@ -1274,6 +1418,9 @@ packages:
   fast-uri@3.1.2:
     resolution: {integrity: sha512-rVjf7ArG3LTk+FS6Yw81V1DLuZl1bRbNrev6Tmd/9RaroeeRRJhAt7jg/6YFxbvAQXUCavSoZhPPj6oOx+5KjQ==}
 
+  fastestsmallesttextencoderdecoder@1.0.22:
+    resolution: {integrity: sha512-Pb8d48e+oIuY4MaM64Cd7OW1gt4nxCHs7/ddPPZ/Ic3sg8yVGM7O9wDvZ7us6ScaUupzM+pfBolwtYhN1IxBIw==}
+
   fdir@6.5.0:
     resolution: {integrity: sha512-tIbYtZbucOs0BRGqPJkshJUYdL+SDH7dVM8gjy+ERp3WAUjLEFJE+02kanyHtwjWOnwrKYBiwAmM0p4kLJAnXg==}
     engines: {node: '>=12.0.0'}
@@ -1282,6 +1429,9 @@ packages:
     peerDependenciesMeta:
       picomatch:
         optional: true
+
+  file-uri-to-path@1.0.0:
+    resolution: {integrity: sha512-0Zt+s3L7Vf1biwWZ29aARiVYLx7iMGnEUl9x33fbB/j3jR81u/O2LbqK+Bm1CDSNDKVtJ/YjwY7TUd5SkeLQLw==}
 
   finalhandler@2.1.1:
     resolution: {integrity: sha512-S8KoZgRZN+a5rNwqTxlZZePjT/4cnm0ROV70LedRHZ0p8u9fRID0hJUZQpkKLzro8LfmC8sx23bY6tVNxv8pQA==}
@@ -1570,6 +1720,10 @@ packages:
     resolution: {integrity: sha512-W67iLl4J2EXEGTbfeHCffrjDfitvLANg0UlX3wFUUSTx92KXRFegMHUVgSqE+wvhAbi4WqjGg9czysTV2Epbew==}
     engines: {node: '>= 0.4'}
 
+  obug@2.1.3:
+    resolution: {integrity: sha512-9miFgM2OFba7hB+pRgvtV84pYTBaoTHohvmIgiRt6dRIzbwEOIaNaP+dIlGs2fNFoB0SeISs0Jz5WFVRid6Xyg==}
+    engines: {node: '>=12.20.0'}
+
   on-finished@2.4.1:
     resolution: {integrity: sha512-oVlzkg3ENAhCk2zdv7IJwd/QUD4z2RxRwpkcGY8psCVcCYZNq4wYnVWALHM+brtuJjePWiYF/ClmuDr8Ch5+kg==}
     engines: {node: '>= 0.8'}
@@ -1735,6 +1889,9 @@ packages:
     resolution: {integrity: sha512-6x6dK6zJdpTzF4sQeNYxwtvBzf6Eg4GtlesS94HOvTudUeyK2WXAaIfmDgsyslYrRBeFIlsi54AYsFGUuhmvrQ==}
     engines: {node: '>= 0.4'}
 
+  siginfo@2.0.0:
+    resolution: {integrity: sha512-ybx0WO1/8bSBLEWXZvEd7gMW3Sn3JFlW3TvX1nREbDLRNQNaeNN8WK0meBwPdAaOI7TtRRRJn/Es1zhrrCHu7g==}
+
   source-map-js@1.2.1:
     resolution: {integrity: sha512-UXWMKhLOwVKb728IUtQPXxfYU+usdybtUrK/8uGE8CQMvrhOpwvzDBwj0QhSL7MQc7vIsISBG8VQ8+IDQxpfQA==}
     engines: {node: '>=0.10.0'}
@@ -1743,12 +1900,18 @@ packages:
     resolution: {integrity: sha512-i5uvt8C3ikiWeNZSVZNWcfZPItFQOsYTUAOkcUPGd8DqDy1uOUikjt5dG+uRlwyvR108Fb9DOd4GvXfT0N2/uQ==}
     engines: {node: '>= 12'}
 
+  stackback@0.0.2:
+    resolution: {integrity: sha512-1XMJE5fQo1jGH6Y/7ebnwPOBEkIEnT4QF32d5R1+VXdXveM0IBMJt8zfaxX1P3QhVwrYe+576+jkANtSS2mBbw==}
+
   standardwebhooks@1.0.0:
     resolution: {integrity: sha512-BbHGOQK9olHPMvQNHWul6MYlrRTAOKn03rOe4A8O3CLWhNf4YHBqq2HJKKC+sfqpxiBY52pNeesD6jIiLDz8jg==}
 
   statuses@2.0.2:
     resolution: {integrity: sha512-DvEy55V3DB7uknRo+4iOGT5fP1slR8wQohVdknigZPMpMstaKJQWhwiYBACJE3Ul2pTnATihhBYnRhZQHGBiRw==}
     engines: {node: '>= 0.8'}
+
+  std-env@4.1.0:
+    resolution: {integrity: sha512-Rq7ybcX2RuC55r9oaPVEW7/xu3tj8u4GeBYHBWCychFtzMIr86A7e3PPEBPT37sHStKX3+TiX/Fr/ACmJLVlLQ==}
 
   stream-chain@2.2.5:
     resolution: {integrity: sha512-1TJmBx6aSWqZ4tx7aTpBDXK0/e2hhcNSTV8+CbFJtDjbb+I1mZ8lHit0Grw9GRT+6JbIrrDd8esncgBi8aBXGA==}
@@ -1785,12 +1948,23 @@ packages:
   thenify@3.3.1:
     resolution: {integrity: sha512-RVZSIV5IG10Hk3enotrhvz0T9em6cyHBLkH/YAZuKqd8hRkKhSfCGIcP2KUY0EPxndzANBmNllzWPwak+bheSw==}
 
+  tinybench@2.9.0:
+    resolution: {integrity: sha512-0+DUvqWMValLmha6lr4kD8iAMK1HzV0/aKnCtWb9v9641TnP/MFb7Pc2bxoxQjTXAErryXVgUOfv2YqNllqGeg==}
+
   tinyexec@0.3.2:
     resolution: {integrity: sha512-KQQR9yN7R5+OSwaK0XQoj22pwHoTlgYqmUscPYoknOoWCWfj/5/ABTMRi69FrKU5ffPVh5QcFikpWJI/P1ocHA==}
+
+  tinyexec@1.2.4:
+    resolution: {integrity: sha512-SHf/r48b7vOrjve9PxJo3MN5v5yuyjHvdUcrQffT3WXMUfnGmHDVbC4k3sHJaJTgZCwpUplIaAo5ANtMyp3YHg==}
+    engines: {node: '>=18'}
 
   tinyglobby@0.2.17:
     resolution: {integrity: sha512-wXR/dYpcqKmfWpEdZjiKJOwCNFndD0DMnrW/cYjVGttEkBfVgcLFHoNrlj47mjOVic9yyNu65alsgF4NQyTa2g==}
     engines: {node: '>=12.0.0'}
+
+  tinyrainbow@3.1.0:
+    resolution: {integrity: sha512-Bf+ILmBgretUrdJxzXM0SgXLZ3XfiaUuOj/IKQHuTXip+05Xn+uyEYdVg0kYDipTBcLrCVyUzAPz7QmArb0mmw==}
+    engines: {node: '>=14.0.0'}
 
   toidentifier@1.0.1:
     resolution: {integrity: sha512-o5sSPKEkg/DIQNmH43V0/uerLrpzVedkUh8tGNvaeXpfpuwjKenlSox/2O/BTlZUtEe+JG7s5YhEz608PlAHRA==}
@@ -1924,6 +2098,47 @@ packages:
       yaml:
         optional: true
 
+  vitest@4.1.8:
+    resolution: {integrity: sha512-flY6ScbCIt9HThs+C5HS7jvGOB560DJtk/Z15IQROTA6zEy49Nh8T/dofWTQL+n3vswqn87sbJNiuqw1SDp5Ig==}
+    engines: {node: ^20.0.0 || ^22.0.0 || >=24.0.0}
+    hasBin: true
+    peerDependencies:
+      '@edge-runtime/vm': '*'
+      '@opentelemetry/api': ^1.9.0
+      '@types/node': ^20.0.0 || ^22.0.0 || >=24.0.0
+      '@vitest/browser-playwright': 4.1.8
+      '@vitest/browser-preview': 4.1.8
+      '@vitest/browser-webdriverio': 4.1.8
+      '@vitest/coverage-istanbul': 4.1.8
+      '@vitest/coverage-v8': 4.1.8
+      '@vitest/ui': 4.1.8
+      happy-dom: '*'
+      jsdom: '*'
+      vite: ^6.0.0 || ^7.0.0 || ^8.0.0
+    peerDependenciesMeta:
+      '@edge-runtime/vm':
+        optional: true
+      '@opentelemetry/api':
+        optional: true
+      '@types/node':
+        optional: true
+      '@vitest/browser-playwright':
+        optional: true
+      '@vitest/browser-preview':
+        optional: true
+      '@vitest/browser-webdriverio':
+        optional: true
+      '@vitest/coverage-istanbul':
+        optional: true
+      '@vitest/coverage-v8':
+        optional: true
+      '@vitest/ui':
+        optional: true
+      happy-dom:
+        optional: true
+      jsdom:
+        optional: true
+
   webidl-conversions@3.0.1:
     resolution: {integrity: sha512-2JAn3z8AR6rjK8Sm8orRC0h/bcl/DqL7tRPdGZ4I1CjdF+EaMLmYxBHyXuKL849eucPFhvBoxMsflfOb8kxaeQ==}
 
@@ -1933,6 +2148,11 @@ packages:
   which@2.0.2:
     resolution: {integrity: sha512-BLI3Tl1TW3Pvl70l3yq3Y64i+awpwXqsGBYWkkqMtnbXgrMD+yj7rhW0kuEDxzJaYXGjEW5ogapKNMEKNMjibA==}
     engines: {node: '>= 8'}
+    hasBin: true
+
+  why-is-node-running@2.3.0:
+    resolution: {integrity: sha512-hUrmaWBdVDcxvYqnyh09zunKzROWjbZTiNy8dBEjkS7ehEDQibXJ7XvlmtbwuTclUiIyN+CyXQD4Vmko8fNm8w==}
+    engines: {node: '>=8'}
     hasBin: true
 
   wrappy@1.0.2:
@@ -2497,13 +2717,43 @@ snapshots:
   '@rollup/rollup-win32-x64-msvc@4.61.1':
     optional: true
 
+  '@solana/buffer-layout-utils@0.2.0(bufferutil@4.1.0)(typescript@5.9.3)(utf-8-validate@6.0.6)':
+    dependencies:
+      '@solana/buffer-layout': 4.0.1
+      '@solana/web3.js': 1.98.4(bufferutil@4.1.0)(typescript@5.9.3)(utf-8-validate@6.0.6)
+      bigint-buffer: 1.1.5
+      bignumber.js: 9.3.1
+    transitivePeerDependencies:
+      - bufferutil
+      - encoding
+      - typescript
+      - utf-8-validate
+
   '@solana/buffer-layout@4.0.1':
     dependencies:
       buffer: 6.0.3
 
+  '@solana/codecs-core@2.0.0-rc.1(typescript@5.9.3)':
+    dependencies:
+      '@solana/errors': 2.0.0-rc.1(typescript@5.9.3)
+      typescript: 5.9.3
+
   '@solana/codecs-core@2.3.0(typescript@5.9.3)':
     dependencies:
       '@solana/errors': 2.3.0(typescript@5.9.3)
+      typescript: 5.9.3
+
+  '@solana/codecs-data-structures@2.0.0-rc.1(typescript@5.9.3)':
+    dependencies:
+      '@solana/codecs-core': 2.0.0-rc.1(typescript@5.9.3)
+      '@solana/codecs-numbers': 2.0.0-rc.1(typescript@5.9.3)
+      '@solana/errors': 2.0.0-rc.1(typescript@5.9.3)
+      typescript: 5.9.3
+
+  '@solana/codecs-numbers@2.0.0-rc.1(typescript@5.9.3)':
+    dependencies:
+      '@solana/codecs-core': 2.0.0-rc.1(typescript@5.9.3)
+      '@solana/errors': 2.0.0-rc.1(typescript@5.9.3)
       typescript: 5.9.3
 
   '@solana/codecs-numbers@2.3.0(typescript@5.9.3)':
@@ -2512,11 +2762,78 @@ snapshots:
       '@solana/errors': 2.3.0(typescript@5.9.3)
       typescript: 5.9.3
 
+  '@solana/codecs-strings@2.0.0-rc.1(fastestsmallesttextencoderdecoder@1.0.22)(typescript@5.9.3)':
+    dependencies:
+      '@solana/codecs-core': 2.0.0-rc.1(typescript@5.9.3)
+      '@solana/codecs-numbers': 2.0.0-rc.1(typescript@5.9.3)
+      '@solana/errors': 2.0.0-rc.1(typescript@5.9.3)
+      fastestsmallesttextencoderdecoder: 1.0.22
+      typescript: 5.9.3
+
+  '@solana/codecs@2.0.0-rc.1(fastestsmallesttextencoderdecoder@1.0.22)(typescript@5.9.3)':
+    dependencies:
+      '@solana/codecs-core': 2.0.0-rc.1(typescript@5.9.3)
+      '@solana/codecs-data-structures': 2.0.0-rc.1(typescript@5.9.3)
+      '@solana/codecs-numbers': 2.0.0-rc.1(typescript@5.9.3)
+      '@solana/codecs-strings': 2.0.0-rc.1(fastestsmallesttextencoderdecoder@1.0.22)(typescript@5.9.3)
+      '@solana/options': 2.0.0-rc.1(fastestsmallesttextencoderdecoder@1.0.22)(typescript@5.9.3)
+      typescript: 5.9.3
+    transitivePeerDependencies:
+      - fastestsmallesttextencoderdecoder
+
+  '@solana/errors@2.0.0-rc.1(typescript@5.9.3)':
+    dependencies:
+      chalk: 5.6.2
+      commander: 12.1.0
+      typescript: 5.9.3
+
   '@solana/errors@2.3.0(typescript@5.9.3)':
     dependencies:
       chalk: 5.6.2
       commander: 14.0.3
       typescript: 5.9.3
+
+  '@solana/options@2.0.0-rc.1(fastestsmallesttextencoderdecoder@1.0.22)(typescript@5.9.3)':
+    dependencies:
+      '@solana/codecs-core': 2.0.0-rc.1(typescript@5.9.3)
+      '@solana/codecs-data-structures': 2.0.0-rc.1(typescript@5.9.3)
+      '@solana/codecs-numbers': 2.0.0-rc.1(typescript@5.9.3)
+      '@solana/codecs-strings': 2.0.0-rc.1(fastestsmallesttextencoderdecoder@1.0.22)(typescript@5.9.3)
+      '@solana/errors': 2.0.0-rc.1(typescript@5.9.3)
+      typescript: 5.9.3
+    transitivePeerDependencies:
+      - fastestsmallesttextencoderdecoder
+
+  '@solana/spl-token-group@0.0.7(@solana/web3.js@1.98.4(bufferutil@4.1.0)(typescript@5.9.3)(utf-8-validate@6.0.6))(fastestsmallesttextencoderdecoder@1.0.22)(typescript@5.9.3)':
+    dependencies:
+      '@solana/codecs': 2.0.0-rc.1(fastestsmallesttextencoderdecoder@1.0.22)(typescript@5.9.3)
+      '@solana/web3.js': 1.98.4(bufferutil@4.1.0)(typescript@5.9.3)(utf-8-validate@6.0.6)
+    transitivePeerDependencies:
+      - fastestsmallesttextencoderdecoder
+      - typescript
+
+  '@solana/spl-token-metadata@0.1.6(@solana/web3.js@1.98.4(bufferutil@4.1.0)(typescript@5.9.3)(utf-8-validate@6.0.6))(fastestsmallesttextencoderdecoder@1.0.22)(typescript@5.9.3)':
+    dependencies:
+      '@solana/codecs': 2.0.0-rc.1(fastestsmallesttextencoderdecoder@1.0.22)(typescript@5.9.3)
+      '@solana/web3.js': 1.98.4(bufferutil@4.1.0)(typescript@5.9.3)(utf-8-validate@6.0.6)
+    transitivePeerDependencies:
+      - fastestsmallesttextencoderdecoder
+      - typescript
+
+  '@solana/spl-token@0.4.14(@solana/web3.js@1.98.4(bufferutil@4.1.0)(typescript@5.9.3)(utf-8-validate@6.0.6))(bufferutil@4.1.0)(fastestsmallesttextencoderdecoder@1.0.22)(typescript@5.9.3)(utf-8-validate@6.0.6)':
+    dependencies:
+      '@solana/buffer-layout': 4.0.1
+      '@solana/buffer-layout-utils': 0.2.0(bufferutil@4.1.0)(typescript@5.9.3)(utf-8-validate@6.0.6)
+      '@solana/spl-token-group': 0.0.7(@solana/web3.js@1.98.4(bufferutil@4.1.0)(typescript@5.9.3)(utf-8-validate@6.0.6))(fastestsmallesttextencoderdecoder@1.0.22)(typescript@5.9.3)
+      '@solana/spl-token-metadata': 0.1.6(@solana/web3.js@1.98.4(bufferutil@4.1.0)(typescript@5.9.3)(utf-8-validate@6.0.6))(fastestsmallesttextencoderdecoder@1.0.22)(typescript@5.9.3)
+      '@solana/web3.js': 1.98.4(bufferutil@4.1.0)(typescript@5.9.3)(utf-8-validate@6.0.6)
+      buffer: 6.0.3
+    transitivePeerDependencies:
+      - bufferutil
+      - encoding
+      - fastestsmallesttextencoderdecoder
+      - typescript
+      - utf-8-validate
 
   '@solana/web3.js@1.98.4(bufferutil@4.1.0)(typescript@5.9.3)(utf-8-validate@6.0.6)':
     dependencies:
@@ -2542,6 +2859,8 @@ snapshots:
       - utf-8-validate
 
   '@stablelib/base64@1.0.1': {}
+
+  '@standard-schema/spec@1.1.0': {}
 
   '@swc/helpers@0.5.23':
     dependencies:
@@ -2636,9 +2955,16 @@ snapshots:
     dependencies:
       '@babel/types': 7.29.7
 
+  '@types/chai@5.2.3':
+    dependencies:
+      '@types/deep-eql': 4.0.2
+      assertion-error: 2.0.1
+
   '@types/connect@3.4.38':
     dependencies:
       '@types/node': 20.19.42
+
+  '@types/deep-eql@4.0.2': {}
 
   '@types/estree@1.0.9': {}
 
@@ -2683,6 +3009,47 @@ snapshots:
     transitivePeerDependencies:
       - supports-color
 
+  '@vitest/expect@4.1.8':
+    dependencies:
+      '@standard-schema/spec': 1.1.0
+      '@types/chai': 5.2.3
+      '@vitest/spy': 4.1.8
+      '@vitest/utils': 4.1.8
+      chai: 6.2.2
+      tinyrainbow: 3.1.0
+
+  '@vitest/mocker@4.1.8(vite@7.3.5(@types/node@20.19.42)(jiti@2.7.0)(lightningcss@1.32.0)(tsx@4.22.4))':
+    dependencies:
+      '@vitest/spy': 4.1.8
+      estree-walker: 3.0.3
+      magic-string: 0.30.21
+    optionalDependencies:
+      vite: 7.3.5(@types/node@20.19.42)(jiti@2.7.0)(lightningcss@1.32.0)(tsx@4.22.4)
+
+  '@vitest/pretty-format@4.1.8':
+    dependencies:
+      tinyrainbow: 3.1.0
+
+  '@vitest/runner@4.1.8':
+    dependencies:
+      '@vitest/utils': 4.1.8
+      pathe: 2.0.3
+
+  '@vitest/snapshot@4.1.8':
+    dependencies:
+      '@vitest/pretty-format': 4.1.8
+      '@vitest/utils': 4.1.8
+      magic-string: 0.30.21
+      pathe: 2.0.3
+
+  '@vitest/spy@4.1.8': {}
+
+  '@vitest/utils@4.1.8':
+    dependencies:
+      '@vitest/pretty-format': 4.1.8
+      convert-source-map: 2.0.0
+      tinyrainbow: 3.1.0
+
   accepts@2.0.0:
     dependencies:
       mime-types: 3.0.2
@@ -2707,6 +3074,8 @@ snapshots:
 
   any-promise@1.3.0: {}
 
+  assertion-error@2.0.1: {}
+
   base-x@3.0.11:
     dependencies:
       safe-buffer: 5.2.1
@@ -2714,6 +3083,16 @@ snapshots:
   base64-js@1.5.1: {}
 
   baseline-browser-mapping@2.10.35: {}
+
+  bigint-buffer@1.1.5:
+    dependencies:
+      bindings: 1.5.0
+
+  bignumber.js@9.3.1: {}
+
+  bindings@1.5.0:
+    dependencies:
+      file-uri-to-path: 1.0.0
 
   bn.js@5.2.3: {}
 
@@ -2784,11 +3163,15 @@ snapshots:
 
   caniuse-lite@1.0.30001799: {}
 
+  chai@6.2.2: {}
+
   chalk@5.6.2: {}
 
   chokidar@4.0.3:
     dependencies:
       readdirp: 4.1.2
+
+  commander@12.1.0: {}
 
   commander@14.0.3: {}
 
@@ -2866,6 +3249,8 @@ snapshots:
 
   es-errors@1.3.0: {}
 
+  es-module-lexer@2.1.0: {}
+
   es-object-atoms@1.1.2:
     dependencies:
       es-errors: 1.3.0
@@ -2938,6 +3323,10 @@ snapshots:
 
   escape-html@1.0.3: {}
 
+  estree-walker@3.0.3:
+    dependencies:
+      '@types/estree': 1.0.9
+
   etag@1.8.1: {}
 
   eventemitter3@4.0.7: {}
@@ -2949,6 +3338,8 @@ snapshots:
   eventsource@3.0.7:
     dependencies:
       eventsource-parser: 3.1.0
+
+  expect-type@1.3.0: {}
 
   express-rate-limit@8.5.2(express@5.2.1):
     dependencies:
@@ -2998,9 +3389,13 @@ snapshots:
 
   fast-uri@3.1.2: {}
 
+  fastestsmallesttextencoderdecoder@1.0.22: {}
+
   fdir@6.5.0(picomatch@4.0.4):
     optionalDependencies:
       picomatch: 4.0.4
+
+  file-uri-to-path@1.0.0: {}
 
   finalhandler@2.1.1:
     dependencies:
@@ -3242,6 +3637,8 @@ snapshots:
 
   object-inspect@1.13.4: {}
 
+  obug@2.1.3: {}
+
   on-finished@2.4.1:
     dependencies:
       ee-first: 1.1.1
@@ -3444,9 +3841,13 @@ snapshots:
       side-channel-map: 1.0.1
       side-channel-weakmap: 1.0.2
 
+  siginfo@2.0.0: {}
+
   source-map-js@1.2.1: {}
 
   source-map@0.7.6: {}
+
+  stackback@0.0.2: {}
 
   standardwebhooks@1.0.0:
     dependencies:
@@ -3454,6 +3855,8 @@ snapshots:
       fast-sha256: 1.3.0
 
   statuses@2.0.2: {}
+
+  std-env@4.1.0: {}
 
   stream-chain@2.2.5: {}
 
@@ -3489,12 +3892,18 @@ snapshots:
     dependencies:
       any-promise: 1.3.0
 
+  tinybench@2.9.0: {}
+
   tinyexec@0.3.2: {}
+
+  tinyexec@1.2.4: {}
 
   tinyglobby@0.2.17:
     dependencies:
       fdir: 6.5.0(picomatch@4.0.4)
       picomatch: 4.0.4
+
+  tinyrainbow@3.1.0: {}
 
   toidentifier@1.0.1: {}
 
@@ -3592,6 +4001,33 @@ snapshots:
       lightningcss: 1.32.0
       tsx: 4.22.4
 
+  vitest@4.1.8(@types/node@20.19.42)(vite@7.3.5(@types/node@20.19.42)(jiti@2.7.0)(lightningcss@1.32.0)(tsx@4.22.4)):
+    dependencies:
+      '@vitest/expect': 4.1.8
+      '@vitest/mocker': 4.1.8(vite@7.3.5(@types/node@20.19.42)(jiti@2.7.0)(lightningcss@1.32.0)(tsx@4.22.4))
+      '@vitest/pretty-format': 4.1.8
+      '@vitest/runner': 4.1.8
+      '@vitest/snapshot': 4.1.8
+      '@vitest/spy': 4.1.8
+      '@vitest/utils': 4.1.8
+      es-module-lexer: 2.1.0
+      expect-type: 1.3.0
+      magic-string: 0.30.21
+      obug: 2.1.3
+      pathe: 2.0.3
+      picomatch: 4.0.4
+      std-env: 4.1.0
+      tinybench: 2.9.0
+      tinyexec: 1.2.4
+      tinyglobby: 0.2.17
+      tinyrainbow: 3.1.0
+      vite: 7.3.5(@types/node@20.19.42)(jiti@2.7.0)(lightningcss@1.32.0)(tsx@4.22.4)
+      why-is-node-running: 2.3.0
+    optionalDependencies:
+      '@types/node': 20.19.42
+    transitivePeerDependencies:
+      - msw
+
   webidl-conversions@3.0.1: {}
 
   whatwg-url@5.0.0:
@@ -3602,6 +4038,11 @@ snapshots:
   which@2.0.2:
     dependencies:
       isexe: 2.0.0
+
+  why-is-node-running@2.3.0:
+    dependencies:
+      siginfo: 2.0.0
+      stackback: 0.0.2
 
   wrappy@1.0.2: {}
 


### PR DESCRIPTION
Relocates the Step-0 core branch (#4, `feat/step0-core-layer`) into the
monorepo's `packages/core/src/*` layout, on top of the chat/approval/auth layer
`main` gained since. **Supersedes #4.** (Re-merge of #10 with mega123-art credited
as co-author.)

The two feature sets are disjoint (main = chat/auth, old branch = on-chain
marketplace), so this is a relocation + one barrel merge.

## What's in here
- `core/{chain,seed,types,skillSource}`, `nft/`, `search/`, `notes/`,
  `reputation/`, `skill-market/` → `packages/core/src/` (35 files)
- Keep main's `account/`/`runtime/` (newer). `core/{crypto,paths}` byte-identical.
- Union `index.ts`, keep main's 3-arg `connect()`.
- Deps: `@solana/spl-token{,-group,-metadata}`, `@modelcontextprotocol/sdk`, `vitest`.
- `plans/STATUS.md` + bootstrap/probe scripts.

## Verification
- `tsc --noEmit` clean; `vitest run` → 15 files / 82 tests pass.

## Follow-up (not here)
`nft/token2022.ts` stores traits in Token-2022 `additionalMetadata`; the settled
format (`plans/onchain-format/skill-nft-json.md` §4) moves them into the code-in
JSON `attributes`. Separate slice (changes on-chain behavior).