### PR TITLE
feat(core): wire the NFT indexer as a hydrated SkillSource

### DIFF
--- a/packages/core/src/core/skillSource.spec.ts
+++ b/packages/core/src/core/skillSource.spec.ts
@@ -1,5 +1,5 @@
 import { describe, it, expect, vi, beforeEach, afterEach } from "vitest";
-import { dasSource } from "./skillSource.js";
+import { dasSource, indexerSource } from "./skillSource.js";
 
 // dasSource enumerates the TokenGroup collections via a DAS RPC. We mock fetch
 // and the collection-mint config (env) to drive it without a real RPC.
@@ -17,7 +17,7 @@ describe("core/skillSource — dasSource", () => {
     process.env = { ...origEnv };
   });
 
-  it("maps DAS items to Skill rows (id from item.id)", async () => {
+  it("maps DAS items to Skill rows (id from item.id) + reads attributes", async () => {
     // The skills collection returns these items; the workflows collection (now a
     // default) returns none — so we only see the skill items.
     vi.stubGlobal(
@@ -30,7 +30,20 @@ describe("core/skillSource — dasSource", () => {
             result: {
               items: isSkills
                 ? [
-                    { id: "skill1", content: { metadata: { name: "A" } }, authorities: [{ address: "w1" }] },
+                    {
+                      id: "skill1",
+                      content: {
+                        metadata: {
+                          name: "A",
+                          // traits arrive in the scan (DAS resolves the uri JSON):
+                          attributes: [
+                            { trait_type: "category", value: "clean-code" },
+                            { trait_type: "skill", value: "testing" },
+                          ],
+                        },
+                      },
+                      authorities: [{ address: "w1" }],
+                    },
                     { id: "skill2", content: { metadata: {} } },
                   ]
                 : [],
@@ -44,6 +57,10 @@ describe("core/skillSource — dasSource", () => {
     expect(skills.map((s) => s.id)).toEqual(["skill1", "skill2"]);
     expect(skills[0].type).toBe("skill");
     expect(skills[0].creator).toBe("w1");
+    // category/hashtags now come from content.metadata.attributes, not blanked.
+    expect(skills[0].category).toBe("clean-code");
+    expect(skills[0].hashtags).toEqual(["testing"]);
+    expect(dasSource.hydrated).toBeFalsy(); // dasSource does NOT carry live supply
   });
 
   it("throws on a DAS error instead of hiding it", async () => {
@@ -62,4 +79,56 @@ describe("core/skillSource — dasSource", () => {
 
   // (No "no collection mints" test: seed.ts now ships default devnet collection
   // ids, so a collection is always configured unless explicitly overridden.)
+});
+
+describe("core/skillSource — indexerSource", () => {
+  afterEach(() => vi.restoreAllMocks());
+
+  it("maps /items to Skill rows with live supply + traits, hydrated:true", async () => {
+    const src = indexerSource("https://nft-index.iqlabs.dev/");
+    expect(src.hydrated).toBe(true);
+
+    vi.stubGlobal(
+      "fetch",
+      vi.fn().mockImplementation(async (url: string) => {
+        expect(url).toBe("https://nft-index.iqlabs.dev/items?limit=1000&sort=supply");
+        return {
+          ok: true,
+          json: async () => ({
+            items: [
+              {
+                mint: "m1",
+                type: "skill",
+                name: "clean-code-refactor",
+                description: "d",
+                creator: "alice",
+                supply: 42, // live — must survive without any getMintSupply
+                attributes: [
+                  { trait_type: "category", value: "clean-code" },
+                  { trait_type: "skill", value: "testing" },
+                ],
+              },
+            ],
+          }),
+        };
+      }),
+    );
+
+    const skills = await src.listSkills();
+    expect(skills).toHaveLength(1);
+    expect(skills[0]).toMatchObject({
+      id: "m1",
+      type: "skill",
+      creator: "alice",
+      supply: 42,
+      category: "clean-code",
+      hashtags: ["testing"],
+    });
+  });
+
+  it("throws on a non-ok indexer response (caller falls back to dasSource)", async () => {
+    const src = indexerSource("https://nft-index.iqlabs.dev");
+    vi.stubGlobal("fetch", vi.fn().mockResolvedValue({ ok: false, status: 503 }));
+    await expect(src.listSkills()).rejects.toThrow(/HTTP 503/);
+  });
 });

--- a/packages/core/src/core/skillSource.ts
+++ b/packages/core/src/core/skillSource.ts
@@ -18,6 +18,12 @@ import type { Skill } from "./types.js";
 export interface SkillSource {
   /** Enumerate all known skills/workflows (id set + cached metadata snapshot). */
   listSkills(limit?: number): Promise<Skill[]>;
+  /**
+   * True when listSkills() returns live `supply` already filled (e.g. an indexer
+   * that stored it). Callers then SKIP the per-mint getMintSupply hydration loop.
+   * dasSource leaves it undefined/false — its `supply` is 0 and must be hydrated.
+   */
+  hydrated?: boolean;
 }
 
 /** Pull category (single) + hashtags (repeated "skill" traits) out of a code-in
@@ -114,3 +120,55 @@ export const dasSource: SkillSource = {
     return skills.slice(0, limit);
   },
 };
+
+/** The indexer's item shape (agentnet-nft-indexer GET /items). Declared here so
+ *  core stays independent of the indexer repo — we only depend on its wire JSON. */
+interface IndexerItem {
+  mint: string;
+  type: "skill" | "workflow";
+  name: string;
+  description: string;
+  creator: string | null;
+  supply: number;
+  attributes: { trait_type: string; value: string }[];
+}
+
+/**
+ * Indexer source — enumerates via the NFT indexer's `/items` instead of a raw
+ * DAS scan. The indexer already stored live `supply` + traits from its own scan,
+ * so this is `hydrated: true`: searchSkills / reputation skip their per-mint
+ * getMintSupply loops. It's the fast path; dasSource is the fallback when the
+ * indexer is unreachable (the caller catches and swaps source).
+ *
+ * No dependency on the indexer repo — just its HTTP JSON. baseUrl e.g.
+ * "https://nft-index.iqlabs.dev".
+ */
+export function indexerSource(baseUrl: string): SkillSource {
+  const base = baseUrl.replace(/\/+$/, "");
+  return {
+    hydrated: true,
+    async listSkills(limit = 1000): Promise<Skill[]> {
+      const res = await fetch(`${base}/items?limit=${limit}&sort=supply`, {
+        headers: { accept: "application/json" },
+      });
+      if (!res.ok) throw new Error(`indexer /items → HTTP ${res.status}`);
+      const { items } = (await res.json()) as { items: IndexerItem[] };
+      return items.map((it) => {
+        const { category, hashtags } = traitsFromAttributes(it.attributes);
+        return {
+          id: it.mint,
+          type: it.type,
+          name: it.name,
+          description: it.description,
+          creator: it.creator ?? "",
+          category,
+          hashtags,
+          price: "0",
+          supply: it.supply, // live — already hydrated by the indexer
+          uriTxid: "",
+          createdAt: 0,
+        };
+      });
+    },
+  };
+}

--- a/packages/core/src/index.ts
+++ b/packages/core/src/index.ts
@@ -48,7 +48,7 @@ export type { PostNoteInput, ReadNotesOptions, PostAgentNoteInput } from "./note
 // search + the enumeration seam
 export { searchSkills } from "./search/index.js";
 export type { SearchFilters, SortBy, SearchOptions } from "./search/index.js";
-export { dasSource } from "./core/skillSource.js";
+export { dasSource, indexerSource } from "./core/skillSource.js";
 export type { SkillSource } from "./core/skillSource.js";
 // reputation (derived live from supply + reviews)
 export { getReputation, getLeaderboard } from "./reputation/index.js";

--- a/packages/core/src/reputation/reputation.ts
+++ b/packages/core/src/reputation/reputation.ts
@@ -24,10 +24,11 @@ export async function getReputation(
   );
 
   const skillsPublished = mySkills.length;
-  // totalSupply = the documented "fame" metric, read live from each mint.
-  const supplies = await Promise.all(
-    mySkills.map((s) => getMintSupply(conn, s.id)),
-  );
+  // totalSupply = the documented "fame" metric. A hydrated source (indexer)
+  // already carries live supply; otherwise read it per-mint from the chain.
+  const supplies = source.hydrated
+    ? mySkills.map((s) => Number(s.supply))
+    : await Promise.all(mySkills.map((s) => getMintSupply(conn, s.id)));
   const totalSupply = supplies.reduce((acc, n) => acc + n, 0);
 
   // Count reviews across all creator's skills (informational, not a score).
@@ -67,13 +68,14 @@ export async function getLeaderboard(
   }
 
   // Rank by totalSupply (the documented fame metric). Reviews omitted here to
-  // avoid N+1 reads — they're informational, not part of ranking anyway.
+  // avoid N+1 reads — they're informational, not part of ranking anyway. A
+  // hydrated source carries live supply; otherwise read each mint.
   const entries: Reputation[] = [];
   for (const [wallet, creatorSkills] of creatorMap.entries()) {
     const skillsPublished = creatorSkills.length;
-    const supplies = await Promise.all(
-      creatorSkills.map((s) => getMintSupply(conn, s.id)),
-    );
+    const supplies = source.hydrated
+      ? creatorSkills.map((s) => Number(s.supply))
+      : await Promise.all(creatorSkills.map((s) => getMintSupply(conn, s.id)));
     const totalSupply = supplies.reduce((acc, n) => acc + n, 0);
     entries.push({
       wallet,

--- a/packages/core/src/search/search.spec.ts
+++ b/packages/core/src/search/search.spec.ts
@@ -1,5 +1,6 @@
 import { describe, it, expect, vi, beforeEach } from "vitest";
 import { searchSkills } from "./search.js";
+import { getMintSupply } from "../nft/token2022.js";
 import type { SkillSource } from "../core/skillSource.js";
 
 // Live supply is hydrated from the mint; echo the per-id supply set below.
@@ -119,5 +120,24 @@ describe("search/search", () => {
     expect(verified.map((s) => s.id)).toEqual(["A"]);
 
     delete META_BY_ID["A"];
+  });
+
+  it("a hydrated source skips the per-mint getMintSupply loop", async () => {
+    // Source carries its own (already-live) supply; sort must use it WITHOUT
+    // any getMintSupply call. Use supplies that differ from SUPPLY_BY_ID so a
+    // stray hydration would reorder and be caught.
+    const hydrated: SkillSource = {
+      hydrated: true,
+      listSkills: vi.fn().mockResolvedValue([
+        { ...mockSkills[0], supply: 1 },   // A
+        { ...mockSkills[1], supply: 999 }, // B (highest via source value)
+        { ...mockSkills[2], supply: 2 },   // C
+      ]),
+    };
+
+    const results = await searchSkills(mockConn, { source: hydrated, sortBy: "supply" });
+
+    expect(getMintSupply).not.toHaveBeenCalled();
+    expect(results.map((s) => s.id)).toEqual(["B", "C", "A"]); // 999 > 2 > 1
   });
 });

--- a/packages/core/src/search/search.ts
+++ b/packages/core/src/search/search.ts
@@ -100,9 +100,12 @@ export async function searchSkills(
     });
   }
 
-  // Hydrate live supply from the mint (indexed supply is stale — always 0).
-  // Done after filtering so we only fetch for the matched set.
-  if (sortBy === "supply") {
+  // Hydrate live supply from the mint, unless the source already filled it.
+  // dasSource leaves supply 0 (the scan doesn't carry the live counter), so a
+  // supply sort needs one getMintSupply per matched skill. A hydrated source
+  // (e.g. the indexer) returns supply already → skip the whole N-RPC loop. Done
+  // after filtering so the fallback only fetches for the matched set.
+  if (sortBy === "supply" && !source.hydrated) {
     await Promise.all(
       skills.map(async (s) => {
         s.supply = await getMintSupply(conn, s.id);


### PR DESCRIPTION
The pure wiring connecting the NFT indexer to the SDK's search/reputation paths.
(Re-opened against main after #13 auto-closed when its base branch
`feat/skill-traits-in-json` was deleted on #12's merge. #12 is already in main.)

## What
- **`indexerSource(baseUrl)`** — a `SkillSource` enumerating via the indexer's
  `GET /items`, mapping each item to a `Skill`. Depends only on the indexer's
  HTTP JSON, not its repo.
- **`SkillSource.hydrated`** — optional flag. The indexer stored live `supply` +
  traits, so `indexerSource` sets `hydrated: true`; `dasSource` leaves it falsy.
- **`searchSkills`** — a hydrated source skips the per-mint `getMintSupply` loop
  on supply sort (was N RPCs/search). `verifyTraits` stays opt-in.
- **`getReputation` / `getLeaderboard`** — use the source's live supply when
  hydrated, else read each mint.

## Fallback
`indexerSource` is the fast path; when unreachable its `listSkills()` throws → the
caller swaps `source` back to `dasSource` (same scan, own RPC).

## Verification
`tsc --noEmit` clean; `vitest run` → 15 files / **85 tests** pass.