### PR TITLE
feat(search): listUnlockable — unlock-ready + almost-there workflows

### DIFF
--- a/packages/core/src/core/skillSource.ts
+++ b/packages/core/src/core/skillSource.ts
@@ -26,21 +26,24 @@ export interface SkillSource {
   hydrated?: boolean;
 }
 
-/** Pull category (single) + hashtags (repeated "skill" traits) out of a code-in
- *  JSON's standard `attributes` array (skill-nft-json.md §4). DAS surfaces these
- *  under content.metadata.attributes after resolving the mint's uri. */
+/** Pull the standard traits out of a code-in JSON's `attributes` array
+ *  (skill-nft-json.md §4/§4b): `category` (single), `skill` (repeated hashtags),
+ *  and `requiredSkill` (repeated prerequisite mint ids, workflows only). DAS
+ *  surfaces these under content.metadata.attributes after resolving the uri. */
 function traitsFromAttributes(
   attributes: unknown,
-): { category: string; hashtags: string[] } {
-  if (!Array.isArray(attributes)) return { category: "", hashtags: [] };
+): { category: string; hashtags: string[]; requiredSkills: string[] } {
+  if (!Array.isArray(attributes)) return { category: "", hashtags: [], requiredSkills: [] };
   let category = "";
   const hashtags: string[] = [];
+  const requiredSkills: string[] = [];
   for (const a of attributes) {
     if (!a || typeof a.value !== "string") continue;
     if (a.trait_type === "category") category = a.value;
     else if (a.trait_type === "skill") hashtags.push(a.value);
+    else if (a.trait_type === "requiredSkill") requiredSkills.push(a.value);
   }
-  return { category, hashtags };
+  return { category, hashtags, requiredSkills };
 }
 
 /**
@@ -95,7 +98,7 @@ export const dasSource: SkillSource = {
         // hashtags come straight from the scan (skill-nft-json.md §4), no
         // per-mint re-read. supply is the one field DAS doesn't carry live, so
         // search.ts still hydrates that from the mint.
-        const { category, hashtags } = traitsFromAttributes(item.content?.metadata?.attributes);
+        const { category, hashtags, requiredSkills } = traitsFromAttributes(item.content?.metadata?.attributes);
         skills.push({
           id: item.id,
           type,
@@ -106,6 +109,7 @@ export const dasSource: SkillSource = {
           creator: item.authorities?.[0]?.address || "",
           category,
           hashtags,
+          requiredSkills,
           price: "0",
           supply: 0, // hydrated by getMintSupply (live counter, not in the scan)
           uriTxid: item.content?.json_uri || "",
@@ -154,7 +158,7 @@ export function indexerSource(baseUrl: string): SkillSource {
       if (!res.ok) throw new Error(`indexer /items → HTTP ${res.status}`);
       const { items } = (await res.json()) as { items: IndexerItem[] };
       return items.map((it) => {
-        const { category, hashtags } = traitsFromAttributes(it.attributes);
+        const { category, hashtags, requiredSkills } = traitsFromAttributes(it.attributes);
         return {
           id: it.mint,
           type: it.type,
@@ -163,6 +167,7 @@ export function indexerSource(baseUrl: string): SkillSource {
           creator: it.creator ?? "",
           category,
           hashtags,
+          requiredSkills,
           price: "0",
           supply: it.supply, // live — already hydrated by the indexer
           uriTxid: "",

--- a/packages/core/src/core/types.ts
+++ b/packages/core/src/core/types.ts
@@ -24,6 +24,10 @@ export interface Skill {
   creator: string; // wallet address
   category: string;
   hashtags?: string[];
+  // Workflows only: the prerequisite skill mint ids (the repeated `requiredSkill`
+  // traits, skill-nft-json.md §4b). Empty/absent for a plain skill. Carried on
+  // Skill so an enumeration result is enough to compute "what can I unlock".
+  requiredSkills?: string[];
   price?: string; // lamports as decimal string (bigint isn't JSON-serializable)
   supply: number; // mint supply = popularity
   uriTxid: string; // codeIn txid holding the skill text

--- a/packages/core/src/index.ts
+++ b/packages/core/src/index.ts
@@ -46,8 +46,8 @@ export { resolveMinter, tryMinterPubkey, resetMinterCache } from "./nft/minter.j
 export { postNote, readNotes, deleteNote, postAgentNote, readAgentNotes, getBalance } from "./notes/index.js";
 export type { PostNoteInput, ReadNotesOptions, PostAgentNoteInput } from "./notes/index.js";
 // search + the enumeration seam
-export { searchSkills } from "./search/index.js";
-export type { SearchFilters, SortBy, SearchOptions } from "./search/index.js";
+export { searchSkills, listUnlockable } from "./search/index.js";
+export type { SearchFilters, SortBy, SearchOptions, UnlockableWorkflow, UnlockOptions } from "./search/index.js";
 export { dasSource, indexerSource } from "./core/skillSource.js";
 export type { SkillSource } from "./core/skillSource.js";
 // reputation (derived live from supply + reviews)

--- a/packages/core/src/search/index.ts
+++ b/packages/core/src/search/index.ts
@@ -1,2 +1,4 @@
 export { searchSkills } from "./search.js";
 export type { SearchFilters, SortBy, SearchOptions } from "./search.js";
+export { listUnlockable } from "./unlock.js";
+export type { UnlockableWorkflow, UnlockOptions } from "./unlock.js";

--- a/packages/core/src/search/unlock.spec.ts
+++ b/packages/core/src/search/unlock.spec.ts
@@ -1,0 +1,57 @@
+import { describe, it, expect, vi } from "vitest";
+import { listUnlockable } from "./unlock.js";
+import type { SkillSource } from "../core/skillSource.js";
+import type { Skill } from "../core/types.js";
+
+// Three workflows with different prerequisite sets + one plain skill (should be
+// ignored). supply is used only as the tie-break.
+const wf = (id: string, requiredSkills: string[], supply = 0): Skill => ({
+  id, type: "workflow", name: id, description: "", creator: "c",
+  category: "", hashtags: [], requiredSkills, supply, price: "0", uriTxid: "", createdAt: 0,
+});
+const ROWS: Skill[] = [
+  wf("wAll", ["s1", "s2"], 10),       // both held → unlockable
+  wf("wOne", ["s1", "s3"], 99),       // missing s3 → 1 away
+  wf("wTwo", ["s3", "s4"], 5),        // missing s3, s4 → 2 away
+  wf("wThree", ["s3", "s4", "s5"]),   // missing 3 → beyond default maxMissing
+  { id: "plainSkill", type: "skill", name: "x", description: "", creator: "c",
+    category: "", hashtags: [], supply: 0, price: "0", uriTxid: "", createdAt: 0 },
+];
+
+const source = (): SkillSource => ({
+  hydrated: true,
+  listSkills: vi.fn().mockResolvedValue(ROWS.map((r) => ({ ...r }))),
+});
+
+describe("search/listUnlockable", () => {
+  it("returns unlockable first, then almost-there by fewest missing", async () => {
+    const held = ["s1", "s2"]; // can do wAll; 1 away from wOne; 2 from wTwo
+    const res = await listUnlockable(held, { source: source() });
+
+    // wThree dropped (3 missing > default maxMissing 2); plainSkill never counts.
+    expect(res.map((r) => r.workflow.id)).toEqual(["wAll", "wOne", "wTwo"]);
+    expect(res[0].unlockable).toBe(true);
+    expect(res[0].missing).toEqual([]);
+    expect(res[1].missing).toEqual(["s3"]);
+    expect(res[2].missing).toEqual(["s3", "s4"]);
+  });
+
+  it("respects maxMissing (0 = only already-unlockable)", async () => {
+    const res = await listUnlockable(["s1", "s2"], { source: source(), maxMissing: 0 });
+    expect(res.map((r) => r.workflow.id)).toEqual(["wAll"]);
+  });
+
+  it("ignores plain skills and prereq-less workflows", async () => {
+    const res = await listUnlockable(["s1", "s2", "s3", "s4", "s5"], { source: source() });
+    // holding everything → all 4 workflows unlockable; the plain skill is absent.
+    expect(res.every((r) => r.workflow.type === "workflow")).toBe(true);
+    expect(res.find((r) => r.workflow.id === "plainSkill")).toBeUndefined();
+  });
+
+  it("a bogus heldMints is harmless — discovery only, on-chain gate is the truth", async () => {
+    // Claiming skills you don't own just labels more workflows unlockable here;
+    // buy_workflow would still revert on-chain. No throw, no state change.
+    const res = await listUnlockable(["s1", "s2", "s3", "s4"], { source: source() });
+    expect(res.find((r) => r.workflow.id === "wTwo")?.unlockable).toBe(true);
+  });
+});

--- a/packages/core/src/search/unlock.ts
+++ b/packages/core/src/search/unlock.ts
@@ -1,0 +1,64 @@
+// "What can I unlock" — discovery over workflow NFTs (search.md §2b / §"what can
+// I unlock", workflow-nft.md §3). A workflow unlocks when the holder owns every
+// one of its `requiredSkill` prerequisites; "almost-there" = missing only a few.
+//
+// This is pure set math over the enumeration result — no extra RPC, no
+// hydration. The source (indexer or dasSource) already carries each workflow's
+// requiredSkills as a trait, so listUnlockable works identically on either, and
+// the fallback path is the same code (workflow-nft.md §2: "trivial id-set
+// compare"). It is DISCOVERY only: heldMints is caller-supplied and untrusted,
+// but that's safe — the real gate is on-chain (buy_workflow reverts if a
+// prerequisite is missing), so a bogus heldMints at most mislabels a card.
+
+import type { Skill } from "../core/types.js";
+import { dasSource, type SkillSource } from "../core/skillSource.js";
+
+export interface UnlockableWorkflow {
+  workflow: Skill;        // the workflow row (type === "workflow")
+  missing: string[];      // requiredSkill mints the holder doesn't have
+  unlockable: boolean;    // missing.length === 0 → can unlock now
+}
+
+export interface UnlockOptions {
+  /** Enumeration source. Defaults to the DAS collection scan. */
+  source?: SkillSource;
+  /** Cap on missing prerequisites to still surface as "almost there". Default 2;
+   *  0 would return only already-unlockable workflows. */
+  maxMissing?: number;
+  limit?: number;
+}
+
+/**
+ * List workflows the holder can unlock now (missing none) plus the "almost
+ * there" ones (missing ≤ maxMissing), sorted by fewest missing first — so
+ * unlockable workflows lead, then 1-away, then 2-away, …
+ *
+ * @param heldMints the caller's owned skill mint ids (untrusted — discovery only)
+ */
+export async function listUnlockable(
+  heldMints: string[],
+  options?: UnlockOptions,
+): Promise<UnlockableWorkflow[]> {
+  const source = options?.source ?? dasSource;
+  const maxMissing = options?.maxMissing ?? 2;
+  const limit = options?.limit ?? 50;
+  const held = new Set(heldMints);
+
+  const workflows = (await source.listSkills()).filter(
+    (s) => (s.type ?? "skill") === "workflow",
+  );
+
+  const result: UnlockableWorkflow[] = [];
+  for (const workflow of workflows) {
+    const required = workflow.requiredSkills ?? [];
+    // A workflow with no prerequisites isn't an "unlock" target — skip it.
+    if (required.length === 0) continue;
+    const missing = required.filter((m) => !held.has(m));
+    if (missing.length > maxMissing) continue;
+    result.push({ workflow, missing, unlockable: missing.length === 0 });
+  }
+
+  // Fewest missing first (unlockable lead); tie-break by popularity (supply).
+  result.sort((a, b) => a.missing.length - b.missing.length || b.workflow.supply - a.workflow.supply);
+  return result.slice(0, limit);
+}


### PR DESCRIPTION
"What can I unlock" discovery (search.md §"what can I unlock", workflow-nft.md §3):
given the skills a holder owns, list workflows that are **unlockable now** plus
the **almost-there** ones, sorted fewest-missing-first.

## What
- `listUnlockable(heldMints, { source?, maxMissing?, limit? })` →
  `{ workflow, missing[], unlockable }[]`, unlockable leading, then 1-away,
  2-away… (tie-break: supply).
- `Skill` gains optional `requiredSkills` (the repeated `requiredSkill` traits,
  §4b); both `dasSource` and `indexerSource` now fill it.

## Why no indexer change
`requiredSkill` is already a pass-through trait in the indexer's `attributes`, so
`listUnlockable` is **pure set math over the enumeration** — no extra RPC, no
hydration. It runs identically on the indexer (fast) and `dasSource` (fallback).

## Safety
Discovery only. `heldMints` is caller-supplied and untrusted — fine, because the
real gate is on-chain: `buy_workflow` reverts on a missing prerequisite, so a
bogus `heldMints` at most mislabels a card (no state/funds at risk).

## Verification
`tsc --noEmit` clean; `vitest run` → 16 files / **89 tests** pass (4 new:
ordering, maxMissing, skill/prereq-less exclusion, bogus-heldMints harmless).