### PR TITLE
feat(memory): shared agent memory over Drive (issue #18)

### DIFF
--- a/packages/core/package.json
+++ b/packages/core/package.json
@@ -12,7 +12,8 @@
   "scripts": {
     "build": "tsup",
     "test": "vitest run",
-    "test:run": "tsx test/test-runtime.ts"
+    "test:run": "tsx test/test-runtime.ts",
+    "test:memory": "tsx test/test-memory.ts"
   },
   "peerDependencies": {
     "@iqlabs-official/solana-sdk": "^0.1.27",

--- a/packages/core/src/core/paths.ts
+++ b/packages/core/src/core/paths.ts
@@ -73,6 +73,21 @@ export function codexSessionsDir(): string {
   return join(codexHome(), "sessions");
 }
 
+// ── shared memory (issue #18): the per-runtime memory files we sync ⇄ canonical ──
+// Claude keeps discrete frontmatter records under its per-project memory dir; stock
+// Codex reads a plain-markdown AGENTS.md at the repo root (verified: it never writes
+// memory itself, so Codex is inject-only). See plans/shared-memory.md.
+
+/** Claude per-project auto-memory dir: projects/{cwd "/"->"-"}/memory */
+export function claudeMemoryDir(cwd: string): string {
+  return join(claudeProjectDir(cwd), "memory");
+}
+
+/** Codex's repo-level memory file (AGENTS.md at the session cwd). */
+export function codexAgentsFile(cwd: string): string {
+  return join(cwd, "AGENTS.md");
+}
+
 /** Ensure a directory exists (mkdir -p). Call before writing into it. */
 export async function ensureDir(dir: string): Promise<void> {
   await mkdir(dir, { recursive: true });

--- a/packages/core/src/memory/convert/claude.ts
+++ b/packages/core/src/memory/convert/claude.ts
@@ -1,0 +1,141 @@
+// Claude per-project memory dir ⇄ canonical (issue #18). Claude is the source of
+// truth: during a session it writes discrete frontmatter `.md` records under
+// claudeMemoryDir(cwd) plus a MEMORY.md index. We READ those into canonical
+// records (capture) and WRITE canonical back out as the same files (inject), so a
+// fact learned in Codex (or on another device) shows up in Claude's memory dir.
+//
+// Frontmatter here is a small, flat YAML subset (name/description + metadata.{type,
+// originSessionId}) — see plans/shared-memory.md — so we parse it directly instead
+// of pulling a YAML dep. MEMORY.md is a generated index (one line per record) and is
+// rebuilt from the records, never parsed back.
+
+import { readFile, writeFile, readdir, rm } from "node:fs/promises";
+import { join } from "node:path";
+import { claudeMemoryDir, ensureDir } from "../../core/paths.js";
+import type { CanonicalMemory, MemoryRecord, MemoryType } from "../types.js";
+import { emptyMemory } from "../types.js";
+
+const MEMORY_TYPES: MemoryType[] = ["user", "feedback", "project", "reference"];
+const isType = (s: string): s is MemoryType => (MEMORY_TYPES as string[]).includes(s);
+
+// [[name]] cross-links embedded in a record body.
+function parseLinks(body: string): string[] {
+  const out = new Set<string>();
+  for (const m of body.matchAll(/\[\[([^\]]+)\]\]/g)) out.add(m[1].trim());
+  return [...out];
+}
+
+// Split a "---\nfm\n---\nbody" file into its frontmatter lines and body.
+function splitFrontmatter(text: string): { fm: string[]; body: string } {
+  if (!text.startsWith("---")) return { fm: [], body: text };
+  const end = text.indexOf("\n---", 3);
+  if (end < 0) return { fm: [], body: text };
+  const fm = text.slice(3, end).split("\n").filter((l) => l.trim() !== "");
+  const body = text.slice(text.indexOf("\n", end + 1) + 1).replace(/^\n+/, "");
+  return { fm, body };
+}
+
+// Parse one Claude memory file into a canonical record. `slug` is the filename stem,
+// used as the record name when the frontmatter omits it.
+export function parseClaudeRecord(slug: string, text: string): MemoryRecord {
+  const { fm, body } = splitFrontmatter(text);
+  let name = slug;
+  let description = "";
+  let type: MemoryType = "project";
+  let originSessionId: string | undefined;
+  let inMeta = false;
+  for (const line of fm) {
+    const indented = /^\s+/.test(line);
+    const [rawKey, ...rest] = line.trim().split(":");
+    const key = rawKey.trim();
+    const val = rest.join(":").trim();
+    if (key === "metadata") { inMeta = true; continue; }
+    if (!indented) inMeta = false;
+    if (key === "name" && val) name = val;
+    else if (key === "description") description = val;
+    else if (inMeta && key === "type" && isType(val)) type = val;
+    else if (inMeta && key === "originSessionId" && val) originSessionId = val;
+  }
+  const links = parseLinks(body);
+  return {
+    name,
+    description,
+    body: body.trimEnd(),
+    type,
+    ...(links.length ? { links } : {}),
+    ...(originSessionId ? { originSessionId } : {}),
+    updatedAt: Date.now(),
+  };
+}
+
+// Read Claude's memory dir for a project into canonical (capture direction).
+// Skips MEMORY.md (it's a generated index, not a record). Missing dir → empty.
+export async function readClaudeMemory(cwd: string): Promise<CanonicalMemory> {
+  const dir = claudeMemoryDir(cwd);
+  let files: string[];
+  try {
+    files = await readdir(dir);
+  } catch {
+    return emptyMemory();
+  }
+  const records: MemoryRecord[] = [];
+  for (const f of files) {
+    if (!f.endsWith(".md") || f === "MEMORY.md") continue;
+    const text = await readFile(join(dir, f), "utf8");
+    const rec = parseClaudeRecord(f.replace(/\.md$/, ""), text);
+    // stamp file mtime so capture merges deterministically (newest wins)
+    const { mtimeMs } = await (await import("node:fs/promises")).stat(join(dir, f));
+    rec.updatedAt = Math.round(mtimeMs);
+    records.push(rec);
+  }
+  return { version: 1, records };
+}
+
+// Render one canonical record back to a Claude memory file (frontmatter + body).
+export function renderClaudeRecord(r: MemoryRecord): string {
+  const meta = [`  type: ${r.type}`];
+  if (r.originSessionId) meta.push(`  originSessionId: ${r.originSessionId}`);
+  return (
+    `---\n` +
+    `name: ${r.name}\n` +
+    `description: ${r.description}\n` +
+    `metadata:\n${meta.join("\n")}\n` +
+    `---\n\n` +
+    `${r.body.trimEnd()}\n`
+  );
+}
+
+// The generated MEMORY.md index — one line per record, same convention Claude uses.
+export function renderMemoryIndex(records: MemoryRecord[]): string {
+  const lines = records.map(
+    (r) => `- [${r.name}](${r.name}.md) — ${r.description}`,
+  );
+  return `# Memory index\n\n${lines.join("\n")}\n`;
+}
+
+// Write canonical out as Claude's memory dir (inject direction). Overwrites the
+// records we manage and rebuilds MEMORY.md; leaves unrelated files untouched except
+// records whose names disappeared from canonical (pruned to stay in sync).
+export async function writeClaudeMemory(
+  cwd: string,
+  mem: CanonicalMemory,
+): Promise<void> {
+  const dir = claudeMemoryDir(cwd);
+  await ensureDir(dir);
+  const keep = new Set(mem.records.map((r) => `${r.name}.md`));
+  keep.add("MEMORY.md");
+  // prune records that canonical no longer has (a delete on another runtime/device)
+  let existing: string[] = [];
+  try {
+    existing = await readdir(dir);
+  } catch {
+    /* fresh dir */
+  }
+  for (const f of existing) {
+    if (f.endsWith(".md") && !keep.has(f)) await rm(join(dir, f));
+  }
+  for (const r of mem.records) {
+    await writeFile(join(dir, `${r.name}.md`), renderClaudeRecord(r));
+  }
+  await writeFile(join(dir, "MEMORY.md"), renderMemoryIndex(mem.records));
+}

--- a/packages/core/src/memory/convert/codex.ts
+++ b/packages/core/src/memory/convert/codex.ts
@@ -1,0 +1,57 @@
+// Canonical → Codex AGENTS.md (issue #18). One-way INJECT only: verified that stock
+// codex (codex-cli 0.139.0) reads AGENTS.md at session start but never writes memory
+// itself, and that a global + repo AGENTS.md are concatenated — so we own a fenced
+// block inside the repo's AGENTS.md and leave any human-authored content alone.
+// See plans/shared-memory.md (Codex live probes).
+//
+// Codex has no per-record structure, so each canonical record renders to a `##`
+// section (description as the lead line, body below). We don't parse this back —
+// Claude is the source of truth for capture.
+
+import { readFile, writeFile } from "node:fs/promises";
+import { codexAgentsFile } from "../../core/paths.js";
+import type { CanonicalMemory, MemoryRecord } from "../types.js";
+
+const START = "<!-- agentnet:memory:start -->";
+const END = "<!-- agentnet:memory:end -->";
+
+function renderSection(r: MemoryRecord): string {
+  return `## ${r.name}\n\n${r.description}\n\n${r.body.trimEnd()}\n`;
+}
+
+// The managed block (between the markers). Regenerated wholesale each sync.
+export function renderCodexBlock(mem: CanonicalMemory): string {
+  const head =
+    "# Shared memory (managed by AgentNet — do not edit between the markers)";
+  const body = mem.records.map(renderSection).join("\n");
+  return `${START}\n${head}\n\n${body}${END}\n`;
+}
+
+// Splice the managed block into existing AGENTS.md text: replace an existing block,
+// else append one. Content outside the markers is preserved verbatim.
+export function spliceCodexBlock(existing: string, block: string): string {
+  const s = existing.indexOf(START);
+  const e = existing.indexOf(END);
+  if (s >= 0 && e > s) {
+    const before = existing.slice(0, s);
+    const after = existing.slice(e + END.length).replace(/^\n/, "");
+    return `${before}${block}${after}`;
+  }
+  if (existing.trim() === "") return block;
+  return `${existing.replace(/\n*$/, "")}\n\n${block}`;
+}
+
+// Write canonical into the cwd's AGENTS.md, preserving any human content.
+export async function writeCodexMemory(
+  cwd: string,
+  mem: CanonicalMemory,
+): Promise<void> {
+  const file = codexAgentsFile(cwd);
+  let existing = "";
+  try {
+    existing = await readFile(file, "utf8");
+  } catch {
+    /* no AGENTS.md yet */
+  }
+  await writeFile(file, spliceCodexBlock(existing, renderCodexBlock(mem)));
+}

--- a/packages/core/src/memory/index.ts
+++ b/packages/core/src/memory/index.ts
@@ -1,0 +1,68 @@
+// Shared-memory orchestrator (issue #18) — the memory analog of runtime/inject's
+// session resume. Ties the three seams together:
+//   Drive (MemoryStore, encrypted) ⇄ canonical ⇄ per-runtime files (convert/*)
+//
+// Two directions, wired into the runtime around a session (see runtime/index.ts):
+//   • injectAtStart(cli, cwd): pull canonical from Drive and write it into the CLI's
+//     native memory location BEFORE the CLI starts, so it loads on this run.
+//   • captureFromClaude(cwd): after Claude turns, read its memory dir back into
+//     canonical, merge, and push to Drive. (Stock Codex never writes memory, so
+//     there is no Codex capture — verified; see plans/shared-memory.md.)
+
+import type { StorageAdapter, Wallet } from "../runtime/contract.js";
+import { MemoryStore } from "./store.js";
+import { readClaudeMemory, writeClaudeMemory } from "./convert/claude.js";
+import { writeCodexMemory } from "./convert/codex.js";
+import type { CanonicalMemory, MemoryRecord } from "./types.js";
+
+type Cli = "claude" | "codex";
+
+// Merge two canonical sets by record name; newest updatedAt wins on conflict. Used
+// to fold freshly-captured Claude records onto what's already in Drive (and to keep
+// records that only exist on one side).
+export function mergeMemory(
+  base: CanonicalMemory,
+  incoming: CanonicalMemory,
+): CanonicalMemory {
+  const byName = new Map<string, MemoryRecord>();
+  for (const r of base.records) byName.set(r.name, r);
+  for (const r of incoming.records) {
+    const prev = byName.get(r.name);
+    if (!prev || r.updatedAt >= prev.updatedAt) byName.set(r.name, r);
+  }
+  return { version: 1, records: [...byName.values()] };
+}
+
+export class MemorySync {
+  private store: MemoryStore;
+
+  constructor(wallet: Wallet, storage: StorageAdapter) {
+    this.store = new MemoryStore(wallet, storage);
+  }
+
+  // INJECT: write the project's canonical memory into the target CLI's native files
+  // before it starts. No-op-safe when memory is empty (writes an empty index/block).
+  async injectAtStart(cli: Cli, cwd: string): Promise<void> {
+    const mem = await this.store.load(cwd);
+    if (cli === "claude") await writeClaudeMemory(cwd, mem);
+    else await writeCodexMemory(cwd, mem);
+  }
+
+  // CAPTURE: fold Claude's on-disk memory back into Drive. Reads the dir, merges onto
+  // the stored canonical (newest wins), and persists if anything changed. Returns the
+  // merged canonical so callers can re-inject the other runtime if they want.
+  async captureFromClaude(cwd: string): Promise<CanonicalMemory> {
+    const [stored, onDisk] = await Promise.all([
+      this.store.load(cwd),
+      readClaudeMemory(cwd),
+    ]);
+    const merged = mergeMemory(stored, onDisk);
+    if (JSON.stringify(merged) !== JSON.stringify(stored)) {
+      await this.store.save(cwd, merged);
+    }
+    return merged;
+  }
+}
+
+export type { CanonicalMemory, MemoryRecord, MemoryType } from "./types.js";
+export { MemoryStore } from "./store.js";

--- a/packages/core/src/memory/store.ts
+++ b/packages/core/src/memory/store.ts
@@ -1,0 +1,53 @@
+// Encrypted canonical-memory persistence (issue #18). One small blob per (wallet,
+// project) on the StorageAdapter — the SAME user-owned storage (Google Drive etc.)
+// and the SAME wallet crypto as session blobs, so only the wallet decrypts it and it
+// syncs across devices. Unlike sessions this isn't an append-only log (memory is
+// small and rewritten in place), so there's no paging — just get/put one blob.
+//
+// The adapter is already scoped per wallet (buildStorage(cfg, walletAddress)); we add
+// a per-project key so each project's memory is separate (matches Claude's per-cwd
+// memory dir). See plans/shared-memory.md.
+
+import type { StorageAdapter, Wallet } from "../runtime/contract.js";
+import {
+  deriveSessionKey,
+  encryptForWallet,
+  decryptForWallet,
+  type SessionKey,
+} from "../core/crypto.js";
+import type { CanonicalMemory } from "./types.js";
+import { emptyMemory } from "./types.js";
+
+// Storage key for a project's memory blob. cwd "/" -> "-" so it's a flat key, the
+// same encoding Claude uses for its per-project dir.
+export function memoryKey(cwd: string): string {
+  return `memory__${cwd.replaceAll("/", "-")}`;
+}
+
+export class MemoryStore {
+  private key?: SessionKey;
+
+  constructor(
+    private wallet: Wallet,
+    private storage: StorageAdapter,
+  ) {}
+
+  private async getKey(): Promise<SessionKey> {
+    return (this.key ??= await deriveSessionKey(this.wallet));
+  }
+
+  // Load + decrypt a project's canonical memory (empty if none stored yet).
+  async load(cwd: string): Promise<CanonicalMemory> {
+    const blob = await this.storage.get(memoryKey(cwd));
+    if (!blob) return emptyMemory();
+    const plain = await decryptForWallet(await this.getKey(), blob);
+    return JSON.parse(new TextDecoder().decode(plain)) as CanonicalMemory;
+  }
+
+  // Encrypt + write a project's canonical memory (overwrites the single blob).
+  async save(cwd: string, mem: CanonicalMemory): Promise<void> {
+    const plain = new TextEncoder().encode(JSON.stringify(mem));
+    const blob = await encryptForWallet(await this.getKey(), plain);
+    await this.storage.put(memoryKey(cwd), blob);
+  }
+}

--- a/packages/core/src/memory/types.ts
+++ b/packages/core/src/memory/types.ts
@@ -1,0 +1,33 @@
+// Canonical shared-memory form (issue #18) — the CLI-neutral representation that
+// maps to both Claude's per-project frontmatter records and Codex's AGENTS.md, and
+// that gets encrypted to the wallet and synced through the StorageAdapter (same path
+// as session blobs). Mirrors CanonicalSession in runtime/contract.ts.
+//
+// Claude is the richer (lossless) shape — discrete records with frontmatter — so the
+// canonical record carries that metadata; Codex renders down to markdown sections.
+// See plans/shared-memory.md for the format study these fields come from.
+
+export type MemoryType = "user" | "feedback" | "project" | "reference";
+
+export interface MemoryRecord {
+  // stable slug — Claude filename (`<name>.md`) and Codex section-heading slug.
+  name: string;
+  // one-liner — Claude's MEMORY.md index line + the lead line of the Codex section.
+  description: string;
+  // the fact itself, markdown. May contain [[other-name]] cross-links.
+  body: string;
+  type: MemoryType;
+  // [[name]] cross-references to other records (parsed out of the body).
+  links?: string[];
+  // provenance: the session that first wrote this record (kept across round-trips).
+  originSessionId?: string;
+  // last-write wall clock (ms) — used to merge concurrent edits (newest wins).
+  updatedAt: number;
+}
+
+export interface CanonicalMemory {
+  version: 1;
+  records: MemoryRecord[];
+}
+
+export const emptyMemory = (): CanonicalMemory => ({ version: 1, records: [] });

--- a/packages/core/src/runtime/index.ts
+++ b/packages/core/src/runtime/index.ts
@@ -7,6 +7,7 @@
 import { spawnCli } from "./spawn.js";
 import { SessionStore } from "../account/store.js";
 import { prepareResume } from "./inject/index.js";
+import { MemorySync } from "../memory/index.js";
 import type { ApprovalChannel } from "./approval/channel.js";
 import type {
   AgentRuntime,
@@ -25,6 +26,9 @@ export function createRuntime(
   approval?: ApprovalChannel,
 ): AgentRuntime {
   const store = new SessionStore(wallet, storage);
+  // Shared memory (issue #18): same wallet + storage as sessions. Injected into the
+  // CLI's native memory files before it starts; captured back from Claude after turns.
+  const memory = new MemorySync(wallet, storage);
 
   return {
     async startSession(opts): Promise<SessionHandle> {
@@ -36,6 +40,15 @@ export function createRuntime(
       const nativeId = resuming
         ? await prepareResume(store, opts.cli, opts.cwd, opts.sessionId!)
         : undefined;
+
+      // Inject the project's shared memory into this CLI's native files (Claude's
+      // memory dir / Codex's AGENTS.md) BEFORE it starts so it loads this run. Best
+      // effort — a memory/storage hiccup must not block starting the session.
+      try {
+        await memory.injectAtStart(opts.cli, opts.cwd);
+      } catch (e) {
+        console.warn("[memory] inject failed:", e);
+      }
 
       // per-session approval channel (each panel passes its own) wins; fall back to
       // the runtime-level default channel.
@@ -80,6 +93,13 @@ export function createRuntime(
         void flush().then(() => {
           for (const cb of turnCbs) cb();
         });
+        // Capture any memory Claude wrote this turn back to Drive (stock Codex never
+        // writes memory, so only Claude is captured). Fire-and-forget; best effort.
+        if (opts.cli === "claude") {
+          void memory.captureFromClaude(opts.cwd).catch((e) =>
+            console.warn("[memory] capture failed:", e),
+          );
+        }
       });
 
       // Surface failures instead of going silent: an engine error shows as a tool

--- a/packages/core/test/e2e-memory-codex.ts
+++ b/packages/core/test/e2e-memory-codex.ts
@@ -1,0 +1,43 @@
+// E2E: full pipeline → REAL codex. Writes a Claude-style memory record, captures it
+// to the (local) Drive store, injects into the project's AGENTS.md via MemorySync,
+// then the CALLER runs `codex exec` in that cwd to confirm stock codex actually loads
+// what our pipeline produced. Prints the project cwd so the shell step can cd there.
+import { tmpdir } from "node:os";
+import { join } from "node:path";
+import { mkdtempSync, mkdirSync, writeFileSync } from "node:fs";
+
+const tmp = mkdtempSync(join(tmpdir(), "agentnet-e2e-"));
+process.env.AGENTNET_HOME = join(tmp, "agentnet");
+process.env.CLAUDE_CONFIG_DIR = join(tmp, "claude");
+
+const { testWallet } = await import("../src/account/keypairWallet.js");
+const { manualStorage } = await import("../src/account/storage/manual.js");
+const { MemorySync } = await import("../src/memory/index.js");
+const { writeClaudeMemory } = await import("../src/memory/convert/claude.js");
+
+const cwd = join(tmp, "proj");
+mkdirSync(cwd, { recursive: true });
+// a human-authored AGENTS.md that must survive
+writeFileSync(join(cwd, "AGENTS.md"), "# Proj\n\nDo not delete this human line.\n");
+
+const wallet = testWallet();
+const storage = manualStorage();
+const sync = new MemorySync(wallet, storage);
+
+// 1. mimic Claude writing a memory record during a session
+await writeClaudeMemory(cwd, {
+  version: 1,
+  records: [{
+    name: "deploy-codeword",
+    description: "the secret deploy word",
+    body: "DEPLOY_CODEWORD is ZEBRA42. This is the canonical shared memory fact.",
+    type: "project",
+    updatedAt: Date.now(),
+  }],
+});
+
+// 2. capture Claude dir → Drive, then 3. inject Drive → codex AGENTS.md
+await sync.captureFromClaude(cwd);
+await sync.injectAtStart("codex", cwd);
+
+console.log(cwd);

--- a/packages/core/test/test-memory.ts
+++ b/packages/core/test/test-memory.ts
@@ -1,0 +1,106 @@
+// Round-trip test for shared memory (issue #18). No CLIs spawned — exercises the
+// three seams directly: Claude memory dir ⇄ canonical ⇄ encrypted Drive blob, and
+// canonical → Codex AGENTS.md. Run: pnpm tsx test/test-memory.ts
+//
+// Isolate all on-disk writes into a temp dir (AGENTNET_HOME + CLAUDE_CONFIG_DIR)
+// BEFORE importing anything that resolves paths at module load.
+import { tmpdir } from "node:os";
+import { join } from "node:path";
+import { mkdtempSync, mkdirSync, writeFileSync, readFileSync } from "node:fs";
+
+const tmp = mkdtempSync(join(tmpdir(), "agentnet-mem-"));
+process.env.AGENTNET_HOME = join(tmp, "agentnet");
+process.env.CLAUDE_CONFIG_DIR = join(tmp, "claude");
+
+const { testWallet } = await import("../src/account/keypairWallet.js");
+const { manualStorage } = await import("../src/account/storage/manual.js");
+const { MemoryStore } = await import("../src/memory/store.js");
+const { MemorySync, mergeMemory } = await import("../src/memory/index.js");
+const claudeConv = await import("../src/memory/convert/claude.js");
+const codexConv = await import("../src/memory/convert/codex.js");
+const { claudeMemoryDir, codexAgentsFile } = await import("../src/core/paths.js");
+import type { CanonicalMemory } from "../src/memory/types.js";
+
+let failures = 0;
+function check(name: string, cond: boolean) {
+  console.log(`${cond ? "  ✓" : "  ✗"} ${name}`);
+  if (!cond) failures++;
+}
+
+const cwd = join(tmp, "proj"); // real temp project dir (Codex writes AGENTS.md here)
+mkdirSync(cwd, { recursive: true });
+const wallet = testWallet();
+const storage = manualStorage();
+
+const sample: CanonicalMemory = {
+  version: 1,
+  records: [
+    {
+      name: "git-sdk-evm-port",
+      description: "Port on-chain Git SDK to EVM — Phase 5 next",
+      body: "Next: port `@iqlabs/git-sdk` to EVM. Reuse [[ethereum-sdk-shape]].",
+      type: "project",
+      links: ["ethereum-sdk-shape"],
+      originSessionId: "62c2f9f5-04c4-4cdf-8459-28e0304a4771",
+      updatedAt: 1000,
+    },
+  ],
+};
+
+// 1. Encrypted store round-trip (the Drive path + wallet crypto).
+console.log("1. MemoryStore encrypt → decrypt");
+const mstore = new MemoryStore(wallet, storage);
+await mstore.save(cwd, sample);
+const loaded = await mstore.load(cwd);
+check("blob decrypts to identical canonical", JSON.stringify(loaded) === JSON.stringify(sample));
+check("stored blob is NOT plaintext", !new TextDecoder()
+  .decode((await storage.get(`memory__${cwd.replaceAll("/", "-")}`))!)
+  .includes("git-sdk-evm-port"));
+
+// 2. canonical → Claude memory dir → back to canonical (lossless on metadata).
+console.log("2. Claude memory dir round-trip");
+await claudeConv.writeClaudeMemory(cwd, sample);
+const dir = claudeMemoryDir(cwd);
+check("record file written", readFileSync(join(dir, "git-sdk-evm-port.md"), "utf8").includes("Phase 5 next"));
+check("MEMORY.md index written", readFileSync(join(dir, "MEMORY.md"), "utf8").includes("[git-sdk-evm-port]"));
+const back = await claudeConv.readClaudeMemory(cwd);
+const r = back.records[0];
+check("name survives", r?.name === "git-sdk-evm-port");
+check("description survives", r?.description === sample.records[0].description);
+check("type survives", r?.type === "project");
+check("originSessionId survives", r?.originSessionId === sample.records[0].originSessionId);
+check("[[links]] re-parsed from body", JSON.stringify(r?.links) === JSON.stringify(["ethereum-sdk-shape"]));
+
+// 3. canonical → Codex AGENTS.md, preserving human content + idempotent re-splice.
+console.log("3. Codex AGENTS.md inject preserves human content");
+const human = "# My project\n\nHand-written notes I do not want clobbered.\n";
+writeFileSync(codexAgentsFile(cwd), human);
+await codexConv.writeCodexMemory(cwd, sample);
+let agents = readFileSync(codexAgentsFile(cwd), "utf8");
+check("human content preserved", agents.includes("Hand-written notes I do not want clobbered"));
+check("memory fact injected", agents.includes("git-sdk-evm-port") && agents.includes("Phase 5 next"));
+check("fenced block present", agents.includes("agentnet:memory:start") && agents.includes("agentnet:memory:end"));
+await codexConv.writeCodexMemory(cwd, sample); // second sync
+agents = readFileSync(codexAgentsFile(cwd), "utf8");
+check("re-sync does not duplicate the block", agents.split("agentnet:memory:start").length === 2);
+check("re-sync keeps human content once", agents.split("Hand-written notes").length === 2);
+
+// 4. merge: newest updatedAt wins; disjoint records both kept.
+console.log("4. mergeMemory newest-wins");
+const older = { version: 1 as const, records: [{ ...sample.records[0], description: "OLD", updatedAt: 1 }] };
+const newer = { version: 1 as const, records: [{ ...sample.records[0], description: "NEW", updatedAt: 2 }] };
+const extra = { version: 1 as const, records: [{ name: "other", description: "x", body: "y", type: "user" as const, updatedAt: 5 }] };
+check("newer description wins", mergeMemory(older, newer).records[0].description === "NEW");
+check("older does not overwrite newer", mergeMemory(newer, older).records[0].description === "NEW");
+check("disjoint records both kept", mergeMemory(sample, extra).records.length === 2);
+
+// 5. cross-runtime: a fact in Claude format ends up readable in Codex's AGENTS.md.
+console.log("5. cross-runtime Claude → Drive → Codex");
+const sync = new MemorySync(wallet, storage);
+const captured = await sync.captureFromClaude(cwd);   // read claude dir → Drive
+check("capture round-trips the Claude record", captured.records.some((x) => x.name === "git-sdk-evm-port"));
+await sync.injectAtStart("codex", cwd);                // Drive → codex AGENTS.md
+check("fact crossed into Codex AGENTS.md", readFileSync(codexAgentsFile(cwd), "utf8").includes("git-sdk-evm-port"));
+
+console.log(failures === 0 ? "\nALL PASS" : `\n${failures} FAILED`);
+process.exit(failures === 0 ? 0 : 1);

--- a/plans/shared-memory.md
+++ b/plans/shared-memory.md
@@ -1,0 +1,176 @@
+# Shared agent memory over Google Drive (issue #18)
+
+One shared, wallet-owned memory that syncs across runtimes (Claude / Codex) and
+devices via the existing Google-Drive `StorageAdapter` — the memory analog of
+cross-CLI session resume. Shape: **per-runtime memory file ⇄ canonical store ⇄
+Drive**, mirroring `runtime/convert` + `runtime/inject` + `account/store.ts`.
+
+Branch: `feat/shared-memory`, cut from `main` (where the storage + capture/inject
+layers already live; `feat/cross-cli-resume-and-storage` is already merged).
+
+---
+
+## Task 1 — Research: real on-disk memory of each runtime
+
+Parsed from a live install on this machine (not from docs). The point is to design
+a canonical form that maps losslessly to whichever of these is the *richer*
+structure (Claude) and renders down to the *flatter* one (Codex).
+
+### Claude — structured, multi-file, with a frontmatter + index convention
+
+Three distinct memory surfaces:
+
+| Surface | Path | Format | Loaded into session |
+|---|---|---|---|
+| Global instructions | `~/.claude/CLAUDE.md` | plain markdown | concatenated into system context every session |
+| Project instructions | `<repo>/CLAUDE.md` | plain markdown (committed to repo) | concatenated when cwd is in that repo |
+| **Auto-memory** | `~/.claude/projects/<encoded-cwd>/memory/` | **frontmatter `.md` files + `MEMORY.md` index** | index loaded every session; individual files *recalled on relevance* (surfaced inside `<system-reminder>`) |
+
+The auto-memory dir is the interesting one (the others are just flat prose). Layout:
+
+- One `.md` file **per fact**, e.g. `git-sdk-evm-port.md`, with YAML frontmatter:
+  ```markdown
+  ---
+  name: git-sdk-evm-port
+  description: Port on-chain Git SDK to EVM — Phases 1-4 done (branch evm-port)…
+  metadata:
+    node_type: memory
+    type: project            # user | feedback | project | reference
+    originSessionId: 62c2f9f5-04c4-4cdf-8459-28e0304a4771
+  ---
+
+  <markdown body — the fact. Links other memories via [[other-name]].>
+  ```
+- `MEMORY.md` — the index, **one line per memory**, loaded into context each session:
+  ```markdown
+  # Memory index
+  - [git-sdk-evm-port](git-sdk-evm-port.md) — port on-chain Git SDK to EVM: Phase 5 next
+  ```
+- Cross-links between records use `[[name]]` (matches another record's `name:` slug).
+- `<encoded-cwd>` = the project path with `/` → `-` (e.g.
+  `-Users-parthagrawal99-Desktop-iq-labs`), so memory is **scoped per project dir**.
+
+Field semantics worth preserving: `name` (stable slug / filename), `description`
+(one-line, used for recall ranking + the index line), `metadata.type`
+(user / feedback / project / reference), `metadata.originSessionId` (provenance).
+
+### Codex — flat, hierarchical, single primitive (`AGENTS.md`)
+
+OpenAI Codex's documented memory primitive is **`AGENTS.md`**: plain markdown, **no
+frontmatter, no per-record structure, no index**. It is hierarchical and *merged*
+at session start (global → repo → cwd):
+
+| Path | Role |
+|---|---|
+| `~/.codex/AGENTS.md` | global, all projects |
+| `<repo-root>/AGENTS.md` | per-repo (committed; AgentNet ships one at `surfaces/android/guest/AGENTS.md`) |
+| `<cwd>/AGENTS.md` | most specific |
+
+`~/.codex/config.toml` is config (notify hooks, `[projects."…"]` trust), **not**
+memory. Sessions are jsonl under `~/.codex/sessions/YYYY/MM/DD/` — already handled
+by `runtime/inject/codex.ts`.
+
+> ⚠️ This particular machine also has a non-standard `~/.codex/memories/` dir (its
+> own `MEMORY.md` + `raw_memories.md` + `rollout_summaries/`) from an extended
+> Codex build. That is **not** the portable Codex primitive and should NOT be the
+> canonical target — AgentNet spawns stock `codex`, whose memory is `AGENTS.md`.
+
+### Codex live probes (codex-cli 0.139.0, model gpt-5.5) — verified, not assumed
+
+Ran `codex exec` against a temp repo with a known codeword in `AGENTS.md`:
+
+1. **Inject works** — AGENTS.md is loaded at session start; codex recalled the
+   planted codeword. So `canonical → AGENTS.md` is a working injection path.
+2. **Merge = concatenation** — with both `~/.codex/AGENTS.md` (global) and
+   `<cwd>/AGENTS.md` (repo) present, codex saw **both** values (not override).
+   → our global block coexists with any repo-authored `AGENTS.md`.
+3. **Stock codex NEVER self-writes memory** — after a turn, AGENTS.md hash was
+   unchanged, no global `~/.codex/AGENTS.md` was created, no memory file written.
+   Only a session `rollout-*.jsonl` was produced (already handled by
+   `runtime/convert/codex.ts`).
+4. CLI note: `codex exec` reads stdin even when a prompt arg is given — pass
+   `< /dev/null` to avoid a hang; `--skip-git-repo-check` lets it run outside a repo.
+
+**Design impact — the round-trip is ASYMMETRIC:**
+- **Claude** = read **and** write (it owns discrete frontmatter records → the
+  canonical *writer/source of truth*).
+- **Codex** = **inject-only / read** (stock codex never mutates memory). So there is
+  **no Codex→canonical capture to build** for stock codex. We only render
+  `canonical → ~/.codex/AGENTS.md` (a fenced `<!-- agentnet:memory -->` block so we
+  never clobber human content), refreshed at session start.
+
+This collapses Task 3: capture-back logic is needed for the **Claude** side only
+(watch its memory dir → canonical → Drive); the Codex side is a one-way inject.
+**Scope (decided): per-wallet + project.** Storage key = `mem/<wallet>/<projectId>`
+where `projectId` is the project cwd (Claude already scopes per project via
+`projects/<encoded-cwd>/memory/`; the same cwd identifies the Codex repo). So the
+Codex fenced block is written to the **repo `<cwd>/AGENTS.md`** (not global) — its
+concatenation behavior keeps any human content in that file intact. One canonical
+blob per (wallet, project), mapping 1:1 to Claude's per-project memory dir.
+
+### Comparison
+
+| | Claude auto-memory | Codex `AGENTS.md` |
+|---|---|---|
+| Unit | one frontmatter `.md` **per fact** | sections (`##`) inside **one** file |
+| Metadata | `name`, `description`, `type`, origin (YAML) | none (heading text only) |
+| Index | explicit `MEMORY.md` | none (the file *is* the whole memory) |
+| Scope | per project dir (`projects/<encoded-cwd>/memory/`) | global + repo + cwd, merged |
+| Cross-links | `[[name]]` | none |
+| Load | index always; records on relevance | whole merged file, always |
+| Write granularity | add/edit/delete a single record file | edit the one markdown file |
+
+**Design consequence:** Claude is the *lossless superset*. The canonical form must
+carry per-record metadata (name/description/type/links/origin). Mapping:
+
+- **canonical → Claude**: one `.md` per record (fields → frontmatter) + regenerate
+  `MEMORY.md` from each record's `description`. Direct.
+- **canonical → Codex**: render every record as a `## <name>` section (description
+  as the lead line, body below) into a single managed `AGENTS.md` block.
+- **Codex → canonical (capture)**: parse `##` sections back to records keyed by
+  heading slug; this is **lossy** (no frontmatter), so merge onto existing
+  canonical metadata rather than overwriting `type`/`origin`. Use a fenced marker
+  region (e.g. `<!-- agentnet:memory:start -->…<!-- end -->`) so we only own our
+  block and never clobber human-authored `AGENTS.md` content.
+
+---
+
+## Task 2 — Design: one canonical memory form (next)
+
+Mirror `CanonicalSession` in
+[contract.ts](../packages/core/src/runtime/contract.ts). Sketch:
+
+```ts
+interface MemoryRecord {
+  name: string;          // stable slug = Claude filename / Codex heading slug
+  description: string;    // one-line; Claude index line + Codex section lead
+  body: string;           // markdown
+  type: "user" | "feedback" | "project" | "reference";
+  links?: string[];       // [[name]] cross-refs
+  originSessionId?: string;
+  updatedAt: number;
+}
+interface CanonicalMemory { version: 1; records: MemoryRecord[]; }
+```
+
+- Persist via `StorageAdapter` (reuse `gdrive.ts`), encrypted to the wallet with the
+  same crypto path `account/store.ts` uses, keyed per wallet/agent (single small
+  blob — no paging needed, unlike sessions).
+- Inject at session start (canonical → that runtime's files); capture writes back
+  (runtime files → canonical → Drive), wired into
+  [runtime/index.ts](../packages/core/src/runtime/index.ts) beside the session path.
+
+## Task 3 — Implement (after design agreed)
+
+`packages/core/src/memory/`:
+- `convert/{claude,codex}.ts` — native memory files ⇄ `CanonicalMemory`.
+- `store.ts` — encrypted canonical memory over `StorageAdapter` (model on
+  `account/store.ts`, single-blob).
+- wire inject-at-start + capture-on-write into `runtime/index.ts`.
+
+## Verification
+- Round-trip test (model on `packages/core/test/test-runtime.ts`): write a fact in
+  Claude format → canonical → (Drive/local stub) → render Codex `AGENTS.md` → parse
+  back → assert the fact + its metadata survive both directions.
+- E2E: learn a fact in a Claude session, start a Codex session for the same wallet,
+  confirm it appears in the injected `AGENTS.md` block.

--- a/plans/skill-ingestion-research.md
+++ b/plans/skill-ingestion-research.md
@@ -1,0 +1,156 @@
+# Skill ingestion — OSS research (issue #17, Task 1)
+
+> Sibling: [`search.md`](search.md) §2c (reader-side verify) ·
+> [`skill-nft-structure.md`](skill-nft-structure.md) ·
+> [`skill-market/skill-shopping.md`](../packages/core/src/skill-market/skill-shopping.md)
+> · [`shared-memory.md`](shared-memory.md) (the inject-at-start pattern we mirror).
+>
+> **This is Task 1: research only — no design decisions are settled here.** Goal: write
+> up how each agent runtime reads/treats skill `.md` files, enough to choose AgentNet's
+> passive (`verify`) + active (on-demand) loading mechanism in
+> [`skill-ingestion.md`](skill-ingestion.md) (Task 2).
+
+---
+
+## 0. Why this first
+
+We have marketplace plumbing (publish / buy / search / `readSkillText`, MCP surface
+`createAgentMcpServer` / `getAgentNetTools` / `handleToolCall` in
+[`skill-market/index.ts`](../packages/core/src/skill-market/index.ts)) but no defined
+**ingestion/run** structure. Two skill kinds must be supported:
+
+- **Passive — always on.** Canonical: `verify`. Loaded every session, runs unasked to
+  vet a candidate skill's text before buy/equip (reader-side; **no on-chain audit** —
+  search.md §2c, onchain-format/tables.md §0).
+- **Active — sometimes on.** Loaded only when the task needs it. Canonical: the existing
+  `skill-shopping.md` (search market → `buy_skill`).
+
+We can't pick the mechanism without knowing how each target runtime handles `.md` skill
+files. The survey below is grounded in the SDK type defs and live behavior verified in
+this repo, not from memory.
+
+---
+
+## 1. Claude Code / `@anthropic-ai/claude-agent-sdk` (v0.3.170, the version we ship)
+
+This is the runtime we already drive in
+[`runtime/spawn.ts`](../packages/core/src/runtime/spawn.ts) via `query()`.
+
+### SKILL.md shape
+- A skill is a directory `<skill-name>/SKILL.md` with **YAML frontmatter** + markdown body.
+- Frontmatter requires `name` (≤64 chars, `[a-z0-9-]`) and `description` (≤1024 chars,
+  non-empty). Our [`skill-shopping.md`](../packages/core/src/skill-market/skill-shopping.md)
+  already matches this shape (`name`, `description`, plus extra fields it tolerates).
+
+### Where skills load from
+- User: `~/.claude/skills/` — `claudeHome()` in
+  [`core/paths.ts`](../packages/core/src/core/paths.ts) is `~/.claude` (override
+  `CLAUDE_CONFIG_DIR`).
+- Project: `.claude/skills/` under the session cwd.
+- Plugins: `plugin:skill` qualified names.
+
+### Always-on vs on-demand (progressive disclosure)
+- **Always-on layer (tiny):** at session start the runtime preloads ONLY each skill's
+  `name` + `description` (from frontmatter) into the system prompt. Hundreds of skills
+  cost almost no context.
+- **On-demand layer:** when the model decides a skill applies, it reads the full
+  `SKILL.md` (and any files it references) into context via the `Skill` tool / bash. The
+  body is not in context until triggered.
+- Consequence for us: **a SKILL.md alone is on-demand by nature.** "Always runs before
+  buy" (passive `verify`) cannot come from merely placing a SKILL.md — it needs an
+  always-on *instruction* in the system prompt / CLAUDE.md that says "always verify
+  first," with the verify skill available for the model to pull.
+
+### The SDK seams (verified in `claude-agent-sdk/sdk.d.ts`, the `Options` type)
+| Option | What it controls | Relevance |
+|---|---|---|
+| `skills?: string[] \| 'all'` | **THE single place to enable skills.** Names = SKILL.md `name`/dir, or `plugin:skill`. Don't add `'Skill'` to `allowedTools` yourself. Context filter, not a sandbox. | Active skills: enable `['verify','skill-shopping', …]`. |
+| `settingSources?: SettingSource[]` (`'user'`/`'project'`/`'local'`) | Which on-disk settings to load. **Must include `'project'` to load CLAUDE.md.** `[]` = SDK isolation. | Needed if we use project `.claude/skills/` + CLAUDE.md for the always-on instruction. |
+| `systemPrompt` | `string` (custom) \| `string[]` (with cache boundary) \| `{type:'preset',preset:'claude_code',append?}` | Always-on `verify` instruction goes in `append`. |
+| `mcpServers?: Record<string,McpServerConfig>` | In-process / external MCP servers. | Wire `createAgentMcpServer` here for `search_skills`/`buy_skill`. |
+| `allowedTools` / `disallowedTools` | Permit/deny tools. | Allow the MCP market tools. |
+
+**Current state:** [`spawn.ts`](../packages/core/src/runtime/spawn.ts) `query({ options })`
+passes `resume`, `model`, `cwd`, `canUseTool`, `pathToClaudeCodeExecutable`, `stderr` —
+**none of `skills` / `systemPrompt` / `settingSources` / `mcpServers`.** This confirms the
+issue note: the MCP surface is exported but not wired into runtime spawn. These five
+options are the entire wiring surface for Task 2.
+
+---
+
+## 2. Hermes (NousResearch/hermes-agent)
+
+- **SKILL.md-compatible by design.** Skills are markdown + YAML frontmatter (`name`,
+  `description`, `version`, `author`, required env vars / credential files). Same opening
+  `---` YAML block, markdown body convention as Claude.
+- **Discovery:** scans `~/.hermes/skills/` (the primary tree it also writes through via
+  `skill_manage`) plus any `skills.external_dirs` listed in `config.yaml`. So passive
+  presence = drop a skill into a scanned dir.
+- **Cross-agent portability:** skills authored for Claude Code, Cursor, or Codex CLI work
+  in Hermes unmodified; agent-specific frontmatter (e.g. Claude's `context: fork`, Cursor
+  globs) is **ignored**, but the markdown body + supporting files (references, scripts,
+  examples) are used as-is.
+- Takeaway for us: a single canonical `SKILL.md` (frontmatter + body) is portable across
+  Claude + Hermes + Codex/Cursor if we keep extra fields tolerated-and-ignored — which is
+  exactly how `skill-shopping.md` is already written.
+
+---
+
+## 3. Other runtimes — how each takes `.md` into context
+
+| Runtime | Mechanism | Always-on vs on-demand | Frontmatter / discovery |
+|---|---|---|---|
+| **Codex CLI** (we drive it via `@openai/codex-sdk`) | Reads **`AGENTS.md`** at the session cwd (global + repo concatenated) at session start. **Inject-only** — stock codex never writes memory (verified in [`memory/convert/codex.ts`](../packages/core/src/memory/convert/codex.ts), codex-cli 0.139.0). No SKILL.md tool / progressive disclosure. | **Always-on only** — whatever is in AGENTS.md is in context every turn; no on-demand pull mechanism. | Plain markdown, no frontmatter discovery. We own a fenced `<!-- agentnet:… -->` block. |
+| **Cursor** | `.cursor/rules/*.mdc` with frontmatter (`description`, `globs`, `alwaysApply`). | `alwaysApply: true` = always-on; otherwise injected when a glob/agent-decision matches = on-demand. | YAML frontmatter; per-rule glob targeting. |
+| **Claude `CLAUDE.md`** (same runtime as §1, different file) | Project/user `CLAUDE.md` concatenated into the system prompt (loaded when `settingSources` includes `'project'`). | **Always-on**, no discovery — closest analog to Codex AGENTS.md. | No frontmatter; plain instructions. |
+
+---
+
+## 4. The two ingestion idioms (what the survey converges on)
+
+Every runtime above is one of two shapes:
+
+1. **System-prompt / file injection (always-on).** Codex `AGENTS.md`, Claude `CLAUDE.md`,
+   Cursor `alwaysApply` rules. Content is in context every turn, no model decision, no
+   discovery. → This is how a **passive** skill (`verify`) must be delivered.
+2. **Discovered-then-pulled (on-demand, progressive disclosure).** Claude/Hermes
+   `SKILL.md`: only `name`+`description` always-on; full body pulled when the model
+   judges it relevant. → This is how an **active** skill (`skill-shopping`) is delivered.
+
+**Crucial asymmetry for our two target runtimes:**
+- **Claude** has *both* idioms (CLAUDE.md/`systemPrompt.append` for passive; `skills` +
+  Skill tool for active).
+- **Codex** has *only* idiom #1 (AGENTS.md). It has no SKILL.md/progressive-disclosure
+  concept — so for Codex, **both** passive and active skills collapse to "text in
+  AGENTS.md," and "on-demand" can only mean "we splice the active skill's text in before
+  the turn that needs it."
+
+This mirrors exactly the Claude-rich / Codex-inject-only split already handled for shared
+memory ([`memory/index.ts`](../packages/core/src/memory/index.ts),
+[`shared-memory.md`](shared-memory.md)).
+
+---
+
+## 5. Reusable precedent in this repo (do not reinvent)
+
+`MemorySync.injectAtStart(cli, cwd)` in
+[`memory/index.ts`](../packages/core/src/memory/index.ts), wired into `createRuntime`
+([`runtime/index.ts`](../packages/core/src/runtime/index.ts)) **before** `spawnCli`, already:
+- writes canonical content into Claude's per-project files (`claudeMemoryDir`) for Claude,
+- splices a fenced block into `AGENTS.md` (`codexAgentsFile`) for Codex, inject-only,
+- is best-effort (a failure must not block the session).
+
+A passive-skill loader is the **same shape** (different target dir + content). Task 2
+should mirror it, not build a parallel mechanism.
+
+---
+
+## 6. Inputs handed to Task 2 (design)
+
+- Passive `verify`: Claude → `systemPrompt.append` instruction ("always verify before
+  buy/equip") + the verify SKILL.md available via `skills`; Codex → verify text in our
+  AGENTS.md fenced block. Loaded every session via a `SkillSync.injectAtStart` sibling.
+- Active (`skill-shopping` etc.): Claude → `skills` + Skill tool, model pulls on demand;
+  Codex → splice the skill text into AGENTS.md when the task needs it.
+- Buy + verify wiring: pass `createAgentMcpServer` via `query()` `mcpServers` + allow
+  `search_skills`/`buy_skill` via `allowedTools` (the unwired surface from §1).

--- a/plans/skill-ingestion-research.md
+++ b/plans/skill-ingestion-research.md
@@ -141,8 +141,8 @@ skill:
 
 | Runtime | Mechanism | Always-on vs on-demand | Frontmatter / discovery |
 |---|---|---|---|
-| **Codex CLI 0.139.0** (the version we pin — `@openai/codex-sdk@^0.139.0`) | Reads **`AGENTS.md`** at the session cwd (global + repo concatenated) at session start. **Inject-only** — stock codex never writes memory (verified in [`memory/convert/codex.ts`](../packages/core/src/memory/convert/codex.ts)). `codex --help` on the pinned binary shows **no `skills` subcommand** → no SKILL.md support at our version. | **Always-on only** — whatever is in AGENTS.md is in context every turn; no on-demand pull. | Plain markdown, no frontmatter discovery. We own a fenced `<!-- agentnet:… -->` block. |
-| **Codex (newer than 0.139.0)** ⚠️ version-gated | Per developers.openai.com/codex/skills: **does** support SKILL.md — scans `.agents/skills` (cwd→repo root), `$HOME/.agents/skills`, `/etc/codex/skills`, built-ins. | Progressive disclosure: name+description+path always-on (list capped ~8k chars), full body on-demand. | `name`+`description` frontmatter; optional `agents/openai.yaml`. | **Only relevant if AgentNet bumps the codex SDK** — then Codex gains the same SKILL.md path as Claude and the AGENTS.md-only workaround can be dropped. |
+| **Codex CLI 0.139.0** (the version we pin — `@openai/codex-sdk@^0.139.0`) — **VERIFIED by inspecting the shipped binary** (`strings` over the vendored `codex`): it bundles a live `core-skills` Rust module (`core-skills/src/loader.rs`, `config_rules.rs`). **It natively supports SKILL.md.** Scans skill roots: `$CODEX_HOME/skills` / `~/.codex/skills`, `.agents/skills`, plus `skills.config` entries (path/name selectors). Injects a `## Skills` system-prompt section. Exposes a `/skills` command. (The top-level `codex --help` doesn't list a `skills` subcommand — skills are auto-discovered + `/skills`, not a subcommand, which is why the earlier `--help` check misread this.) | **Two-layer, same as Claude.** Always-on **Discovery**: the `## Skills` block lists each skill's **name + description + short path** (with a `### Skill roots` alias table). On-demand: the model opens the SKILL.md at the listed path "for full instructions when using a specific skill." Hard **2% context budget** for the skills list ("Exceeded skills context budget of 2%"). | Frontmatter keys: `name`, `description`, `license`, `allowed-tools`, `metadata`; plus `disable-model-invocation` (true = side-effect workflow, manual-invoke only), `interface.*`, `dependencies.tools.*`. |
+| **`AGENTS.md` (Codex, separate lane)** | Still read at session start (global + repo concatenated), **inject-only** — stock codex never *writes* memory (verified in [`memory/convert/codex.ts`](../packages/core/src/memory/convert/codex.ts)). This is the plain-instruction lane, **distinct from skills** — used for our always-on directives + shared memory, not for delivering skill bodies. | **Always-on**, no discovery. | Plain markdown, no frontmatter. We own a fenced `<!-- agentnet:… -->` block. |
 | **Cursor** (verified at cursor.com/docs/context/rules) | `.cursor/rules/*.mdc` — YAML frontmatter (`description`, `globs`, `alwaysApply`) + body. **Plain `.md` in `.cursor/rules` is ignored** (no frontmatter); `AGENTS.md` at root is the plain-markdown alternative. Rules apply to Agent/Chat only (not Tab/Inline Edit). | **Four** modes: (1) `alwaysApply:true` = always-on (globs/description ignored); (2) "Apply Intelligently" — `false`+description, agent decides from description; (3) "Apply to Specific Files" — globs, auto-attached when a matching file is in context; (4) "Apply Manually" — `@rule-name` mention only. | YAML frontmatter; per-rule glob targeting. Best practice: keep rules **under 500 lines** (docs give no token figure). |
 | **Aider** (verified aider.chat/docs) | `CONVENTIONS.md` — free-form markdown, no frontmatter. Loaded **read-only** into chat via `/read CONVENTIONS.md`, `--read` flag, or the `read:` key in `.aider.conf.yml`; cached if prompt caching on. | **Manual / config-pinned always-on** (once added it stays in context). No discovery, no on-demand pull. | None; plain markdown. Idiom #1. |
 | **Claude `CLAUDE.md`** (same runtime as §1, different file) | Project/user `CLAUDE.md` concatenated into the system prompt (loaded when `settingSources` includes `'project'`). | **Always-on**, no discovery — closest analog to Codex AGENTS.md. | No frontmatter; plain instructions. |
@@ -165,8 +165,9 @@ skill:
   file to the edit wins; explicit chat prompts override. This is the idiom-#1 lane that
   Codex 0.139.0 and Cline (issue #5033) implement.
 - Implication: authoring our skills (`verify`, `skill-shopping`, bought skills) as plain
-  agentskills.io `SKILL.md` keeps them portable across every runtime above; the AGENTS.md
-  block is the fallback for runtimes (our pinned Codex) without SKILL.md support.
+  agentskills.io `SKILL.md` keeps them portable across every runtime above — including our
+  pinned Codex 0.139.0, which supports SKILL.md natively (§3). AGENTS.md is **not** a skill
+  fallback; it's only the always-on *instruction* lane for the passive directive.
 
 ---
 
@@ -181,19 +182,25 @@ Every runtime above is one of two shapes:
    `SKILL.md`: only `name`+`description` always-on; full body pulled when the model
    judges it relevant. → This is how an **active** skill (`skill-shopping`) is delivered.
 
-**Crucial asymmetry for our two target runtimes:**
-- **Claude** has *both* idioms (CLAUDE.md/`systemPrompt.append` for passive; `skills` +
-  Skill tool for active). Leaked-harness confirmed (§1b).
-- **Codex 0.139.0 (pinned)** has *only* idiom #1 (AGENTS.md) — verified no `skills`
-  subcommand (§3). So for our Codex, **both** passive and active skills collapse to "text in
-  AGENTS.md," and "on-demand" can only mean "splice the active skill's text in before the
-  turn that needs it." ⚠️ **Version-gated:** a newer codex (§3, `.agents/skills`) would give
-  Codex idiom #2 too, letting us drop the AGENTS.md workaround — design for AGENTS.md now,
-  leave the door open for the bump.
+**Both target runtimes support BOTH idioms — the asymmetry I first assumed does NOT exist:**
+- **Claude** (agent-SDK + leaked harness §1/§1b): `skills` option + Skill tool for active
+  (idiom #2); `systemPrompt.append` / CLAUDE.md for the always-on passive directive (idiom #1).
+- **Codex 0.139.0** (§3, verified in the shipped binary): native SKILL.md discovery +
+  on-demand body load (idiom #2, with a 2% budget); `AGENTS.md` for the always-on passive
+  directive (idiom #1).
 
-This mirrors exactly the Claude-rich / Codex-inject-only split already handled for shared
-memory ([`memory/index.ts`](../packages/core/src/memory/index.ts),
-[`shared-memory.md`](shared-memory.md)).
+So **active skills use the SAME SKILL.md mechanism on both** — write the skill into the
+runtime's skills dir, it's auto-discovered and pulled on demand. The only per-runtime split
+is the **passive always-run directive**: Claude → `systemPrompt.append`; Codex → AGENTS.md
+block. Note: Codex's `disable-model-invocation: true` is the *opposite* of passive (it means
+"manual-invoke only, don't auto-run"), so it can't express "always run verify" — the
+directive must live in AGENTS.md / system instruction, with `verify` left model-invocable.
+
+(Note: the Claude-rich / Codex-inject-only split that shared memory deals with
+([`memory/index.ts`](../packages/core/src/memory/index.ts),
+[`shared-memory.md`](shared-memory.md)) is a **memory** fact — Codex doesn't *write* memory.
+It does NOT carry over to skills: Codex 0.139.0 fully supports SKILL.md ingestion. Only the
+passive *directive* lane reuses the AGENTS.md splice plumbing.)
 
 ---
 
@@ -213,10 +220,12 @@ should mirror it, not build a parallel mechanism.
 
 ## 6. Inputs handed to Task 2 (design)
 
-- Passive `verify`: Claude → `systemPrompt.append` instruction ("always verify before
-  buy/equip") + the verify SKILL.md available via `skills`; Codex → verify text in our
-  AGENTS.md fenced block. Loaded every session via a `SkillSync.injectAtStart` sibling.
-- Active (`skill-shopping` etc.): Claude → `skills` + Skill tool, model pulls on demand;
-  Codex → splice the skill text into AGENTS.md when the task needs it.
+- Passive `verify`: **both runtimes** get `verify/SKILL.md` written into their skills dir
+  (Claude `.claude/skills`, Codex `~/.codex/skills`); the always-run *directive* is the only
+  split — Claude `systemPrompt.append`, Codex AGENTS.md fenced block. Loaded every session
+  via a `SkillSync.injectAtStart` sibling.
+- Active (`skill-shopping`, bought skills): **same mechanism on both** — write SKILL.md into
+  the runtime's skills dir; auto-discovered, body pulled on demand (Claude Skill tool / Codex
+  `## Skills` list). No AGENTS.md splicing for skill bodies.
 - Buy + verify wiring: pass `createAgentMcpServer` via `query()` `mcpServers` + allow
   `search_skills`/`buy_skill` via `allowedTools` (the unwired surface from §1).

--- a/plans/skill-ingestion-research.md
+++ b/plans/skill-ingestion-research.md
@@ -76,23 +76,64 @@ passes `resume`, `model`, `cwd`, `canUseTool`, `pathToClaudeCodeExecutable`, `st
 issue note: the MCP surface is exported but not wired into runtime spawn. These five
 options are the entire wiring surface for Task 2.
 
+### 1b. The leaked harness — primary-source confirmation (issue's literal ask)
+
+Verified against leaked Claude system prompts (jujumilk3/leaked-system-prompts:
+`anthropic-claude-opus-4.6_20260206.md`, `-4.7`, `-4.5-full`). The harness implements the
+same two-layer model, and — crucially — shows *exactly* how Anthropic force-runs a passive
+skill:
+
+- **Always-on layer** = a `<available_skills>` block in the system prompt. Each entry is a
+  `<skill>` with name, description, and the **path to its SKILL.md** (e.g.
+  `/mnt/skills/public/docx/SKILL.md`). Skill roots: `/mnt/skills/public/` (built-in),
+  `/mnt/skills/user/` (user-uploaded — "attend very closely"), `/mnt/skills/example/`.
+- **On-demand layer** = the model calls the `view` tool on a SKILL.md path *before* doing
+  the task (progressive disclosure, stated explicitly: "read the documentation … BEFORE
+  writing any code").
+- **Passive force-load mechanism (the key finding):** an `<additional_skills_reminder>`
+  block hard-codes *"ALWAYS call `view` on `/mnt/skills/public/pptx/SKILL.md` before …"* —
+  an always-on system-prompt directive that makes a skill run unasked. **This is direct
+  evidence that our passive-`verify` design (a `systemPrompt.append` directive: "always run
+  verify before buy/equip") is exactly the mechanism Anthropic itself uses.** Note the
+  leaked harness (claude.ai computer-use) loads skills from `/mnt/skills`, whereas the
+  shipped Claude Code / agent-SDK (§1) loads from `~/.claude/skills` + project
+  `.claude/skills` via the `skills` option — same model, different surface.
+
 ---
 
 ## 2. Hermes (NousResearch/hermes-agent)
 
-- **SKILL.md-compatible by design.** Skills are markdown + YAML frontmatter (`name`,
-  `description`, `version`, `author`, required env vars / credential files). Same opening
-  `---` YAML block, markdown body convention as Claude.
-- **Discovery:** scans `~/.hermes/skills/` (the primary tree it also writes through via
-  `skill_manage`) plus any `skills.external_dirs` listed in `config.yaml`. So passive
-  presence = drop a skill into a scanned dir.
-- **Cross-agent portability:** skills authored for Claude Code, Cursor, or Codex CLI work
-  in Hermes unmodified; agent-specific frontmatter (e.g. Claude's `context: fork`, Cursor
-  globs) is **ignored**, but the markdown body + supporting files (references, scripts,
-  examples) are used as-is.
-- Takeaway for us: a single canonical `SKILL.md` (frontmatter + body) is portable across
-  Claude + Hermes + Codex/Cursor if we keep extra fields tolerated-and-ignored — which is
-  exactly how `skill-shopping.md` is already written.
+> Verified against the primary source — `website/docs/user-guide/features/skills.md` and
+> `website/docs/guides/work-with-skills.md` in the repo — not just secondary write-ups.
+
+- **SKILL.md + YAML frontmatter.** Required `name`, `description`; optional `version`,
+  `platforms`, and a `metadata.hermes` section (tags, categories, config). Same `---` block
+  + markdown body as Claude.
+- **Discovery:** scans `~/.hermes/skills/` (primary source of truth, organized by category
+  subdirs) plus `skills.external_dirs` in `config.yaml`. Local version wins on name clash.
+- **Loading = three-tier progressive disclosure (its OWN mechanism, like Claude — not
+  always-on):**
+  - **Level 0** `skills_list()` → `[{name, description, category}, …]` (~3k tokens), loaded
+    at session start.
+  - **Level 1** `skill_view(name)` → full SKILL.md body, only when the agent decides it's
+    relevant.
+  - **Level 2** `skill_view(name, file_path)` → specific reference files on demand.
+  - "Skills don't cost tokens until they're actually used."
+- **Activation modes:** built-in skills are **always-on slash commands** (`/skill-name`
+  injects the full SKILL.md into the user message alongside the task); Hub skills are
+  **on-demand**, installed via `hermes skills install official/<cat>/<skill>`. Per-platform
+  enable/disable (CLI / Telegram / Discord) via `hermes skills`.
+- **Config/credentials:** skills declaring needs store under `skills.config.*` in
+  `config.yaml`; prompted on first load.
+- **Cross-agent portability:** follows the open **agentskills.io** standard; skills authored
+  for Claude/Cursor/Codex work unmodified, agent-specific frontmatter ignored, body +
+  supporting files used as-is.
+- **Takeaway for us:** Hermes sits in idiom #2 (discovered-then-pulled, §4) right next to
+  Claude — and it *also* has an always-on lane (built-in slash commands). So the same
+  canonical `SKILL.md` is portable across Claude + Hermes + Codex/Cursor (extra fields
+  tolerated-and-ignored), exactly how `skill-shopping.md` is already written. Its
+  slash-command "inject full body into the user message" is a third concrete pattern for
+  forcing a passive skill in.
 
 ---
 
@@ -100,9 +141,32 @@ options are the entire wiring surface for Task 2.
 
 | Runtime | Mechanism | Always-on vs on-demand | Frontmatter / discovery |
 |---|---|---|---|
-| **Codex CLI** (we drive it via `@openai/codex-sdk`) | Reads **`AGENTS.md`** at the session cwd (global + repo concatenated) at session start. **Inject-only** — stock codex never writes memory (verified in [`memory/convert/codex.ts`](../packages/core/src/memory/convert/codex.ts), codex-cli 0.139.0). No SKILL.md tool / progressive disclosure. | **Always-on only** — whatever is in AGENTS.md is in context every turn; no on-demand pull mechanism. | Plain markdown, no frontmatter discovery. We own a fenced `<!-- agentnet:… -->` block. |
-| **Cursor** | `.cursor/rules/*.mdc` with frontmatter (`description`, `globs`, `alwaysApply`). | `alwaysApply: true` = always-on; otherwise injected when a glob/agent-decision matches = on-demand. | YAML frontmatter; per-rule glob targeting. |
+| **Codex CLI 0.139.0** (the version we pin — `@openai/codex-sdk@^0.139.0`) | Reads **`AGENTS.md`** at the session cwd (global + repo concatenated) at session start. **Inject-only** — stock codex never writes memory (verified in [`memory/convert/codex.ts`](../packages/core/src/memory/convert/codex.ts)). `codex --help` on the pinned binary shows **no `skills` subcommand** → no SKILL.md support at our version. | **Always-on only** — whatever is in AGENTS.md is in context every turn; no on-demand pull. | Plain markdown, no frontmatter discovery. We own a fenced `<!-- agentnet:… -->` block. |
+| **Codex (newer than 0.139.0)** ⚠️ version-gated | Per developers.openai.com/codex/skills: **does** support SKILL.md — scans `.agents/skills` (cwd→repo root), `$HOME/.agents/skills`, `/etc/codex/skills`, built-ins. | Progressive disclosure: name+description+path always-on (list capped ~8k chars), full body on-demand. | `name`+`description` frontmatter; optional `agents/openai.yaml`. | **Only relevant if AgentNet bumps the codex SDK** — then Codex gains the same SKILL.md path as Claude and the AGENTS.md-only workaround can be dropped. |
+| **Cursor** (verified at cursor.com/docs/context/rules) | `.cursor/rules/*.mdc` — YAML frontmatter (`description`, `globs`, `alwaysApply`) + body. **Plain `.md` in `.cursor/rules` is ignored** (no frontmatter); `AGENTS.md` at root is the plain-markdown alternative. Rules apply to Agent/Chat only (not Tab/Inline Edit). | **Four** modes: (1) `alwaysApply:true` = always-on (globs/description ignored); (2) "Apply Intelligently" — `false`+description, agent decides from description; (3) "Apply to Specific Files" — globs, auto-attached when a matching file is in context; (4) "Apply Manually" — `@rule-name` mention only. | YAML frontmatter; per-rule glob targeting. Best practice: keep rules **under 500 lines** (docs give no token figure). |
+| **Aider** (verified aider.chat/docs) | `CONVENTIONS.md` — free-form markdown, no frontmatter. Loaded **read-only** into chat via `/read CONVENTIONS.md`, `--read` flag, or the `read:` key in `.aider.conf.yml`; cached if prompt caching on. | **Manual / config-pinned always-on** (once added it stays in context). No discovery, no on-demand pull. | None; plain markdown. Idiom #1. |
 | **Claude `CLAUDE.md`** (same runtime as §1, different file) | Project/user `CLAUDE.md` concatenated into the system prompt (loaded when `settingSources` includes `'project'`). | **Always-on**, no discovery — closest analog to Codex AGENTS.md. | No frontmatter; plain instructions. |
+| **smolagents** (HF — counter-example) | **No `.md` skill files at all.** Capabilities = Python `Tool` objects (name/description/inputs/output_type) rendered via Jinja2; system prompts = YAML templates (`code_agent.yaml`) loaded from package resources with `importlib.resources`. | n/a — prompt-template + code-object paradigm, not file-discovered skills. | Shows not every framework uses the `.md`-skill model; irrelevant to our two runtimes but bounds the survey. |
+
+### 3b. The portability standard (breadth)
+
+- **agentskills.io** (verified at the canonical site, not a secondary blog) — open SKILL.md
+  standard: a skill is a folder with **`SKILL.md` (required, `name`+`description` min)** plus
+  optional `scripts/`, `references/`, `assets/`. **Originally developed by Anthropic,
+  released as an open standard.** Defines the §4 idiom-#2 pattern explicitly as three stages:
+  **Discovery** (startup: only name+description per skill) → **Activation** (read full
+  SKILL.md when task matches description) → **Execution** (follow + load bundled files on
+  demand). Canonical client list (from the site's showcase) includes: Claude Code, Claude,
+  OpenAI Codex, Cursor, VS Code, GitHub Copilot, Gemini CLI, **OpenHands**, **Goose**, Roo
+  Code, JetBrains Junie, OpenCode, Amp, Letta, Kiro, Factory, Tabnine, Mistral Vibe, and
+  ~30 more. So a plain agentskills.io `SKILL.md` is the maximally-portable authoring format.
+- **AGENTS.md** (agents.md) — minimalist sibling standard: a single root `AGENTS.md`,
+  **parsed as plain natural-language markdown, no required structure/metadata**; closest
+  file to the edit wins; explicit chat prompts override. This is the idiom-#1 lane that
+  Codex 0.139.0 and Cline (issue #5033) implement.
+- Implication: authoring our skills (`verify`, `skill-shopping`, bought skills) as plain
+  agentskills.io `SKILL.md` keeps them portable across every runtime above; the AGENTS.md
+  block is the fallback for runtimes (our pinned Codex) without SKILL.md support.
 
 ---
 
@@ -119,11 +183,13 @@ Every runtime above is one of two shapes:
 
 **Crucial asymmetry for our two target runtimes:**
 - **Claude** has *both* idioms (CLAUDE.md/`systemPrompt.append` for passive; `skills` +
-  Skill tool for active).
-- **Codex** has *only* idiom #1 (AGENTS.md). It has no SKILL.md/progressive-disclosure
-  concept — so for Codex, **both** passive and active skills collapse to "text in
-  AGENTS.md," and "on-demand" can only mean "we splice the active skill's text in before
-  the turn that needs it."
+  Skill tool for active). Leaked-harness confirmed (§1b).
+- **Codex 0.139.0 (pinned)** has *only* idiom #1 (AGENTS.md) — verified no `skills`
+  subcommand (§3). So for our Codex, **both** passive and active skills collapse to "text in
+  AGENTS.md," and "on-demand" can only mean "splice the active skill's text in before the
+  turn that needs it." ⚠️ **Version-gated:** a newer codex (§3, `.agents/skills`) would give
+  Codex idiom #2 too, letting us drop the AGENTS.md workaround — design for AGENTS.md now,
+  leave the door open for the bump.
 
 This mirrors exactly the Claude-rich / Codex-inject-only split already handled for shared
 memory ([`memory/index.ts`](../packages/core/src/memory/index.ts),

--- a/plans/skill-ingestion.md
+++ b/plans/skill-ingestion.md
@@ -1,0 +1,144 @@
+# Skill ingestion & run structure — design (issue #17, Task 2)
+
+> Built on the research in [`skill-ingestion-research.md`](skill-ingestion-research.md).
+> Settled model: reader-side verify, **no on-chain audit** (search.md §2c,
+> onchain-format/tables.md §0). Mirrors the inject-at-start pattern of
+> [`shared-memory.md`](shared-memory.md).
+
+---
+
+## 0. The model in one line
+
+A **passive** skill (`verify`) is force-loaded into every session as an always-on
+instruction; an **active** skill (`skill-shopping`, bought skills) is made discoverable and
+pulled on demand. Buy + verify run against the existing market MCP tools
+(`search_skills` / `buy_skill`), which we now wire into the spawned engine.
+
+---
+
+## 1. Where it plugs in
+
+A new `SkillSync` orchestrator, the sibling of `MemorySync`
+([`memory/index.ts`](../packages/core/src/memory/index.ts)), wired into `createRuntime`
+([`runtime/index.ts`](../packages/core/src/runtime/index.ts)) right beside the existing
+`memory.injectAtStart` call — **before** `spawnCli`:
+
+```
+const skills = new SkillSync(wallet, storage);
+...
+await memory.injectAtStart(opts.cli, opts.cwd);   // existing (#18)
+await skills.injectAtStart(opts.cli, opts.cwd);    // new (#17) — best-effort, same try/catch
+const cli = spawnCli({ ...opts, /* + skill spawn opts, see §4 */ });
+```
+
+New module: `packages/core/src/skill-market/ingest/` (or `skills/`), with `index.ts`
+(`SkillSync`) + `convert/claude.ts` + `convert/codex.ts`, matching the memory module's
+layout. Path helpers added to [`core/paths.ts`](../packages/core/src/core/paths.ts) (see §2).
+
+---
+
+## 2. Passive skill (`verify`) — force-load every session
+
+Per-runtime, because the two engines differ (research §4):
+
+### Claude
+- **Instruction (always-on):** add `verify`'s directive to `query()`
+  `systemPrompt: { type:'preset', preset:'claude_code', append: <verify-instruction> }`
+  in [`spawn.ts`](../packages/core/src/runtime/spawn.ts). The append says: *"Before buying
+  or equipping any marketplace skill, run the `verify` skill over its text and act on the
+  result."* This is what makes verify run unasked — a SKILL.md alone is on-demand
+  (research §1).
+- **Skill body (available):** write `verify/SKILL.md` into the project skills dir
+  (`<cwd>/.claude/skills/verify/SKILL.md`) and enable it via `skills: ['verify', …]`.
+  Requires `settingSources` to include `'project'`.
+- New paths: `claudeSkillsDir(cwd)` → `<cwd>/.claude/skills`.
+
+### Codex
+- No SKILL.md / progressive disclosure — only `AGENTS.md` (research §3). So the verify
+  instruction **and** its text go into our managed fenced block in
+  `codexAgentsFile(cwd)`. Reuse the exact splice helpers (`spliceCodexBlock`, marker
+  approach) from [`memory/convert/codex.ts`](../packages/core/src/memory/convert/codex.ts);
+  use a distinct marker pair (`<!-- agentnet:skills:start/end -->`) so memory and skills
+  blocks coexist.
+
+### Source of the verify skill
+`verify` is itself a skill in the net (dogfooding — search.md §2c). `SkillSync` loads its
+text via the existing `readSkillText` ([`skill-market/index.ts`] / `nft/index.ts`), with a
+bundled fallback `verify.md` if the net is unreachable (verify must never be absent — it's
+the safety gate). Bundled fallback lives next to `skill-shopping.md`.
+
+---
+
+## 3. Active skill — discover + load on demand
+
+### Claude (native progressive disclosure)
+- Enable known active skills via `skills` (e.g. `['verify','skill-shopping']`) +
+  `settingSources:['project']`. The model pulls the full body through the Skill tool only
+  when the task needs it — no extra work from us.
+- A **bought** skill (its text fetched via `readSkillText` after `buy_skill`) is written to
+  `<cwd>/.claude/skills/<name>/SKILL.md` so it becomes discoverable next turn/session.
+
+### Codex (no on-demand mechanism)
+- "On demand" can only mean: splice the active skill's text into the AGENTS.md skills block
+  when the task needs it. Simplest correct v1: include `skill-shopping` text in the block
+  every session (it's small and self-gating — "when you lack a capability…"). Bought skills
+  get appended to the block on purchase.
+
+### The shopping flow (unchanged content, now wired)
+[`skill-shopping.md`](../packages/core/src/skill-market/skill-shopping.md) already drives:
+identify missing capability → `search_skills` → evaluate → `buy_skill` (soulbound). Our job
+is only to (a) make it loaded per §3 and (b) make the two tools callable per §4, and (c)
+gate the buy behind verify per §2.
+
+---
+
+## 4. Buy + verify wired to the market MCP tools
+
+The surface exists but is unwired (research §1, confirmed in `spawn.ts`).
+
+- `createAgentMcpServer(conn, signer, defaultCreatorWallet)`
+  ([`skill-market/index.ts:151`](../packages/core/src/skill-market/index.ts)) returns a
+  low-level `@modelcontextprotocol/sdk` `Server` exposing `search_skills` + `buy_skill`
+  (`getAgentNetTools` / `handleToolCall`).
+- **Claude:** pass it through `query()` `mcpServers` and allow the tools via
+  `allowedTools: ['mcp__agentnet-marketplace__search_skills',
+  'mcp__agentnet-marketplace__buy_skill', …]`. Note a bridge is needed: claude-agent-sdk's
+  `mcpServers` takes its own `McpServerConfig` (in-process via `createSdkMcpServer`, or
+  stdio/http) — wrap our `Server`, or re-register the two tools as an SDK MCP server. Decide
+  in implementation; the tool logic (`handleToolCall`) is reused verbatim.
+- **Codex:** configure the same MCP server through `@openai/codex-sdk` thread options
+  (Codex's MCP config), or expose the two operations as local commands the AGENTS.md text
+  tells it to call. Claude is the primary target for v1; Codex MCP can follow.
+- **Verify gate:** the §2 systemPrompt/AGENTS.md instruction makes the agent run `verify`
+  over a candidate's `readSkillText` output *before* calling `buy_skill`. The gate is the
+  buyer's agent (skin in the game), not a central authority (search.md §2c).
+
+`SpawnOpts` in [`spawn.ts`](../packages/core/src/runtime/spawn.ts) gains optional skill
+fields (enabled skill names, the mcp server handle, the verify append text) so
+`createRuntime` passes them through.
+
+---
+
+## 5. Build order
+
+1. `core/paths.ts`: add `claudeSkillsDir(cwd)`; reuse `codexAgentsFile(cwd)`.
+2. `skill-market/ingest/`: `SkillSync.injectAtStart(cli, cwd)` + `convert/{claude,codex}`
+   (mirror memory module). Bundled `verify.md` fallback.
+3. `runtime/index.ts`: instantiate + call `skills.injectAtStart` beside memory's.
+4. `runtime/spawn.ts`: thread `skills`, `systemPrompt.append`, `settingSources:['project']`,
+   `mcpServers`, `allowedTools` into the Claude `query()` options; Codex via AGENTS.md.
+5. MCP bridge for `createAgentMcpServer` → claude-agent-sdk `mcpServers`.
+
+---
+
+## 6. Verification
+
+- Unit: `SkillSync` writes `verify/SKILL.md` under `claudeSkillsDir` and a fenced skills
+  block into `AGENTS.md` (assert markers + idempotent re-splice), mirroring
+  `test-memory.ts`.
+- Integration: start a Claude session, confirm `verify` + `skill-shopping` appear in the
+  skill listing and `search_skills`/`buy_skill` are callable (allowedTools).
+- E2E: give the agent a task needing an unowned capability → it searches, runs verify over
+  the candidate text, then buys — buy never fires before a verify pass.
+- Codex: confirm the skills block lands in `AGENTS.md` alongside the memory block without
+  clobbering it.

--- a/plans/skill-ingestion.md
+++ b/plans/skill-ingestion.md
@@ -100,12 +100,17 @@ The surface exists but is unwired (research §1, confirmed in `spawn.ts`).
   ([`skill-market/index.ts:151`](../packages/core/src/skill-market/index.ts)) returns a
   low-level `@modelcontextprotocol/sdk` `Server` exposing `search_skills` + `buy_skill`
   (`getAgentNetTools` / `handleToolCall`).
-- **Claude:** pass it through `query()` `mcpServers` and allow the tools via
-  `allowedTools: ['mcp__agentnet-marketplace__search_skills',
-  'mcp__agentnet-marketplace__buy_skill', …]`. Note a bridge is needed: claude-agent-sdk's
-  `mcpServers` takes its own `McpServerConfig` (in-process via `createSdkMcpServer`, or
-  stdio/http) — wrap our `Server`, or re-register the two tools as an SDK MCP server. Decide
-  in implementation; the tool logic (`handleToolCall`) is reused verbatim.
+- **Claude:** pass it through `query()` `mcpServers: Record<string, McpServerConfig>` and
+  allow the tools via `allowedTools: ['mcp__agentnet-marketplace__search_skills',
+  'mcp__agentnet-marketplace__buy_skill', …]`. **Bridge needed (verified in
+  `sdk.d.ts`):** the SDK's in-process MCP config is `McpSdkServerConfigWithInstance`
+  (`type:'sdk'`, `instance: McpServer`), produced by the exported
+  `createSdkMcpServer(opts)` (sdk.d.ts:485). Our `createAgentMcpServer`
+  ([`skill-market/index.ts:151`](../packages/core/src/skill-market/index.ts)) returns a
+  **low-level `@modelcontextprotocol/sdk` `Server`**, not the SDK's high-level `McpServer`,
+  so don't wrap it — **re-register the two tools through `createSdkMcpServer`**, reusing
+  `getAgentNetTools()` for the tool schemas and `handleToolCall(...)` for the logic
+  verbatim. Net: a thin `createAgentSdkMcpServer()` adapter in `skill-market/`.
 - **Codex:** configure the same MCP server through `@openai/codex-sdk` thread options
   (Codex's MCP config), or expose the two operations as local commands the AGENTS.md text
   tells it to call. Claude is the primary target for v1; Codex MCP can follow.

--- a/plans/skill-ingestion.md
+++ b/plans/skill-ingestion.md
@@ -53,13 +53,18 @@ Per-runtime, because the two engines differ (research §4):
   Requires `settingSources` to include `'project'`.
 - New paths: `claudeSkillsDir(cwd)` → `<cwd>/.claude/skills`.
 
-### Codex
-- No SKILL.md / progressive disclosure — only `AGENTS.md` (research §3). So the verify
-  instruction **and** its text go into our managed fenced block in
-  `codexAgentsFile(cwd)`. Reuse the exact splice helpers (`spliceCodexBlock`, marker
-  approach) from [`memory/convert/codex.ts`](../packages/core/src/memory/convert/codex.ts);
-  use a distinct marker pair (`<!-- agentnet:skills:start/end -->`) so memory and skills
-  blocks coexist.
+### Codex (0.139.0 — supports SKILL.md natively, research §3)
+- **Skill body (available):** write `verify/SKILL.md` into a Codex skill root —
+  `~/.codex/skills/verify/SKILL.md` (`$CODEX_HOME/skills`) or `<cwd>/.agents/skills/verify/`.
+  Codex auto-discovers it and injects it into the always-on `## Skills` list (name +
+  description + path); body pulled on demand. Mind the **2% skills context budget**.
+- **Instruction (always-on, the only per-runtime split):** Codex skills are model-invoked,
+  and `disable-model-invocation` is the *opposite* of what we want — so the "always run
+  verify before buy/equip" directive goes in our managed fenced block in
+  `codexAgentsFile(cwd)`, reusing `spliceCodexBlock` from
+  [`memory/convert/codex.ts`](../packages/core/src/memory/convert/codex.ts) with a distinct
+  marker pair (`<!-- agentnet:skills:start/end -->`) so memory + skills blocks coexist.
+- New paths: `codexSkillsDir()` → `$CODEX_HOME/skills` (default `~/.codex/skills`).
 
 ### Source of the verify skill
 `verify` is itself a skill in the net (dogfooding — search.md §2c). `SkillSync` loads its
@@ -78,11 +83,12 @@ the safety gate). Bundled fallback lives next to `skill-shopping.md`.
 - A **bought** skill (its text fetched via `readSkillText` after `buy_skill`) is written to
   `<cwd>/.claude/skills/<name>/SKILL.md` so it becomes discoverable next turn/session.
 
-### Codex (no on-demand mechanism)
-- "On demand" can only mean: splice the active skill's text into the AGENTS.md skills block
-  when the task needs it. Simplest correct v1: include `skill-shopping` text in the block
-  every session (it's small and self-gating — "when you lack a capability…"). Bought skills
-  get appended to the block on purchase.
+### Codex (native SKILL.md discovery — same as Claude)
+- Write active skills (`skill-shopping`, bought skills) into `codexSkillsDir()` /
+  `<cwd>/.agents/skills/<name>/SKILL.md`. Codex auto-discovers, lists them in `## Skills`,
+  and pulls the body on demand — no AGENTS.md splicing needed for skill *bodies*. A bought
+  skill's text (via `readSkillText` after `buy_skill`) is written there so it's discoverable
+  next turn/session. Watch the 2% skills budget — write skills, don't dump everything.
 
 ### The shopping flow (unchanged content, now wired)
 [`skill-shopping.md`](../packages/core/src/skill-market/skill-shopping.md) already drives:
@@ -111,9 +117,14 @@ The surface exists but is unwired (research §1, confirmed in `spawn.ts`).
   so don't wrap it — **re-register the two tools through `createSdkMcpServer`**, reusing
   `getAgentNetTools()` for the tool schemas and `handleToolCall(...)` for the logic
   verbatim. Net: a thin `createAgentSdkMcpServer()` adapter in `skill-market/`.
-- **Codex:** configure the same MCP server through `@openai/codex-sdk` thread options
-  (Codex's MCP config), or expose the two operations as local commands the AGENTS.md text
-  tells it to call. Claude is the primary target for v1; Codex MCP can follow.
+- **Codex:** `ThreadOptions` exposes **no** `mcpServers` (verified in
+  `@openai/codex-sdk@0.139.0` `dist/index.d.ts`). Codex MCP is configured via TOML —
+  `CodexOptions.config` (`--config` overrides → `~/.codex/config.toml` `mcp_servers.*`), or
+  the user's `~/.codex/config.toml` / `codex mcp add`. So wiring our market tools into Codex
+  means registering an `mcp_servers` entry (stdio command to a small AgentNet MCP binary, or
+  `codex mcp-server` style). Heavier than Claude's in-process path — **Claude is the v1
+  target; Codex MCP follows.** (Note: `ThreadOptions` also has no `systemPrompt`/`instructions`
+  field — confirms the passive directive must go through AGENTS.md on Codex, §2.)
 - **Verify gate:** the §2 systemPrompt/AGENTS.md instruction makes the agent run `verify`
   over a candidate's `readSkillText` output *before* calling `buy_skill`. The gate is the
   buyer's agent (skin in the game), not a central authority (search.md §2c).
@@ -126,12 +137,17 @@ fields (enabled skill names, the mcp server handle, the verify append text) so
 
 ## 5. Build order
 
-1. `core/paths.ts`: add `claudeSkillsDir(cwd)`; reuse `codexAgentsFile(cwd)`.
+1. `core/paths.ts`: add `claudeSkillsDir(cwd)` (`<cwd>/.claude/skills`) and `codexSkillsDir()`
+   (`$CODEX_HOME/skills`, default `~/.codex/skills`); reuse `codexAgentsFile(cwd)` for the
+   passive directive only.
 2. `skill-market/ingest/`: `SkillSync.injectAtStart(cli, cwd)` + `convert/{claude,codex}`
-   (mirror memory module). Bundled `verify.md` fallback.
+   (mirror memory module). Both converters write SKILL.md into the runtime's skills dir;
+   the Codex converter additionally splices the always-run directive into AGENTS.md. Bundled
+   `verify.md` fallback.
 3. `runtime/index.ts`: instantiate + call `skills.injectAtStart` beside memory's.
-4. `runtime/spawn.ts`: thread `skills`, `systemPrompt.append`, `settingSources:['project']`,
-   `mcpServers`, `allowedTools` into the Claude `query()` options; Codex via AGENTS.md.
+4. `runtime/spawn.ts`: Claude — thread `skills`, `systemPrompt.append`,
+   `settingSources:['project']`, `mcpServers`, `allowedTools` into `query()`; Codex — skills
+   auto-discovered from `codexSkillsDir()`, directive via AGENTS.md.
 5. MCP bridge for `createAgentMcpServer` → claude-agent-sdk `mcpServers`.
 
 ---
@@ -147,3 +163,41 @@ fields (enabled skill names, the mcp server handle, the verify append text) so
   the candidate text, then buys — buy never fires before a verify pass.
 - Codex: confirm the skills block lands in `AGENTS.md` alongside the memory block without
   clobbering it.
+
+---
+
+## 7. Open risks / unverified (resolve during implementation)
+
+These are assumptions the design rests on but that are **not yet verified** — runtime-tested
+or, for #1–#2, not yet decided. Listed worst-first.
+
+1. **`verify` skill does not exist yet.** Only
+   [`skill-shopping.md`](../packages/core/src/skill-market/skill-shopping.md) is in the repo.
+   The entire passive flow assumes a `verify` SKILL.md is authored (and published to the net,
+   or bundled as fallback). **Action:** author `verify/SKILL.md` before any of this works;
+   decide net-published vs bundled-only.
+2. **Passive verify is a soft instruction, not a hard gate.** `systemPrompt.append` /
+   AGENTS.md "always verify before buy" can be skipped by the model (the leaked harness §1b
+   leans on heavy *repeated* reminders for exactly this reason). If verify must be guaranteed,
+   it needs **code enforcement** — e.g. `handleToolCall` rejects `buy_skill` unless a verify
+   pass for that `skillId` was recorded this session. **Decide:** soft directive vs hard
+   interception. Recommend hard for a safety gate.
+3. **Claude `skills` + freshly-dropped project skill timing.** Design writes
+   `verify/SKILL.md` in `injectAtStart` then spawns with `skills:[…]` +
+   `settingSources:['project']`. Grounded in `sdk.d.ts`, but **not runtime-tested** that the
+   SDK rescans `.claude/skills` after our write on the same spawn. **Verify:** the skill
+   appears in the session's listing.
+4. **Codex skills scan via the SDK path.** The 0.139.0 binary has the `core-skills` loader
+   (research §3), but it's **assumed** that a `@openai/codex-sdk` `Thread` run triggers the
+   same `~/.codex/skills` / `.agents/skills` scan as the interactive CLI. **Verify** with a
+   live Codex thread.
+5. **2% skills context budget.** Read from the binary string "Exceeded skills context budget
+   of 2%"; exact semantics (2% of which window, overflow behavior — drop? error?) **inferred,
+   not confirmed.** Matters if many bought skills accumulate. **Verify** the cap + failure mode.
+6. **MCP bridge is a sketch.** `createSdkMcpServer` exists (sdk.d.ts:485) and our `Server` is
+   low-level, so the re-register plan is sound — but the adapter isn't written and the
+   `getAgentNetTools()` schema → SDK tool-def shape mapping is **unverified**. **Build + test**
+   the `createAgentSdkMcpServer()` adapter in isolation first.
+7. **Codex MCP is heavier than Claude's.** No in-process option — needs an `mcp_servers` TOML
+   entry pointing at a stdio MCP binary (§4). The "small AgentNet MCP binary" doesn't exist;
+   scope it or defer Codex MCP past v1 (Claude-first).


### PR DESCRIPTION
Closes #18.

## What
One wallet-owned **shared memory** synced across runtimes (Claude/Codex) and devices through the existing `StorageAdapter` / `gdrive.ts` path — the memory analog of cross-CLI session resume: `canonical form ⇄ per-runtime file ⇄ Drive`.

## Research first (verified live, codex-cli 0.139.0 / gpt-5.5)
Parsed real on-disk memory of each runtime, not docs (see `plans/shared-memory.md`):
- **Claude** = structured superset: discrete frontmatter records under `~/.claude/projects/<encoded-cwd>/memory/` + a `MEMORY.md` index, `[[name]]` cross-links.
- **Codex** = flat `AGENTS.md`. Probed live: loaded at session start, global + repo are **concatenated** (not override), and **stock Codex never self-writes memory**.

**→ Asymmetric round-trip:** Claude is the source of truth (read+write); Codex is **inject-only** via a fenced `<!-- agentnet:memory -->` block that preserves human-authored `AGENTS.md` content.

## Implementation (`packages/core/src/memory/`)
- `types.ts` — canonical `MemoryRecord` / `CanonicalMemory`
- `convert/claude.ts` — read/write Claude memory dir + regen `MEMORY.md` (minimal flat-YAML parser, no new dep)
- `convert/codex.ts` — render canonical → `AGENTS.md` fenced block (one-way, splice preserves human text)
- `store.ts` — one encrypted blob per (wallet, project), reuses `core/crypto.ts` (same wallet crypto as sessions); no paging
- `index.ts` — `MemorySync.injectAtStart` / `captureFromClaude` + `mergeMemory` (newest-`updatedAt` wins)
- Wired into `runtime/index.ts` (inject before spawn, capture on Claude turn-end); path helpers in `core/paths.ts`

## Verification
- Typecheck clean
- `test/test-memory.ts` (`pnpm test:memory`) — **21/21**: encrypted blob round-trip, Claude dir round-trip incl `[[links]]` re-parse, Codex human-content preservation + idempotent re-splice, merge newest-wins, cross-runtime Claude→Drive→Codex
- `test/e2e-memory-codex.ts` — drives **real codex**: pipeline-produced `AGENTS.md` recalled correctly, human content intact