### PR TITLE
feat: 6.9% protocol fee on priced buys

### DIFF
--- a/packages/core/src/core/seed.ts
+++ b/packages/core/src/core/seed.ts
@@ -52,6 +52,13 @@ export const SKILLS_COLLECTION_MINT = "4exdqNEcXixiMzenEBts2cE7qLmMvcVtHCjsZUGBm
 export const WORKFLOWS_COLLECTION_MINT = "ByrnPfd9DcbpuVxm7J7xo2gnWxNfuTAdvZUPds7ctYN4";
 /** agent-workflow-nft gate program — publish_workflow / buy_workflow. */
 export const WORKFLOW_GATE_PROGRAM_ID = "3ptXj4yuaQG51WTA3SZZ37jGvYFgMhgXnSKWJLASJNkt";
+/**
+ * Protocol fee treasury. On every priced buy the gate program sends FEE_BPS of
+ * the price here (out of the price — the buyer pays exactly `price`, the creator
+ * nets the rest) and rejects any other treasury account. Must match the program's
+ * constants.rs::FEE_TREASURY.
+ */
+export const FEE_TREASURY = "EWNSTD8tikwqHMcRNuuNbZrnYJUiJdKq9UXLXSEU4wZ1";
 
 /**
  * The TokenGroup mint skills are enrolled into. Env override wins; otherwise the
@@ -72,6 +79,11 @@ export function getWorkflowsCollectionMint(): string | null {
 /** The workflow gate program id (env override wins). */
 export function getWorkflowGateProgramId(): string {
   return process.env.AGENTNET_WORKFLOW_GATE_PROGRAM_ID || WORKFLOW_GATE_PROGRAM_ID;
+}
+
+/** The protocol fee treasury (env override wins). */
+export function getFeeTreasury(): string {
+  return process.env.AGENTNET_FEE_TREASURY || FEE_TREASURY;
 }
 
 /**

--- a/packages/core/src/nft/skill.spec.ts
+++ b/packages/core/src/nft/skill.spec.ts
@@ -16,6 +16,7 @@ vi.mock("../core/chain.js", () => ({
 vi.mock("../core/seed.js", () => ({
   getSkillsCollectionMint: vi.fn().mockReturnValue(null),
   getWorkflowGateProgramId: vi.fn().mockReturnValue("3ptXj4yuaQG51WTA3SZZ37jGvYFgMhgXnSKWJLASJNkt"),
+  getFeeTreasury: vi.fn().mockReturnValue("EWNSTD8tikwqHMcRNuuNbZrnYJUiJdKq9UXLXSEU4wZ1"),
 }));
 
 vi.mock("./token2022.js", async () => {

--- a/packages/core/src/nft/workflow.spec.ts
+++ b/packages/core/src/nft/workflow.spec.ts
@@ -16,6 +16,7 @@ vi.mock("../core/chain.js", () => ({
 vi.mock("../core/seed.js", () => ({
   getWorkflowsCollectionMint: vi.fn().mockReturnValue(null),
   getWorkflowGateProgramId: vi.fn().mockReturnValue("3ptXj4yuaQG51WTA3SZZ37jGvYFgMhgXnSKWJLASJNkt"),
+  getFeeTreasury: vi.fn().mockReturnValue("EWNSTD8tikwqHMcRNuuNbZrnYJUiJdKq9UXLXSEU4wZ1"),
 }));
 
 vi.mock("./token2022.js", async () => {

--- a/packages/core/src/nft/workflowGate.ts
+++ b/packages/core/src/nft/workflowGate.ts
@@ -14,7 +14,7 @@ import {
   getAssociatedTokenAddressSync,
   TOKEN_2022_PROGRAM_ID,
 } from "@solana/spl-token";
-import { getWorkflowGateProgramId } from "../core/seed.js";
+import { getWorkflowGateProgramId, getFeeTreasury } from "../core/seed.js";
 
 // Anchor instruction discriminators (sha256("global:<name>")[0..8]) — from the IDL.
 const DISC_PUBLISH = Buffer.from([125, 80, 203, 31, 0, 230, 147, 33]); // publish_item
@@ -86,6 +86,8 @@ export function buyItemIx(args: {
   const keys = [
     { pubkey: args.buyer, isSigner: true, isWritable: true },
     { pubkey: args.creator, isSigner: false, isWritable: true },
+    // protocol fee treasury — the program requires this exact account on a priced buy.
+    { pubkey: new PublicKey(getFeeTreasury()), isSigner: false, isWritable: true },
     { pubkey: itemConfigPda(args.itemMint), isSigner: false, isWritable: false },
     { pubkey: args.itemMint, isSigner: false, isWritable: true },
     { pubkey: itemMintAuthorityPda(args.itemMint), isSigner: false, isWritable: false },


### PR DESCRIPTION
Wires the SDK to the gate program's new protocol-fee split.

## What
On a priced buy, the `agent-workflow-nft` gate program now sends **6.9%** of the price to a fixed treasury (`EWNSTD8tikwqHMcRNuuNbZrnYJUiJdKq9UXLXSEU4wZ1`) and the rest to the creator. The fee comes **out of the price** — the buyer pays exactly `price`, the creator nets `price − fee`. The treasury is a constant the program enforces (`require_keys_eq!`), so the fee can't be skipped or redirected.

## SDK changes
- `seed.ts`: `FEE_TREASURY` + `getFeeTreasury()` (env override `AGENTNET_FEE_TREASURY`), mirroring the gate-program-id pattern.
- `workflowGate.ts`: `buyItemIx` passes the `fee_treasury` account in the slot right after `creator`, matching the program's `BuyItem` context. (No discriminator change — same `buy_item`.)
- spec mocks updated for the new `getFeeTreasury` export.

## Verified
- Contract: deployed to devnet (same program id `3ptXj4…`), integration test proves the treasury gains **exactly 6.9%** and a wrong treasury **reverts** (5 passing). See `IQCoreTeam/agent-workflow-nft@e588b42`.
- SDK: tsc clean, 89 tests passing.

🤖 Generated with [Claude Code](https://claude.com/claude-code)