### PR TITLE
feat(market): Skills/Workflows tabs + item detail with clickable required skills

### DIFF
--- a/packages/core/src/chat/marketMessages.ts
+++ b/packages/core/src/chat/marketMessages.ts
@@ -10,14 +10,30 @@
 //
 // Direction is in the name: *Request = UI -> host; *Event = host -> UI.
 
-/** One skill row as the UI renders it (search results / cards). Mirrors the subset of
- *  `Skill` a card needs — kept here so host (searchSkills env callback) and UI agree. */
+/** One item row as the UI renders it (cards + detail). Mirrors the subset of `Skill`
+ *  the UI needs — kept here so host (env callbacks) and UI agree. Covers both kinds:
+ *  `type` splits the Skills / Workflows tabs; `requiredSkills` (workflows only) are
+ *  the prerequisite skill mint ids the detail view renders as clickable links. */
 export interface SkillCard {
   id: string; // mint address
+  type?: "skill" | "workflow";
   name: string;
   description?: string;
+  category?: string;
+  hashtags?: string[];
+  image?: string | null; // txid / url / null (viewer infers; null -> default art)
   supply?: number; // popularity
   creator?: string; // wallet (paid on a priced buy)
+  requiredSkills?: string[]; // workflows only: prerequisite skill mint ids
+}
+
+/** A full detail payload for one item: its card, the on-chain body (skillText, read
+ *  separately — not in the indexer), and — for a workflow — the cards of each required
+ *  skill so the UI can render them as clickable rows that open their own detail. */
+export interface SkillDetail {
+  card: SkillCard;
+  skillText: string | null; // the SKILL.md / workflow body (readSkillText)
+  requiredCards: SkillCard[]; // resolved cards for requiredSkills (workflows)
 }
 
 /** RPC status the UI shows (issue #23). `dasReady` = a DAS-capable RPC (a Helius key
@@ -34,7 +50,8 @@ export interface RpcStatus {
 
 // ── UI -> host (requests) ───────────────────────────────────────────────────
 export type MarketRequest =
-  | { type: "searchSkills"; query: string }
+  | { type: "searchSkills"; query: string; kind?: "skill" | "workflow" } // kind = the active tab
+  | { type: "getSkillDetail"; mint: string } // open the detail view for one item
   | { type: "buySkill"; skillId: string; creatorWallet?: string }
   | { type: "ownedSkills" } // ask the host to (re)send the owned list
   | { type: "setHeliusKey" } // host opens a native input to capture + save the key
@@ -45,6 +62,7 @@ export type MarketRequest =
 export type MarketEvent =
   | { type: "searchResults"; results: SkillCard[] }
   | { type: "searchError"; message: string } // search threw (RPC/DAS failure) — show why, don't hang
+  | { type: "skillDetail"; detail: SkillDetail } // full detail for the opened item
   | { type: "buyResult"; skillId: string; ok: boolean; slug?: string; error?: string }
   | { type: "ownedSkills"; names: string[] } // installed skill names (panel fill)
   | { type: "skillActive"; name: string } // a skill fired -> "Casting <name>" cue

--- a/packages/core/src/chat/session.ts
+++ b/packages/core/src/chat/session.ts
@@ -45,7 +45,8 @@ export interface ChatEnv {
   // are host-held (the extension owns them), so they're delegated like wallet/cloud.
   // buySkill installs the bought skill's SKILL.md into the runtime skills dir as part
   // of the buy (the host calls SkillSync.installBought), returning the installed slug.
-  searchSkills?(query: string): Promise<SkillCard[]>;
+  searchSkills?(query: string, kind?: "skill" | "workflow"): Promise<SkillCard[]>;
+  getSkillDetail?(mint: string): Promise<import("./marketMessages.js").SkillDetail>;
   buySkill?(skillId: string, creatorWallet?: string): Promise<{ ok: boolean; slug?: string; error?: string }>;
   ownedSkills?(): Promise<string[]>; // skill names already installed (panel fill)
   // install every owned skill NFT into the runtime skills dir (session start + after a
@@ -247,10 +248,19 @@ export function createChatSession(
       case "searchSkills": {
         const req = m as Extract<MarketRequest, { type: "searchSkills" }>;
         try {
-          const results = env.searchSkills ? await env.searchSkills(req.query ?? "") : [];
+          const results = env.searchSkills ? await env.searchSkills(req.query ?? "", req.kind) : [];
           sendMarket({ type: "searchResults", results });
         } catch (e) {
           // a chain/RPC failure must NOT leave the UI stuck on "Searching…": surface it.
+          sendMarket({ type: "searchError", message: e instanceof Error ? e.message : String(e) });
+        }
+        break;
+      }
+      case "getSkillDetail": {
+        const req = m as Extract<MarketRequest, { type: "getSkillDetail" }>;
+        try {
+          if (env.getSkillDetail) sendMarket({ type: "skillDetail", detail: await env.getSkillDetail(req.mint) });
+        } catch (e) {
           sendMarket({ type: "searchError", message: e instanceof Error ? e.message : String(e) });
         }
         break;

--- a/packages/core/src/chat/ui/webview.ts
+++ b/packages/core/src/chat/ui/webview.ts
@@ -513,6 +513,41 @@ export function chatHtml(): string {
                      border-radius: var(--an-radius); padding: 6px 14px; cursor: pointer; white-space: nowrap; font-weight: 600; }
   .mktCard .mc-buy[disabled] { opacity: 0.5; cursor: default; }
   .mktGrid .mktEmpty { opacity: 0.5; font-size: 0.9em; padding: 8px 2px; }
+  /* a card body is clickable (opens detail); the Buy button stops propagation */
+  .mktCard .mc-main { cursor: pointer; }
+  .mktCard .mc-main:hover .mc-name { color: var(--an-green); }
+  /* Skills / Workflows segmented tabs */
+  .mktTabs { display: inline-flex; gap: 2px; padding: 2px; margin-bottom: 12px;
+             background: var(--an-bg); border: 1px solid var(--an-line); border-radius: 999px; }
+  .mktTab { background: transparent; border: none; color: var(--vscode-foreground); opacity: 0.6;
+            border-radius: 999px; padding: 4px 16px; font-size: 0.85em; cursor: pointer; }
+  .mktTab.on { background: var(--an-green-dim); color: var(--an-green); opacity: 1; font-weight: 600; }
+  /* detail sub-view */
+  #mktDetailBody .dt-head { display: flex; align-items: center; gap: 12px; margin-bottom: 10px; }
+  #mktDetailBody .dt-img { width: 56px; height: 56px; border-radius: 10px; background: var(--an-green-dim);
+                           display: flex; align-items: center; justify-content: center; flex: none; }
+  #mktDetailBody .dt-img .wand { width: 28px; height: 28px; color: var(--an-green); }
+  #mktDetailBody .dt-name { font-size: 1.15em; font-weight: 700; }
+  #mktDetailBody .dt-kind { font-size: 0.7em; text-transform: uppercase; letter-spacing: 0.05em;
+                            color: var(--an-green); opacity: 0.8; }
+  #mktDetailBody .dt-desc { opacity: 0.85; margin-bottom: 10px; }
+  #mktDetailBody .dt-meta { display: flex; flex-wrap: wrap; gap: 6px; margin-bottom: 12px; }
+  #mktDetailBody .dt-tag { font-size: 0.75em; padding: 2px 9px; border-radius: 999px;
+                           background: var(--an-bg); border: 1px solid var(--an-line); opacity: 0.8; }
+  #mktDetailBody .dt-sec { font-size: 0.7em; text-transform: uppercase; letter-spacing: 0.05em;
+                           opacity: 0.5; margin: 14px 0 6px; }
+  #mktDetailBody .dt-body { white-space: pre-wrap; font-family: var(--vscode-editor-font-family, monospace);
+                            font-size: 0.82em; background: var(--an-bg); border: 1px solid var(--an-line);
+                            border-radius: var(--an-radius); padding: 10px 12px; max-height: 320px; overflow: auto; }
+  #mktDetailBody .dt-buy { background: var(--an-green-dim); border: 1px solid var(--an-green-line); color: var(--an-green);
+                           border-radius: var(--an-radius); padding: 8px 18px; cursor: pointer; font-weight: 600; }
+  #mktDetailBody .dt-buy[disabled] { opacity: 0.5; cursor: default; }
+  /* a required skill row inside a workflow detail — clickable, opens its detail */
+  #mktDetailBody .dt-req { display: flex; align-items: center; gap: 8px; padding: 8px 10px; cursor: pointer;
+                           border: 1px solid var(--an-line); border-radius: var(--an-radius); margin-bottom: 6px; }
+  #mktDetailBody .dt-req:hover { border-color: var(--an-green-line); background: var(--an-green-dim); }
+  #mktDetailBody .dt-req .rq-name { font-weight: 600; }
+  #mktDetailBody .dt-req .rq-arrow { margin-left: auto; opacity: 0.5; }
 
   /* skill marquee — ONLY shows when an equipped skill fires ("Casting <skill>").
      Plain tool work isn't shown here (it's already in the chat timeline). Green with
@@ -737,16 +772,28 @@ export function chatHtml(): string {
        shared market message contract; the same screens get a mobile design later. -->
   <div id="marketView" class="panel" style="display:none">
     <div class="page">
-      <div id="backToChatM" class="muted" style="cursor:pointer;margin-bottom:10px">‹ Back to chat</div>
-      <div class="mktHead">
-        <div class="mktTitle"><span class="wand">${WAND_SVG}</span> Skill Market</div>
-        <div class="muted small">Popular skills first. Buy a skill (soulbound) and your agent equips it.</div>
+      <!-- LIST sub-view: tabs (Skills/Workflows) + search + grid -->
+      <div id="mktList">
+        <div id="backToChatM" class="muted" style="cursor:pointer;margin-bottom:10px">‹ Back to chat</div>
+        <div class="mktHead">
+          <div class="mktTitle"><span class="wand">${WAND_SVG}</span> Skill Market</div>
+          <div class="muted small">Popular first. Buy an item (soulbound) and your agent equips it.</div>
+        </div>
+        <div class="mktTabs">
+          <button class="mktTab on" data-kind="skill">Skills</button>
+          <button class="mktTab" data-kind="workflow">Workflows</button>
+        </div>
+        <div class="mktSearchRow">
+          <input id="mktSearch" type="text" placeholder="Search…" />
+          <button id="mktSearchBtn">Search</button>
+        </div>
+        <div id="mktResults" class="mktGrid"></div>
       </div>
-      <div class="mktSearchRow">
-        <input id="mktSearch" type="text" placeholder="Search skills…" />
-        <button id="mktSearchBtn">Search</button>
+      <!-- DETAIL sub-view: one item's full info (hidden until a card is clicked) -->
+      <div id="mktDetail" style="display:none">
+        <div id="backToList" class="muted" style="cursor:pointer;margin-bottom:10px">‹ Back to market</div>
+        <div id="mktDetailBody"></div>
       </div>
-      <div id="mktResults" class="mktGrid"></div>
     </div>
   </div>
 <!-- markdown libs (marked + dompurify), inlined; expose window.marked / window.DOMPurify -->
@@ -1504,22 +1551,97 @@ export function chatHtml(): string {
   // ---- Markets full-screen view (same contract, marketplace design) ----
   const mktSearch = document.getElementById('mktSearch');
   const mktResults = document.getElementById('mktResults');
+  const mktListEl = document.getElementById('mktList');
+  const mktDetailEl = document.getElementById('mktDetail');
+  const mktDetailBody = document.getElementById('mktDetailBody');
   let lastMarketResults = []; // last search results, kept to re-render on owned-list change
+  let currentKind = 'skill';  // active tab: Skills | Workflows
   function runMarketSearch() {
     mktResults.innerHTML = '<div class="mktEmpty">Searching…</div>';
-    vscode.postMessage({ type: 'searchSkills', query: mktSearch.value.trim() });
+    vscode.postMessage({ type: 'searchSkills', query: mktSearch.value.trim(), kind: currentKind });
   }
   function openMarket() {
+    showMktList();
     // first open (and re-open) loads the popular list (empty query = supply-sorted)
     mktResults.innerHTML = '<div class="mktEmpty">Loading…</div>';
-    vscode.postMessage({ type: 'searchSkills', query: '' });
+    vscode.postMessage({ type: 'searchSkills', query: '', kind: currentKind });
     vscode.postMessage({ type: 'ownedSkills' });
   }
+  function showMktList() { mktListEl.style.display = 'block'; mktDetailEl.style.display = 'none'; }
+  function showMktDetail() { mktListEl.style.display = 'none'; mktDetailEl.style.display = 'block'; }
   document.getElementById('mktSearchBtn').addEventListener('click', runMarketSearch);
+  document.getElementById('backToList').addEventListener('click', showMktList);
   mktSearch.addEventListener('keydown', (e) => {
     if (e.isComposing || e.keyCode === 229) return;
     if (e.key === 'Enter') { e.preventDefault(); runMarketSearch(); }
   });
+  // Skills / Workflows tabs — switching re-runs the search filtered to that kind.
+  for (const tab of document.querySelectorAll('.mktTab')) {
+    tab.addEventListener('click', () => {
+      currentKind = tab.getAttribute('data-kind');
+      for (const t of document.querySelectorAll('.mktTab')) t.classList.toggle('on', t === tab);
+      runMarketSearch();
+    });
+  }
+  function openDetail(mint) {
+    showMktDetail();
+    mktDetailBody.innerHTML = '<div class="mktEmpty">Loading…</div>';
+    vscode.postMessage({ type: 'getSkillDetail', mint });
+  }
+  // Render the detail sub-view from a {card, skillText, requiredCards} payload. For a
+  // workflow, each requiredCard is a clickable row that opens ITS detail (re-uses the
+  // same view, so you can drill skill→workflow→skill without leaving the market).
+  function renderDetail(detail) {
+    const c = (detail && detail.card) || {};
+    const owned = ownedSkills.indexOf(c.name) >= 0;
+    mktDetailBody.innerHTML = '';
+    // head: icon + name + kind
+    const head = document.createElement('div'); head.className = 'dt-head';
+    const img = document.createElement('div'); img.className = 'dt-img';
+    img.innerHTML = '<span class="wand">' + ${JSON.stringify(WAND_SVG)} + '</span>';
+    const htxt = document.createElement('div');
+    const kind = document.createElement('div'); kind.className = 'dt-kind'; kind.textContent = (c.type || 'skill');
+    const nm = document.createElement('div'); nm.className = 'dt-name'; nm.textContent = c.name || c.id || '';
+    htxt.appendChild(kind); htxt.appendChild(nm);
+    head.appendChild(img); head.appendChild(htxt);
+    mktDetailBody.appendChild(head);
+    // description
+    if (c.description) { const d = document.createElement('div'); d.className = 'dt-desc'; d.textContent = c.description; mktDetailBody.appendChild(d); }
+    // meta: category + hashtags + supply
+    const meta = document.createElement('div'); meta.className = 'dt-meta';
+    const addTag = (t) => { const s = document.createElement('span'); s.className = 'dt-tag'; s.textContent = t; meta.appendChild(s); };
+    if (c.category) addTag(c.category);
+    for (const h of (c.hashtags || [])) addTag('#' + h);
+    if (typeof c.supply === 'number') addTag(c.supply + '\\u00d7 owned');
+    if (meta.childElementCount) mktDetailBody.appendChild(meta);
+    // buy
+    const buy = document.createElement('button'); buy.className = 'dt-buy';
+    buy.textContent = owned ? 'Owned' : 'Buy'; buy.disabled = owned;
+    buy.addEventListener('click', () => {
+      buy.disabled = true; buy.textContent = 'Buying…';
+      vscode.postMessage({ type: 'buySkill', skillId: c.id, creatorWallet: c.creator });
+    });
+    mktDetailBody.appendChild(buy);
+    // required skills (workflow only) — clickable rows
+    const reqs = (detail && detail.requiredCards) || [];
+    if (reqs.length) {
+      const sec = document.createElement('div'); sec.className = 'dt-sec'; sec.textContent = 'Required skills'; mktDetailBody.appendChild(sec);
+      for (const rc of reqs) {
+        const row = document.createElement('div'); row.className = 'dt-req';
+        const w = document.createElement('span'); w.className = 'wand'; w.style.width = '14px'; w.style.color = 'var(--an-green)'; w.innerHTML = ${JSON.stringify(WAND_SVG)};
+        const rn = document.createElement('span'); rn.className = 'rq-name'; rn.textContent = rc.name || rc.id;
+        const ar = document.createElement('span'); ar.className = 'rq-arrow'; ar.textContent = '\\u203a';
+        row.appendChild(w); row.appendChild(rn); row.appendChild(ar);
+        row.addEventListener('click', () => openDetail(rc.id)); // drill into that skill
+        mktDetailBody.appendChild(row);
+      }
+    }
+    // body (skillText)
+    if (detail && detail.skillText) {
+      const sec = document.createElement('div'); sec.className = 'dt-sec'; sec.textContent = (c.type === 'workflow' ? 'Workflow' : 'Skill') + ' text'; mktDetailBody.appendChild(sec);
+      const body = document.createElement('div'); body.className = 'dt-body'; body.textContent = detail.skillText; mktDetailBody.appendChild(body);
+    }
+  }
   function renderMarketResults(results) {
     results = results || [];
     mktResults.innerHTML = '';
@@ -1539,11 +1661,13 @@ export function chatHtml(): string {
       const nm = document.createElement('div'); nm.className = 'mc-name'; nm.textContent = r.name || r.id;
       const ds = document.createElement('div'); ds.className = 'mc-desc'; ds.textContent = r.description || '';
       main.appendChild(nm); main.appendChild(ds);
+      main.addEventListener('click', () => openDetail(r.id)); // card body → detail view
       const sup = document.createElement('span'); sup.className = 'mc-sup';
       sup.textContent = (typeof r.supply === 'number') ? (r.supply + '\\u00d7') : '';
       const buy = document.createElement('button'); buy.className = 'mc-buy';
       buy.textContent = owned ? 'Owned' : 'Buy'; buy.disabled = owned;
-      buy.addEventListener('click', () => {
+      buy.addEventListener('click', (e) => {
+        e.stopPropagation(); // don't trigger the card-body detail open
         buy.disabled = true; buy.textContent = 'Buying…';
         vscode.postMessage({ type: 'buySkill', skillId: r.id, creatorWallet: r.creator });
       });
@@ -1725,6 +1849,7 @@ export function chatHtml(): string {
       mktResults.innerHTML = '<div class="mktEmpty">' + msg + '</div>';
       skillResults.innerHTML = '<div class="shopEmpty">' + msg + '</div>';
     }
+    else if (m.type === 'skillDetail') renderDetail(m.detail);
     else if (m.type === 'ownedSkills') {
       setSkills(m.names || []);                // updates ownedSkills used by both renders
       if (panels.market.style.display !== 'none') renderMarketResults(lastMarketResults); // refresh Owned badges

--- a/packages/core/src/index.ts
+++ b/packages/core/src/index.ts
@@ -50,7 +50,7 @@ export { resolveRpcUrl, saveHeliusKey, loadHeliusKey, hasDasRpc, heliusUrl, mask
 export { getNetwork, NETWORK } from "./core/seed.js";
 export type { Network } from "./core/seed.js";
 // the marketplace UI<->host message contract (shared by every surface's UI)
-export type { SkillCard, MarketRequest, MarketEvent, MarketMessage, RpcStatus } from "./chat/marketMessages.js";
+export type { SkillCard, SkillDetail, MarketRequest, MarketEvent, MarketMessage, RpcStatus } from "./chat/marketMessages.js";
 // active-skill injection (install a bought skill's SKILL.md into a runtime's skills dir)
 export { SkillSync } from "./skill-market/ingest/index.js";
 export { toSkillMd, skillSlug } from "./skill-market/ingest/convert.js";

--- a/packages/core/src/skill-market/ingest/env.ts
+++ b/packages/core/src/skill-market/ingest/env.ts
@@ -14,10 +14,22 @@ import type { Wallet } from "../../runtime/contract.js";
 import { searchSkills } from "../../search/index.js";
 import { dasSource, indexerSource } from "../../core/skillSource.js";
 import { buySkill } from "../../nft/skill.js";
+import { readSkillText } from "../../nft/token2022.js";
 import { claudeSkillsDir } from "../../core/paths.js";
 import { resolveRpcUrl } from "../../core/rpc.js";
-import type { SkillCard } from "../../chat/marketMessages.js";
+import type { SkillCard, SkillDetail } from "../../chat/marketMessages.js";
+import type { Skill } from "../../core/types.js";
 import { SkillSync } from "./index.js";
+
+// Skill (enumeration row) -> SkillCard (what the UI renders). One place so search +
+// detail map identically.
+function toCard(s: Skill): SkillCard {
+  return {
+    id: s.id, type: s.type, name: s.name, description: s.description,
+    category: s.category, hashtags: s.hashtags, supply: s.supply,
+    creator: s.creator, requiredSkills: s.requiredSkills,
+  };
+}
 
 // The marketplace half of a surface's ChatEnv. Spread it into the env object the
 // surface passes to createChatSession. RPC comes from resolveRpcUrl() — a registered
@@ -35,20 +47,40 @@ export async function marketplaceEnv(wallet: Wallet) {
   const conn = new Connection(await resolveRpcUrl(), "confirmed");
   const skills = new SkillSync(conn);
 
+  // Run a search via the indexer (fast, has supply+traits); fall back to a direct DAS
+  // scan only if it errors (server down). `kind` = the active Skills/Workflows tab.
+  async function runSearch(query: string, kind?: "skill" | "workflow"): Promise<Skill[]> {
+    const filters = { keyword: query, ...(kind ? { type: kind } : {}) };
+    try {
+      return await searchSkills(conn, { source: indexerSource(INDEXER_URL), filters });
+    } catch {
+      return await searchSkills(conn, { source: dasSource, filters });
+    }
+  }
+
   return {
-    async searchSkills(query: string): Promise<SkillCard[]> {
-      const filters = { keyword: query };
-      // indexer first (fast, has supply+traits); fall back to a direct DAS scan only
-      // if it errors (server down) — that path returns little for a Token-2022 group.
-      let found;
-      try {
-        found = await searchSkills(conn, { source: indexerSource(INDEXER_URL), filters });
-      } catch {
-        found = await searchSkills(conn, { source: dasSource, filters });
-      }
-      return found.map((s) => ({
-        id: s.id, name: s.name, description: s.description, supply: s.supply, creator: s.creator,
-      }));
+    async searchSkills(query: string, kind?: "skill" | "workflow"): Promise<SkillCard[]> {
+      return (await runSearch(query, kind)).map(toCard);
+    },
+
+    // Full detail for one item: its card + the on-chain body (readSkillText) + — for a
+    // workflow — the cards of its required skills, so the UI can render them clickable.
+    async getSkillDetail(mint: string): Promise<SkillDetail> {
+      // find the card among all items (indexer has no single-item-with-traits route we
+      // map; one search covers both kinds since they share the catalog).
+      const all = await runSearch("");
+      const card = all.find((s) => s.id === mint);
+      const skillText = await readSkillText(conn, mint).catch(() => null);
+      const reqIds = card?.requiredSkills ?? [];
+      const requiredCards = reqIds
+        .map((id) => all.find((s) => s.id === id))
+        .filter((s): s is Skill => !!s)
+        .map(toCard);
+      return {
+        card: card ? toCard(card) : { id: mint, name: mint },
+        skillText,
+        requiredCards,
+      };
     },
 
     // creatorWallet comes from the search result (a Skill carries .creator); the


### PR DESCRIPTION
Extends the VSCode Skill Market per zo's request: tabs, a per-item detail view, and clickable required-skills on workflows.

## What you get
- **Skills / Workflows tabs** — a segmented toggle at the top of the market. Switching re-runs the search filtered to that kind. (The indexer now splits types — **62 skills / 5 workflows** live, thanks to the indexer fix on the nft track.)
- **Item detail** — click a card body → a detail sub-view (in-market list↔detail toggle, "Back to market"). Shows icon, name, kind, description, category + hashtag tags, supply, and Buy. The card's Buy button stops propagation so it doesn't also open detail.
- **Clickable required skills** — a **workflow's** detail lists its prerequisite skills as clickable rows; clicking one opens **that skill's** detail. So you can drill skill → workflow → skill without leaving the market.

## Contract (shared, all surfaces)
`SkillCard` gains `type / category / hashtags / image / requiredSkills`. New `SkillDetail {card, skillText, requiredCards}` + `getSkillDetail` (request) / `skillDetail` (event). `searchSkills` gains a `kind` param for the tab filter. `env.getSkillDetail` resolves the body via `readSkillText` and the required-skill cards from the same search.

## Verified live (devnet, real indexer)
- tabs split **62 / 5**
- `getSkillDetail("cut-a-release")` → workflow with **requiredCards resolved** (collect-commits-since-tag, generate-changelog, …)
- `tsc` clean (core + vscode), `vitest` **95/95**, webview script parses

## Known data issue (NOT this UI — flagged to the nft/seed track)
`skillText` reads empty for the seeded items: their on-chain `uri` is malformed (88 chars, not a 44-char txid), so `readSkillText` can't resolve the code-in body. The detail view just omits the body section; everything else works. This is a seed/mint encoding bug for the indexer/nft track to fix.

🤖 Generated with [Claude Code](https://claude.com/claude-code)