### PR TITLE
feat(skill-market): publish_skill MCP tool — the agent's publish door (#33 §B mechanism)

### DIFF
--- a/packages/core/src/skill-market/index.spec.ts
+++ b/packages/core/src/skill-market/index.spec.ts
@@ -1,13 +1,13 @@
 import { describe, it, expect, vi, beforeEach } from "vitest";
 import { getAgentNetTools, handleToolCall, newVerifyGuard } from "./index.js";
 import { searchSkills } from "../search/search.js";
-import { buySkill } from "../nft/skill.js";
+import { buySkill, publishSkill } from "../nft/skill.js";
 import { postNote, postAgentNote } from "../notes/notes.js";
 import { readSkillText } from "../nft/token2022.js";
 import { Keypair } from "@solana/web3.js";
 
 vi.mock("../search/search.js", () => ({ searchSkills: vi.fn() }));
-vi.mock("../nft/skill.js", () => ({ buySkill: vi.fn() }));
+vi.mock("../nft/skill.js", () => ({ buySkill: vi.fn(), publishSkill: vi.fn() }));
 vi.mock("../nft/token2022.js", () => ({ readSkillText: vi.fn() }));
 vi.mock("../notes/notes.js", () => ({
   postNote: vi.fn(),
@@ -34,14 +34,39 @@ describe("skill-market", () => {
 
   it("exposes exactly the L1 trio (no wallet_balance)", () => {
     const tools = getAgentNetTools();
-    expect(tools).toHaveLength(5);
+    expect(tools).toHaveLength(6);
     expect(tools.map((t) => t.name)).toEqual([
       "search_skills",
       "verify_skill",
       "buy_skill",
       "post_skill_comment",
       "post_agent_comment",
+      "publish_skill",
     ]);
+  });
+
+  it("publish_skill mints via core publishSkill (priceSol → lamports, default 0.1)", async () => {
+    vi.mocked(publishSkill).mockResolvedValue("mintAddr123");
+    const result = await handleToolCall(mockConn, signer, "defaultCreator", "publish_skill", {
+      name: "clean-code",
+      description: "Refactor toward clean code.",
+      text: "# Clean code\n...",
+      // priceSol omitted → defaults to 0.1 SOL = 100_000_000 lamports
+    });
+    expect(result.content[0].text).toContain("mintAddr123");
+    expect(publishSkill).toHaveBeenCalledWith(mockConn, signer, expect.objectContaining({
+      name: "clean-code",
+      price: 100_000_000n,
+    }));
+  });
+
+  it("publish_skill rejects an invalid priceSol", async () => {
+    const result = await handleToolCall(mockConn, signer, "defaultCreator", "publish_skill", {
+      name: "x", description: "y", text: "z", priceSol: "abc",
+    });
+    expect(result.isError).toBe(true);
+    expect(result.content[0].text).toContain("Invalid priceSol");
+    expect(publishSkill).not.toHaveBeenCalled();
   });
 
   it("search_skills returns empty when there are no results", async () => {

--- a/packages/core/src/skill-market/index.ts
+++ b/packages/core/src/skill-market/index.ts
@@ -26,13 +26,14 @@ import { z } from "zod";
 import type { Connection } from "@solana/web3.js";
 import type { SignerInput } from "@iqlabs-official/solana-sdk/utils";
 import { searchSkills } from "../search/search.js";
-import { buySkill } from "../nft/skill.js";
+import { buySkill, publishSkill } from "../nft/skill.js";
 import { readSkillText } from "../nft/token2022.js";
 import { signerAddress } from "../core/chain.js";
 import { postNote, postAgentNote } from "../notes/notes.js";
 import { getSkillsCollectionMint, getWorkflowsCollectionMint } from "../core/seed.js";
 import { scanSkillText } from "./scan.js";
 import { VERIFY_RUBRIC } from "./rubric.js";
+import { solToLamports } from "./ingest/env.js";
 
 /**
  * Per-session record of which skills cleared the code-side verify scan (plan §3 ③).
@@ -187,6 +188,24 @@ export function getAgentNetTools() {
         required: ["agentWallet", "text"],
       },
     },
+    {
+      name: "publish_skill",
+      description:
+        "Publish a new skill to the marketplace: mint it as a soulbound Token-2022 NFT and store the SKILL.md body on-chain (you, the creator, auto-receive 1 copy). This is the raw publish action — it does NOT decide WHETHER something is worth becoming a skill; call it once you've authored the SKILL.md content and chosen a name/price.",
+      inputSchema: {
+        type: "object",
+        properties: {
+          name: { type: "string", description: "Short skill name / slug, e.g. 'clean-code-refactor'." },
+          description: { type: "string", description: "One or two lines on what the skill does." },
+          text: { type: "string", description: "The full SKILL.md body the agent reads when this skill fires." },
+          category: { type: "string", description: "Optional single category, e.g. 'clean-code'." },
+          hashtags: { type: "array", items: { type: "string" }, description: "Optional tags, e.g. ['refactoring','testing']." },
+          priceSol: { type: "string", description: "Price in SOL a buyer pays (e.g. '0.1'). Use '0' for a free skill. Defaults to 0.1 if omitted." },
+          image: { type: "string", description: "Optional cover image: an http URL or an on-chain (base58) address." },
+        },
+        required: ["name", "description", "text"],
+      },
+    },
   ];
 }
 
@@ -276,6 +295,38 @@ export async function handleToolCall(
       return { content: [{ type: "text", text: `Comment posted (id: ${noteId})` }] };
     } catch (err: any) {
       return { isError: true, content: [{ type: "text", text: `Failed to post comment: ${err.message}` }] };
+    }
+  }
+
+  if (name === "publish_skill") {
+    // The raw publish DOOR — author fills the fields, we mint. No "is this worth a
+    // skill?" policy here (that judgment is the Hermes-informed workflow, issue #33
+    // §B / item 2); this tool is just the mechanism the workflow would call.
+    const skillName = args?.name as string;
+    const description = args?.description as string;
+    const text = args?.text as string;
+    if (!skillName || !description || !text) {
+      throw new Error("Missing required argument: name, description, and text");
+    }
+    // priceSol uses the SAME parse as the publish UI (default 0.1 SOL when omitted).
+    const priceSol = (args?.priceSol as string | undefined) ?? "0.1";
+    const lamports = solToLamports(priceSol);
+    if (lamports === null) {
+      return { isError: true, content: [{ type: "text", text: `Invalid priceSol "${priceSol}" — use a SOL amount like "0.1" or "0".` }] };
+    }
+    try {
+      const mint = await publishSkill(conn, signer, {
+        name: skillName,
+        description,
+        text,
+        category: args?.category as string | undefined,
+        hashtags: args?.hashtags as string[] | undefined,
+        price: lamports,
+        image: args?.image as string | undefined,
+      });
+      return { content: [{ type: "text", text: `Published skill "${skillName}" — mint: ${mint}` }] };
+    } catch (err: any) {
+      return { isError: true, content: [{ type: "text", text: `Failed to publish skill: ${err.message}` }] };
     }
   }
 

--- a/packages/core/src/skill-market/ingest/env.ts
+++ b/packages/core/src/skill-market/ingest/env.ts
@@ -55,8 +55,9 @@ function collectionIdFor(type?: "skill" | "workflow"): Promise<string | null> {
 // Parse a human SOL string ("0.1", "2", "0") into integer lamports without float
 // rounding: split on the decimal point and pad the fraction to 9 places. Returns
 // null for anything not a non-negative decimal (so the caller can reject it).
+// Exported so the publish_skill MCP tool reuses the exact same parse as the UI.
 const LAMPORTS_PER_SOL = 1_000_000_000n;
-function solToLamports(sol: string): bigint | null {
+export function solToLamports(sol: string): bigint | null {
   const s = sol.trim();
   if (!/^\d+(\.\d+)?$/.test(s)) return null;
   const [whole, frac = ""] = s.split(".");


### PR DESCRIPTION
Closes the agent half of the publish path: the human can already publish via the make-skill UI; now the **agent** can too.

## What
- New `publish_skill` MCP tool (tools 5 → 6, next to search/verify/buy/comment×2). Fields: name, description, text, category?, hashtags?, priceSol?, image?.
- Handler reuses core `publishSkill` (Token-2022 mint + code-in + publish_item, creator self-owns 1) and the **same** SOL→lamports parse as the UI (`solToLamports` now exported from `ingest/env.ts`), default 0.1 SOL.

## Scope — mechanism, not policy
This is **only the publish door**: the agent fills the fields, we mint. It deliberately contains **no judgment** about *whether* a solved task is worth becoming a skill, or *how* to shape the SKILL.md. That heuristic — informed by **Hermes** / leaked Codex (issue #33 §B/§C, the item-2 track) — sits **above** this tool and decides when to call it. A workflow can wire `publish_skill` in without this PR prescribing the policy.

## Verify
tsc clean · 262 tests (incl. publish_skill mint + invalid-price) · vscode build ok.

🤖 Generated with [Claude Code](https://claude.com/claude-code)