### PR TITLE
feat(parity): agent feature parity across CLI / VSCode / app (issue #38)

### DIFF
--- a/packages/core/src/chat/session.ts
+++ b/packages/core/src/chat/session.ts
@@ -117,7 +117,7 @@ export function createChatSession(
   // q.interrupt / codex child.kill). Instead we re-spawn lazily on the next send,
   // carrying the live session over, so the running turn finishes untouched and the new
   // setting applies from the next message.
-  type Slot = { handle: SessionHandle | null; pendingId?: string; model?: string; mode?: string; restage?: boolean };
+  type Slot = { handle: SessionHandle | null; pendingId?: string; model?: string; mode?: string; effort?: "low" | "medium" | "high" | "xhigh" | "max"; restage?: boolean };
   const slots: Record<"claude" | "codex", Slot> = {
     claude: { handle: null, mode: "acceptEdits" },
     codex: { handle: null, mode: "auto" },
@@ -139,6 +139,8 @@ export function createChatSession(
     // a skill firing → the green "Casting <skill>" marquee (issue #17). Transient, not
     // persisted; only painted for the active tab.
     h.onSkill((name) => { if (cli === forCli) sendMarket({ type: "skillActive", name }); });
+    // token usage: forward to the active surface so it can render a context meter.
+    h.onUsage((contextTokens) => { if (cli === forCli) transport.send({ type: "usage", contextTokens }); });
     h.onTurnEnd(async () => {
       if (cli === forCli) transport.send({ type: "turnEnd" }); // stop the typing dots
       await pushSessions();
@@ -186,7 +188,7 @@ export function createChatSession(
       s.restage = false;
     }
     const spawnCli = cli; // capture: cli must not change across the await
-    s.handle = await rt.startSession({ cli: spawnCli, model: s.model, mode: s.mode, cwd: env.cwd(), sessionId: s.pendingId, approval: env.approval });
+    s.handle = await rt.startSession({ cli: spawnCli, model: s.model, mode: s.mode, effort: s.effort, cwd: env.cwd(), sessionId: s.pendingId, approval: env.approval });
     wire(spawnCli, s.handle);
     return s.handle;
   }
@@ -280,6 +282,15 @@ export function createChatSession(
           if (slot().handle) slot().restage = true;
         }
         break;
+      case "effort": {
+        // reasoning effort is per-slot. Same lazy-restage rule as model/mode: never kill
+        // a live turn — the new effort takes effect from the next spawned handle.
+        const EFFORTS = ["low", "medium", "high", "xhigh", "max"] as const;
+        const e = EFFORTS.find((v) => v === m.effort);
+        slot().effort = e;
+        if (slot().handle) slot().restage = true;
+        break;
+      }
       case "send": {
         // images are optional; an image-only turn (empty text) is allowed. Each is
         // { mime, dataBase64, name? } — the engine layer renders/attaches per its CLI.

--- a/packages/core/src/chat/ui/webview.ts
+++ b/packages/core/src/chat/ui/webview.ts
@@ -2389,7 +2389,7 @@ export function chatHtml(): string {
             '/copy — copy last reply', '/engine claude|codex — switch engine',
             '/model <model> — change model', '/mode <mode> — change permission mode',
             '/effort low|medium|high|xhigh|max — set reasoning effort',
-          ].join('\n');
+          ].join('\\n');
           const pre = document.createElement('pre');
           pre.style.cssText = 'margin:8px 0;padding:8px 12px;background:var(--an-bg-1);border-radius:6px;font-size:0.82em;opacity:0.8';
           pre.textContent = helpText;

--- a/packages/core/src/chat/ui/webview.ts
+++ b/packages/core/src/chat/ui/webview.ts
@@ -680,7 +680,8 @@ export function chatHtml(): string {
   .etab.active .ed { opacity: 1; }
 
   #inputWrap { border: 1.5px solid var(--engLine); border-radius: var(--an-radius-sm);
-               background: var(--an-bg-2); overflow: hidden; transition: border-color 0.12s; }
+               background: var(--an-bg-2); overflow: visible; transition: border-color 0.12s;
+               position: relative; }
   #input { width: 100%; box-sizing: border-box; padding: 11px 12px 8px; background: transparent;
            color: var(--vscode-input-foreground); border: none; resize: none; font-family: inherit;
            font-size: 0.95em; display: block; line-height: 1.5;
@@ -750,6 +751,57 @@ export function chatHtml(): string {
                 box-shadow: 0 8px 28px rgba(0,0,0,0.4); }
   /* usage context meter: small text chip near the composer chips */
   #ctxMeter { font-size: 0.82em; opacity: 0.55; display: inline-flex; align-items: center; }
+  /* slash command dropdown menu */
+  .slashMenu {
+    position: absolute;
+    bottom: calc(100% + 6px);
+    left: 0;
+    right: 0;
+    z-index: 50;
+    background: var(--vscode-editorWidget-background, var(--vscode-editor-background));
+    border: 1px solid var(--an-line);
+    border-radius: var(--an-radius-sm, 6px);
+    box-shadow: 0 -8px 28px rgba(0,0,0,0.4);
+    max-height: 200px;
+    overflow-y: auto;
+    padding: 4px;
+    display: none;
+    flex-direction: column;
+    gap: 2px;
+  }
+  .slashOpt {
+    display: flex;
+    align-items: center;
+    gap: 8px;
+    padding: 6px 10px;
+    border-radius: 4px;
+    cursor: pointer;
+    font-size: 0.85em;
+    user-select: none;
+    color: var(--vscode-foreground);
+    text-align: left;
+  }
+  .slashOpt.sel {
+    background: var(--vscode-list-activeSelectionBackground, var(--eng));
+    color: var(--vscode-list-activeSelectionForeground, #fff);
+  }
+  .slashOpt .cmd {
+    font-weight: 600;
+  }
+  .slashOpt .desc {
+    opacity: 0.7;
+    font-size: 0.9em;
+  }
+  .slashHint {
+    font-size: 0.76em;
+    opacity: 0.5;
+    padding: 6px 10px;
+    border-top: 1px solid var(--an-line);
+    margin-top: 4px;
+    user-select: none;
+    color: var(--vscode-foreground);
+    text-align: left;
+  }
   /* send/stop: a single small, flat, round icon button (Claude/Codex style) —
      no text, no gradient, no lift. Engine accent when ready, neutral when empty. */
   #send { margin-left: auto; display: inline-flex; align-items: center; justify-content: center;
@@ -1158,6 +1210,7 @@ export function chatHtml(): string {
           </div>
         </div>
         <div id="inputWrap">
+          <div id="slashMenu" class="slashMenu" style="display:none"></div>
           <!-- attached-image thumbnails (hidden until you add one). Each has an × to remove. -->
           <div id="attachStrip" style="display:none"></div>
           <textarea id="input" rows="1" placeholder="Message claude... (Enter to send)"></textarea>
@@ -1394,6 +1447,7 @@ export function chatHtml(): string {
   const effortLabel = document.getElementById('effortLabel');
   const ctxMeter = document.getElementById('ctxMeter');
   const approvalDock = document.getElementById('approvalDock');
+  const slashMenu = document.getElementById('slashMenu');
   const tabs = Array.from(document.querySelectorAll('.etab'));
 
   let streaming = null;     // bubble currently being streamed into
@@ -1401,6 +1455,153 @@ export function chatHtml(): string {
   let activeId = null;
   let expanded = false;     // "모두 보기" toggled?
   const COLLAPSED = 5;      // sessions shown before "모두 보기(N)"
+
+  // ---- slash command autocomplete ----
+  const SLASH_CMDS = [
+    { name: 'new', desc: 'start fresh session', insert: '/new' },
+    { name: 'clear', desc: 'clear on-screen log', insert: '/clear' },
+    { name: 'copy', desc: 'copy last reply', insert: '/copy' },
+    { name: 'engine', desc: 'switch engine (claude|codex)', insert: '/engine ' },
+    { name: 'model', desc: 'change model', insert: '/model ' },
+    { name: 'mode', desc: 'change permission mode', insert: '/mode ' },
+    { name: 'effort', desc: 'set reasoning effort', insert: '/effort ' },
+    { name: 'help', desc: 'show help text', insert: '/help' },
+  ];
+  let slashIdx = 0;
+  let suppressSlash = false;
+  let activeSlashMatches = [];
+
+  function renderSlashMenu() {
+    if (suppressSlash) {
+      slashMenu.style.display = 'none';
+      activeSlashMatches = [];
+      return;
+    }
+    const val = input.value;
+    
+    // Check if it matches a sub-command argument first
+    let subCmd = null;
+    let prefix = '';
+    let options = [];
+
+    // 1. Engine options
+    let m = /^\\/engine(?:\\s+(\\S*))?$/.exec(val);
+    if (m) {
+      subCmd = 'engine';
+      prefix = (m[1] || '').toLowerCase();
+      options = [
+        { name: 'claude', desc: 'switch to Claude engine', insert: '/engine claude' },
+        { name: 'codex',  desc: 'switch to Codex engine',  insert: '/engine codex' }
+      ];
+    }
+    // 2. Model options
+    if (!subCmd) {
+      m = /^\\/model(?:\\s+(\\S*))?$/.exec(val);
+      if (m) {
+        subCmd = 'model';
+        prefix = (m[1] || '').toLowerCase();
+        const list = MODELS[cli] || [];
+        options = list.map(function(o) {
+          return { name: o.value, desc: o.label, insert: '/model ' + o.value };
+        });
+      }
+    }
+    // 3. Mode options
+    if (!subCmd) {
+      m = /^\\/mode(?:\\s+(\\S*))?$/.exec(val);
+      if (m) {
+        subCmd = 'mode';
+        prefix = (m[1] || '').toLowerCase();
+        const list = MODES[cli] || [];
+        options = list.map(function(o) {
+          return { name: o.value, desc: o.label + ' - ' + o.title, insert: '/mode ' + o.value };
+        });
+      }
+    }
+    // 4. Effort options
+    if (!subCmd) {
+      m = /^\\/effort(?:\\s+(\\S*))?$/.exec(val);
+      if (m) {
+        subCmd = 'effort';
+        prefix = (m[1] || '').toLowerCase();
+        options = EFFORTS.map(function(o) {
+          return { name: o.value, desc: o.label + ' - ' + o.title, insert: '/effort ' + o.value };
+        });
+      }
+    }
+
+    if (subCmd) {
+      activeSlashMatches = options.filter(function(opt) {
+        return opt.name.toLowerCase().startsWith(prefix);
+      });
+      // If the user fully typed the sub-command argument, hide the menu
+      if (activeSlashMatches.length === 1 && prefix === activeSlashMatches[0].name.toLowerCase()) {
+        slashMenu.style.display = 'none';
+        activeSlashMatches = [];
+        return;
+      }
+    } else {
+      // Otherwise match the main slash commands
+      const mainMatch = /^\\/(\\S*)$/.exec(val);
+      if (!mainMatch) {
+        slashMenu.style.display = 'none';
+        activeSlashMatches = [];
+        return;
+      }
+      prefix = mainMatch[1].toLowerCase();
+      activeSlashMatches = SLASH_CMDS.filter(function(cmd) {
+        return cmd.name.toLowerCase().startsWith(prefix);
+      });
+    }
+
+    if (activeSlashMatches.length === 0) {
+      slashMenu.style.display = 'none';
+      return;
+    }
+
+    if (slashIdx >= activeSlashMatches.length) {
+      slashIdx = activeSlashMatches.length - 1;
+    }
+    if (slashIdx < 0) {
+      slashIdx = 0;
+    }
+
+    let html = '';
+    activeSlashMatches.forEach(function(cmd, idx) {
+      const isSel = idx === slashIdx;
+      const label = subCmd ? cmd.name : '/' + cmd.name;
+      html += '<div class="slashOpt' + (isSel ? ' sel' : '') + '" data-idx="' + idx + '">' +
+                '<span class="cmd">' + label + '</span>' +
+                '<span class="desc">' + cmd.desc + '</span>' +
+              '</div>';
+    });
+    html += '<div class="slashHint">Use ↑↓ to navigate, Tab/Enter to select, Esc to close</div>';
+    slashMenu.innerHTML = html;
+    slashMenu.style.display = 'flex';
+  }
+
+  function completeSlash(c) {
+    input.value = c.insert;
+    autoGrowInput();
+    suppressSlash = false;
+    slashMenu.style.display = 'none';
+    activeSlashMatches = [];
+    input.focus();
+    if (c.insert.endsWith(' ')) {
+      renderSlashMenu();
+    }
+  }
+
+  slashMenu.addEventListener('click', function(e) {
+    const opt = e.target.closest('.slashOpt');
+    if (opt) {
+      e.stopPropagation();
+      const idx = parseInt(opt.getAttribute('data-idx') || '0', 10);
+      if (activeSlashMatches[idx]) {
+        completeSlash(activeSlashMatches[idx]);
+      }
+    }
+  });
 
   // Platform = which CLI. Model = the actual model inside it.
   // value 'default' = pass no --model (CLI's own default); label shows WHICH model
@@ -2421,6 +2622,36 @@ export function chatHtml(): string {
     // e.isComposing = IME (Korean/Japanese/Chinese) mid-composition; don't send
     // a half-formed syllable. keyCode 229 is the legacy IME-in-progress signal.
     if (e.isComposing || e.keyCode === 229) return;
+
+    if (activeSlashMatches.length > 0) {
+      if (e.key === 'ArrowDown') {
+        e.preventDefault();
+        slashIdx = (slashIdx + 1) % activeSlashMatches.length;
+        renderSlashMenu();
+        return;
+      }
+      if (e.key === 'ArrowUp') {
+        e.preventDefault();
+        slashIdx = (slashIdx - 1 + activeSlashMatches.length) % activeSlashMatches.length;
+        renderSlashMenu();
+        return;
+      }
+      if (e.key === 'Tab' || e.key === 'Enter') {
+        e.preventDefault();
+        if (activeSlashMatches[slashIdx]) {
+          completeSlash(activeSlashMatches[slashIdx]);
+        }
+        return;
+      }
+      if (e.key === 'Escape') {
+        e.preventDefault();
+        e.stopPropagation();
+        suppressSlash = true;
+        renderSlashMenu();
+        return;
+      }
+    }
+
     if (e.key === 'Enter' && !e.shiftKey) { e.preventDefault(); send(); }
     if (e.key === 'Escape' && busy) { e.preventDefault(); interruptTurn(); } // Esc stops the turn
   });
@@ -2433,7 +2664,12 @@ export function chatHtml(): string {
     input.style.height = 'auto';
     input.style.height = Math.min(input.scrollHeight, 220) + 'px';
   }
-  input.addEventListener('input', autoGrowInput);
+  input.addEventListener('input', () => {
+    autoGrowInput();
+    suppressSlash = false;
+    slashIdx = 0;
+    renderSlashMenu();
+  });
 
   // ---- storage pill (Local always on; Cloud optional mirror) ----
   const cloudState = document.getElementById('cloudState');
@@ -2793,7 +3029,13 @@ export function chatHtml(): string {
   });
   document.getElementById('openWalletPage').addEventListener('click', () => { closeMenus(); if (myWalletAddress) showProfile(myWalletAddress); else showView('wallet'); });
   // click outside closes any open menu
-  document.addEventListener('click', () => closeMenus());
+  document.addEventListener('click', (e) => {
+    closeMenus();
+    if (inputWrap && !inputWrap.contains(e.target)) {
+      slashMenu.style.display = 'none';
+      activeSlashMatches = [];
+    }
+  });
   histMenu.addEventListener('click', (e) => e.stopPropagation());
   walletMenu.addEventListener('click', (e) => e.stopPropagation());
 

--- a/packages/core/src/chat/ui/webview.ts
+++ b/packages/core/src/chat/ui/webview.ts
@@ -734,6 +734,22 @@ export function chatHtml(): string {
                background: var(--vscode-editorWidget-background, var(--vscode-editor-background));
                border: 1px solid var(--an-line); border-radius: var(--an-radius);
                box-shadow: 0 8px 28px rgba(0,0,0,0.4); }
+  /* effort chip: same chip+popover language as the model chip. Neutral-tinted (un-tinted)
+     so it's visible but doesn't compete with the mode chip's engine accent. */
+  #effortWrap { position: relative; display: inline-flex; }
+  #effortBtn { display: inline-flex; align-items: center; gap: 6px; cursor: pointer;
+               background: var(--an-bg-1); color: var(--vscode-foreground); font-weight: 600;
+               border: 1px solid var(--an-line); border-radius: 999px; padding: 3px 10px;
+               font-size: 0.92em; font-family: inherit; }
+  #effortBtn:hover { border-color: var(--eng); }
+  #effortBtn .mglyph { opacity: 0.5; font-size: 0.82em; font-weight: 700; }
+  #effortBtn .mcaret { opacity: 0.5; font-size: 0.8em; }
+  #effortMenu { position: fixed; z-index: 60; min-width: 176px; padding: 5px;
+                background: var(--vscode-editorWidget-background, var(--vscode-editor-background));
+                border: 1px solid var(--an-line); border-radius: var(--an-radius);
+                box-shadow: 0 8px 28px rgba(0,0,0,0.4); }
+  /* usage context meter: small text chip near the composer chips */
+  #ctxMeter { font-size: 0.82em; opacity: 0.55; display: inline-flex; align-items: center; }
   /* send/stop: a single small, flat, round icon button (Claude/Codex style) —
      no text, no gradient, no lift. Engine accent when ready, neutral when empty. */
   #send { margin-left: auto; display: inline-flex; align-items: center; justify-content: center;
@@ -1160,6 +1176,13 @@ export function chatHtml(): string {
               </button>
               <div id="modeMenu" style="display:none"></div>
             </span>
+            <span id="effortWrap">
+              <button id="effortBtn" title="Reasoning effort: how deeply the model thinks before replying">
+                <span class="mglyph">⚡</span><span id="effortLabel">effort</span><span class="mcaret">▾</span>
+              </button>
+              <div id="effortMenu" style="display:none"></div>
+            </span>
+            <span id="ctxMeter" style="display:none"></span>
             <button id="send" title="Send" aria-label="Send"><svg class="ic-send" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2.4" stroke-linecap="round" stroke-linejoin="round" aria-hidden="true"><path d="M12 19V5"/><path d="M5 12l7-7 7 7"/></svg><svg class="ic-stop" viewBox="0 0 24 24" fill="currentColor" aria-hidden="true"><rect x="6.5" y="6.5" width="11" height="11" rx="1.5"/></svg><span class="lbl">Send</span></button>
           </div>
         </div>
@@ -1366,6 +1389,10 @@ export function chatHtml(): string {
   const modeBtn = document.getElementById('modeBtn');
   const modeMenu = document.getElementById('modeMenu');
   const modeLabel = document.getElementById('modeLabel');
+  const effortBtn = document.getElementById('effortBtn');
+  const effortMenu = document.getElementById('effortMenu');
+  const effortLabel = document.getElementById('effortLabel');
+  const ctxMeter = document.getElementById('ctxMeter');
   const approvalDock = document.getElementById('approvalDock');
   const tabs = Array.from(document.querySelectorAll('.etab'));
 
@@ -1409,9 +1436,19 @@ export function chatHtml(): string {
       { value: 'full',     label: 'Full access', title: 'Full disk + network access, never ask (use with care)' },
     ],
   };
-  // remember the chosen mode + model per engine so switching tabs restores them
+  // reasoning effort levels (applies to both engines; labels mirror CLI EffortPicker)
+  const EFFORTS = [
+    { value: 'default', label: 'default',  title: 'Engine default (usually medium)' },
+    { value: 'low',     label: 'low',      title: 'Minimal thinking, fastest' },
+    { value: 'medium',  label: 'medium',   title: 'Moderate reasoning' },
+    { value: 'high',    label: 'high',     title: 'Deeper thinking' },
+    { value: 'xhigh',  label: 'x-high',   title: 'Extended reasoning' },
+    { value: 'max',     label: 'max',      title: 'Maximum effort (select models)' },
+  ];
+  // remember the chosen mode + model + effort per engine so switching tabs restores them
   const modeByCli = { claude: 'acceptEdits', codex: 'auto' };
   const modelByCli = { claude: 'default', codex: 'default' };
+  const effortByCli = { claude: 'default', codex: 'default' };
   let cli = 'claude';
 
   // ---- platform tabs + model picker (chip + popover, mirroring the mode picker) ----
@@ -1494,6 +1531,37 @@ export function chatHtml(): string {
     modeMenu.style.left = r.left + 'px';
     modeMenu.style.bottom = (window.innerHeight - r.top + 6) + 'px';
   }
+  function currentEffort() { return effortByCli[cli] || 'default'; }
+  function fillEfforts() {
+    const cur = currentEffort();
+    const curOpt = EFFORTS.find(o => o.value === cur) || EFFORTS[0];
+    effortLabel.textContent = curOpt ? curOpt.label : 'effort';
+    while (effortMenu.firstChild) effortMenu.removeChild(effortMenu.firstChild);
+    for (const e of EFFORTS) {
+      const row = document.createElement('div');
+      row.className = 'modeOpt' + (e.value === cur ? ' sel' : '');
+      const txt = document.createElement('div'); txt.className = 'mtext';
+      const lab = document.createElement('div'); lab.className = 'mlabel'; lab.textContent = e.label;
+      txt.appendChild(lab);
+      if (e.title) { const d = document.createElement('div'); d.className = 'mdesc'; d.textContent = e.title; txt.appendChild(d); }
+      const chk = document.createElement('span'); chk.className = 'mcheck'; chk.textContent = '✓';
+      row.appendChild(txt); row.appendChild(chk);
+      row.addEventListener('click', (ev) => {
+        ev.stopPropagation();
+        effortByCli[cli] = e.value;
+        effortMenu.style.display = 'none';
+        fillEfforts();
+        vscode.postMessage({ type: 'effort', effort: e.value === 'default' ? undefined : e.value });
+      });
+      effortMenu.appendChild(row);
+    }
+  }
+  function openEffortMenu() {
+    const r = effortBtn.getBoundingClientRect();
+    effortMenu.style.display = 'block';
+    effortMenu.style.left = r.left + 'px';
+    effortMenu.style.bottom = (window.innerHeight - r.top + 6) + 'px';
+  }
   function setTab(next) {
     if (next !== 'claude' && next !== 'codex') return;
     cli = next;
@@ -1502,6 +1570,7 @@ export function chatHtml(): string {
     input.placeholder = 'Message ' + cli + '... (Enter to send)';
     fillModels();
     fillModes();
+    fillEfforts();
   }
   function selectTab(next) {
     if (next === cli) return;
@@ -1509,26 +1578,35 @@ export function chatHtml(): string {
     vscode.postMessage({ type: 'platform', cli });
     vscode.postMessage({ type: 'model', model: currentModel() });
     vscode.postMessage({ type: 'mode', mode: currentMode() });
+    vscode.postMessage({ type: 'effort', effort: currentEffort() === 'default' ? undefined : currentEffort() });
   }
   tabs.forEach(t => t.addEventListener('click', () => selectTab(t.dataset.cli)));
   // each chip toggles its own popover; clicking it again (while open) closes it
   modelBtn.addEventListener('click', (e) => {
     e.stopPropagation();
     if (modelMenu.style.display === 'block') { modelMenu.style.display = 'none'; return; }
-    modeMenu.style.display = 'none'; closeMenus();
+    modeMenu.style.display = 'none'; effortMenu.style.display = 'none'; closeMenus();
     openModelMenu();
   });
   modelMenu.addEventListener('click', (e) => e.stopPropagation());
   modeBtn.addEventListener('click', (e) => {
     e.stopPropagation();
     if (modeMenu.style.display === 'block') { modeMenu.style.display = 'none'; return; }
-    modelMenu.style.display = 'none'; closeMenus(); // also close the hist/wallet menus (hoisted, defined below)
+    modelMenu.style.display = 'none'; effortMenu.style.display = 'none'; closeMenus();
     openModeMenu();
   });
   modeMenu.addEventListener('click', (e) => e.stopPropagation());
-  document.addEventListener('click', () => { modeMenu.style.display = 'none'; modelMenu.style.display = 'none'; });
+  effortBtn.addEventListener('click', (e) => {
+    e.stopPropagation();
+    if (effortMenu.style.display === 'block') { effortMenu.style.display = 'none'; return; }
+    modelMenu.style.display = 'none'; modeMenu.style.display = 'none'; closeMenus();
+    openEffortMenu();
+  });
+  effortMenu.addEventListener('click', (e) => e.stopPropagation());
+  document.addEventListener('click', () => { modeMenu.style.display = 'none'; modelMenu.style.display = 'none'; effortMenu.style.display = 'none'; });
   fillModels();
   fillModes();
+  fillEfforts();
 
   // ---- relative time ("3개월", "1일", "방금") ----
   function rel(ts) {
@@ -1902,18 +1980,43 @@ export function chatHtml(): string {
 
     // ── plan / bash / edit / read / write: a yes-or-no permission card ──
     const isPlan = req.kind === 'plan';
-    const head = document.createElement('div'); head.className = 'apHead';
-    head.innerHTML = '<span class="apk">' + (req.kind === 'bash' ? '$' : req.kind === 'read' ? '📖' : isPlan ? '✦' : '✎') + '</span>';
+    const isDanger = req.risk === 'danger';
+    const head = document.createElement('div'); head.className = 'apHead' + (isDanger ? ' apDanger' : '');
+    const glyphEl = document.createElement('span'); glyphEl.className = 'apk';
+    glyphEl.textContent = req.kind === 'bash' ? '$' : req.kind === 'read' ? '📖' : isPlan ? '✦' : '✎';
+    head.appendChild(glyphEl);
+    if (isDanger) {
+      const warn = document.createElement('span'); warn.style.cssText = 'color:var(--vscode-errorForeground,#f44);font-weight:700;margin-right:4px';
+      warn.textContent = '⚠ DANGER ·'; head.appendChild(warn);
+    }
     const ttl = document.createElement('span'); ttl.className = 'apTitle'; ttl.textContent = req.title || req.tool;
     head.appendChild(ttl);
     const tag = document.createElement('span'); tag.className = 'apTag'; tag.textContent = req.cli;
     head.appendChild(tag);
     card.appendChild(head);
 
-    // detail: command for bash, plan text for plan, diff for edit, file for read/write
+    // detail: command for bash (editable), plan text for plan, diff for edit, file for read/write
+    let commandInput = null; // textarea for bash edit mode
     if (req.command) {
       const pre = document.createElement('pre'); pre.className = 'apBody'; pre.textContent = req.command;
       card.appendChild(pre);
+      // bash: allow editing the command before approving
+      if (req.kind === 'bash') {
+        commandInput = document.createElement('textarea');
+        commandInput.className = 'apBody';
+        commandInput.style.cssText = 'display:none;width:100%;box-sizing:border-box;resize:vertical;font-family:monospace;font-size:0.85em;background:var(--an-bg-1);border:1px solid var(--eng);border-radius:4px;padding:6px;color:inherit';
+        commandInput.value = req.command;
+        card.appendChild(commandInput);
+        const editBtn = document.createElement('button'); editBtn.className = 'apBtn'; editBtn.textContent = 'Edit';
+        editBtn.style.cssText = 'margin-left:auto;font-size:0.78em;opacity:0.7';
+        editBtn.addEventListener('click', () => {
+          const editing = commandInput.style.display !== 'none';
+          pre.style.display = editing ? '' : 'none';
+          commandInput.style.display = editing ? 'none' : '';
+          editBtn.textContent = editing ? 'Edit' : 'Cancel';
+        });
+        head.appendChild(editBtn);
+      }
     } else if (req.plan) {
       const pre = document.createElement('pre'); pre.className = 'apBody planBody'; pre.textContent = req.plan;
       card.appendChild(pre);
@@ -1931,8 +2034,8 @@ export function chatHtml(): string {
     }
 
     const actions = document.createElement('div'); actions.className = 'apActions';
-    const decide = (outcome) => {
-      vscode.postMessage({ type: 'approvalDecision', id: req.id, outcome });
+    const decide = (outcome, extra) => {
+      vscode.postMessage({ type: 'approvalDecision', id: req.id, outcome, ...extra });
       card.remove(); // answered → clear it from the dock
       syncComposerLock(); // unfreeze once the last pending approval is answered
     };
@@ -1940,19 +2043,67 @@ export function chatHtml(): string {
       const b = document.createElement('button'); b.className = 'apBtn ' + cls; b.textContent = label;
       b.addEventListener('click', () => decide(outcome)); return b;
     };
-    // plan has no "Always" (you approve THIS plan or send it back to revise)
-    const btns = isPlan
-      ? [mk('Approve plan', 'once', 'ok'), mk('Keep planning', 'deny', 'no')]
-      : [mk('Approve', 'once', 'ok'), mk('Always', 'always', 'always'), mk('Deny', 'deny', 'no')];
-    for (const b of btns) actions.appendChild(b);
-    card.appendChild(actions);
 
-    // keyboard: ← → move focus between buttons, Enter/Space activates the focused one
-    // (a native button does that for Enter/Space). Default focus = Approve, like claude.
+    if (isPlan) {
+      // plan has no "Always" and no edit/deny-reason
+      actions.appendChild(mk('Approve plan', 'once', 'ok'));
+      actions.appendChild(mk('Keep planning', 'deny', 'no'));
+    } else {
+      actions.appendChild(mk('Approve', 'once', 'ok'));
+      actions.appendChild(mk('Always', 'always', 'always'));
+
+      // bash: "Approve edited" (visible only when edit mode is active)
+      let approveEdited = null;
+      if (req.kind === 'bash' && commandInput) {
+        approveEdited = document.createElement('button');
+        approveEdited.className = 'apBtn ok'; approveEdited.textContent = 'Approve edited';
+        approveEdited.style.display = 'none';
+        approveEdited.addEventListener('click', () => {
+          decide('once', { updatedInput: { ...(req.input ?? {}), command: commandInput.value } });
+        });
+        actions.appendChild(approveEdited);
+        // sync visibility with the edit toggle button in the header
+        const editToggle = head.querySelector('button');
+        if (editToggle) {
+          editToggle.addEventListener('click', () => {
+            const isEditing = commandInput.style.display !== 'none';
+            if (approveEdited) approveEdited.style.display = isEditing ? '' : 'none';
+          });
+        }
+      }
+
+      // deny-with-reason: clicking Deny reveals a reason input; the reason row's Deny sends
+      const reasonRow = document.createElement('div');
+      reasonRow.style.cssText = 'display:none;gap:6px;margin-top:4px;align-items:center;flex-wrap:wrap';
+      const reasonInput = document.createElement('input'); reasonInput.type = 'text';
+      reasonInput.placeholder = 'Reason for denying (optional)';
+      reasonInput.style.cssText = 'flex:1;min-width:120px;background:var(--an-bg-1);border:1px solid var(--an-line);border-radius:4px;padding:4px 8px;font-size:0.82em;color:inherit;outline:none';
+      const confirmDeny = document.createElement('button'); confirmDeny.className = 'apBtn no'; confirmDeny.textContent = 'Deny';
+      confirmDeny.addEventListener('click', () => decide('deny', { reason: reasonInput.value.trim() || undefined }));
+      const cancelDeny = document.createElement('button'); cancelDeny.className = 'apBtn'; cancelDeny.textContent = '↩';
+      cancelDeny.style.cssText = 'opacity:0.6'; cancelDeny.addEventListener('click', () => { reasonRow.style.display = 'none'; });
+      reasonRow.appendChild(reasonInput); reasonRow.appendChild(confirmDeny); reasonRow.appendChild(cancelDeny);
+
+      // Deny button: first click reveals reason row; doesn't call decide() directly
+      const denyBtn = document.createElement('button'); denyBtn.className = 'apBtn no'; denyBtn.textContent = 'Deny';
+      denyBtn.addEventListener('click', () => {
+        reasonRow.style.display = 'flex';
+        reasonInput.focus();
+      });
+      actions.appendChild(denyBtn);
+      card.appendChild(actions);
+      card.appendChild(reasonRow);
+    }
+
+    if (isPlan) card.appendChild(actions);
+
+    // keyboard: ← → move focus between action buttons, Enter/Space activates focused button.
     card.addEventListener('keydown', (e) => {
-      const i = btns.indexOf(document.activeElement);
-      if (e.key === 'ArrowRight') { e.preventDefault(); btns[(Math.max(0, i) + 1) % btns.length].focus(); }
-      else if (e.key === 'ArrowLeft') { e.preventDefault(); btns[(Math.max(0, i) + btns.length - 1) % btns.length].focus(); }
+      const btnsAll = Array.from(actions.querySelectorAll('button'));
+      const i = btnsAll.indexOf(document.activeElement);
+      if (i < 0) return;
+      if (e.key === 'ArrowRight') { e.preventDefault(); btnsAll[(i + 1) % btnsAll.length].focus(); }
+      else if (e.key === 'ArrowLeft') { e.preventDefault(); btnsAll[(i + btnsAll.length - 1) % btnsAll.length].focus(); }
     });
 
     // dock it just above the composer (newest on top), not inside the scrolling log
@@ -1963,7 +2114,7 @@ export function chatHtml(): string {
     // approval popping in a BACKGROUND session would otherwise yank focus out of the
     // panel the user is typing in. document.hasFocus() is false for that background
     // webview, so we skip the auto-focus there and leave the active panel alone.
-    if (document.hasFocus()) btns[0].focus();
+    if (document.hasFocus()) { const first = actions.querySelector('button'); if (first) first.focus(); }
   }
 
   function onMessage(msg) {
@@ -2202,6 +2353,57 @@ export function chatHtml(): string {
       flashSkill(text.slice('/mockskill'.length).trim() || 'cleancode');
       input.value = '';
       return;
+    }
+    // ── real slash-command registry (local UI commands, not forwarded to the agent) ──
+    if (text.startsWith('/')) {
+      const [cmd, ...rest] = text.slice(1).split(' ');
+      const arg = rest.join(' ').trim();
+      switch (cmd) {
+        case 'new':
+          vscode.postMessage({ type: 'new' });
+          input.value = ''; return;
+        case 'clear':
+          while (log.firstChild) log.removeChild(log.firstChild);
+          syncWatermark();
+          input.value = ''; return;
+        case 'copy': {
+          const last = Array.from(log.querySelectorAll('.bubble.assistant')).pop();
+          if (last && navigator.clipboard) navigator.clipboard.writeText(last.textContent || '').catch(() => {});
+          input.value = ''; return;
+        }
+        case 'engine':
+          if (arg === 'claude' || arg === 'codex') selectTab(arg);
+          input.value = ''; return;
+        case 'model':
+          if (arg) { modelByCli[cli] = arg; fillModels(); vscode.postMessage({ type: 'model', model: arg }); }
+          input.value = ''; return;
+        case 'mode':
+          if (arg) { modeByCli[cli] = arg; fillModes(); vscode.postMessage({ type: 'mode', mode: arg }); }
+          input.value = ''; return;
+        case 'effort':
+          if (arg) { effortByCli[cli] = arg; fillEfforts(); vscode.postMessage({ type: 'effort', effort: arg === 'default' ? undefined : arg }); }
+          input.value = ''; return;
+        case 'help': {
+          const helpText = [
+            '/new — start fresh session', '/clear — clear on-screen log',
+            '/copy — copy last reply', '/engine claude|codex — switch engine',
+            '/model <model> — change model', '/mode <mode> — change permission mode',
+            '/effort low|medium|high|xhigh|max — set reasoning effort',
+          ].join('\n');
+          const pre = document.createElement('pre');
+          pre.style.cssText = 'margin:8px 0;padding:8px 12px;background:var(--an-bg-1);border-radius:6px;font-size:0.82em;opacity:0.8';
+          pre.textContent = helpText;
+          log.appendChild(pre); syncWatermark();
+          input.value = ''; return;
+        }
+        default: {
+          const notice = document.createElement('div');
+          notice.style.cssText = 'padding:4px 12px;font-size:0.82em;opacity:0.55';
+          notice.textContent = 'Unknown command: /' + cmd + ' — type /help for the list';
+          log.appendChild(notice); syncWatermark();
+          input.value = ''; return;
+        }
+      }
     }
     const images = attached.map((a) => ({ mime: a.mime, dataBase64: a.dataBase64, name: a.name }));
     pendingSentImages = attached.map((a) => a.dataUrl); // painted onto the echoed bubble
@@ -3288,8 +3490,17 @@ export function chatHtml(): string {
     if (m.type === 'message') onMessage(m.msg);
     else if (m.type === 'sessions') { allSessions = m.list || []; activeId = m.activeId; renderSessions(); }
     else if (m.type === 'loading') showLoading();
-    else if (m.type === 'clear') { log.innerHTML = ''; approvalDock.innerHTML = ''; syncComposerLock(); streaming = null; openBash = null; tailTurn = null; headTurn = null; hideTyping(); hideActivity(); resetPaging(); syncWatermark(); hideLoading(); }
+    else if (m.type === 'clear') { log.innerHTML = ''; approvalDock.innerHTML = ''; ctxMeter.style.display = 'none'; syncComposerLock(); streaming = null; openBash = null; tailTurn = null; headTurn = null; hideTyping(); hideActivity(); resetPaging(); syncWatermark(); hideLoading(); }
     else if (m.type === 'turnEnd') { hideTyping(); hideActivity(); }
+    else if (m.type === 'usage') {
+      // update the context token meter near the composer chips
+      const n = m.contextTokens;
+      if (typeof n === 'number') {
+        const label = n >= 1000 ? Math.round(n / 1000) + 'k' : String(n);
+        ctxMeter.textContent = 'ctx: ' + label;
+        ctxMeter.style.display = 'inline-flex';
+      }
+    }
     else if (m.type === 'skillActive') flashSkill(m.name); // a real skill fired (was /mockskill)
     else if (m.type === 'rpcStatus') renderRpcStatus(m.status);
     else if (m.type === 'skillShopping') setShopToggle(m.on);

--- a/surfaces/cli/src/clipboardImage.ts
+++ b/surfaces/cli/src/clipboardImage.ts
@@ -1,0 +1,101 @@
+import { spawn } from "node:child_process";
+import { readFile, writeFile, unlink } from "node:fs/promises";
+import { tmpdir } from "node:os";
+import { join, extname } from "node:path";
+
+export interface ImageInput {
+  mime: string;
+  dataBase64: string;
+  name?: string;
+}
+
+// Read an image off the OS clipboard. Best-effort, no dependency.
+// Returns null if no image is on the clipboard or the tool isn't available.
+export async function readImageFromClipboard(): Promise<ImageInput | null> {
+  if (process.platform === "darwin") return readClipboardMac();
+  if (process.platform === "linux") return readClipboardLinux();
+  if (process.platform === "win32") return readClipboardWin();
+  return null;
+}
+
+async function readClipboardMac(): Promise<ImageInput | null> {
+  // Prefer pngpaste (brew install pngpaste) — pipes PNG directly to stdout.
+  const direct = await runAndCapture("pngpaste", ["-"]);
+  if (direct && direct.length > 0) {
+    return { mime: "image/png", dataBase64: direct.toString("base64"), name: "clipboard.png" };
+  }
+  // Fallback: osascript writes clipboard PNG to a temp file then we read it.
+  const tmp = join(tmpdir(), `agentnet-clip-${Date.now()}.png`);
+  const script = `tell app "System Events" to write (the clipboard as «class PNGf») to POSIX file "${tmp}"`;
+  try {
+    await runAndCapture("osascript", ["-e", script]);
+    const buf = await readFile(tmp).catch(() => null);
+    await unlink(tmp).catch(() => {});
+    if (!buf || buf.length === 0) return null;
+    return { mime: "image/png", dataBase64: buf.toString("base64"), name: "clipboard.png" };
+  } catch {
+    return null;
+  }
+}
+
+async function readClipboardLinux(): Promise<ImageInput | null> {
+  const buf = await runAndCapture("xclip", ["-selection", "clipboard", "-t", "image/png", "-o"]);
+  if (!buf || buf.length === 0) return null;
+  return { mime: "image/png", dataBase64: buf.toString("base64"), name: "clipboard.png" };
+}
+
+async function readClipboardWin(): Promise<ImageInput | null> {
+  const tmp = join(tmpdir(), `agentnet-clip-${Date.now()}.png`);
+  const ps = `
+$img = [System.Windows.Forms.Clipboard]::GetImage()
+if ($img -ne $null) { $img.Save('${tmp.replace(/\\/g, "\\\\")}') }
+`;
+  try {
+    await runAndCapture("powershell", ["-NoProfile", "-Command", ps]);
+    const buf = await readFile(tmp).catch(() => null);
+    await unlink(tmp).catch(() => {});
+    if (!buf || buf.length === 0) return null;
+    return { mime: "image/png", dataBase64: buf.toString("base64"), name: "clipboard.png" };
+  } catch {
+    return null;
+  }
+}
+
+function runAndCapture(cmd: string, args: string[]): Promise<Buffer | null> {
+  return new Promise((resolve) => {
+    try {
+      const chunks: Buffer[] = [];
+      const p = spawn(cmd, args, { stdio: ["ignore", "pipe", "ignore"] });
+      p.stdout.on("data", (d: Buffer) => chunks.push(d));
+      p.on("error", () => resolve(null));
+      p.on("close", (code) => {
+        if (code !== 0) { resolve(null); return; }
+        resolve(Buffer.concat(chunks));
+      });
+    } catch {
+      resolve(null);
+    }
+  });
+}
+
+const IMAGE_EXTS: Record<string, string> = {
+  ".png": "image/png",
+  ".jpg": "image/jpeg",
+  ".jpeg": "image/jpeg",
+  ".gif": "image/gif",
+  ".webp": "image/webp",
+};
+
+// Encode an image file at the given path to an ImageInput.
+// Returns null if the extension isn't a recognised image type or the file can't be read.
+export async function readImageFile(path: string): Promise<ImageInput | null> {
+  const mime = IMAGE_EXTS[extname(path).toLowerCase()];
+  if (!mime) return null;
+  try {
+    const buf = await readFile(path);
+    const name = path.split("/").pop() ?? path.split("\\").pop() ?? "image";
+    return { mime, dataBase64: buf.toString("base64"), name };
+  } catch {
+    return null;
+  }
+}

--- a/surfaces/cli/src/components/Composer.tsx
+++ b/surfaces/cli/src/components/Composer.tsx
@@ -3,6 +3,7 @@ import { Box, Text, useInput } from "ink";
 import { colors } from "../theme.js";
 import { SLASH_COMMANDS } from "../commands.js";
 import { indexFiles, filterFiles } from "../fileIndex.js";
+import { readImageFromClipboard, readImageFile, type ImageInput } from "../clipboardImage.js";
 
 // The input box — far past a single line. Supports:
 //   • multi-line editing (←/→ within the buffer, paste with newlines, \ + ↵ = newline)
@@ -16,12 +17,13 @@ export function Composer({
   history = [],
 }: {
   cwd: string;
-  onSubmit: (text: string) => void;
+  onSubmit: (text: string, images?: ImageInput[]) => void;
   disabled?: boolean;
   history?: string[]; // prior user messages, newest last — recalled with ↑/↓
 }) {
   const [value, setValue] = useState("");
   const [cursor, setCursor] = useState(0);
+  const [attached, setAttached] = useState<ImageInput[]>([]);
   const [files, setFiles] = useState<string[]>([]);
   const [menuIdx, setMenuIdx] = useState(0);
   const [suppress, setSuppress] = useState(false); // esc hides the menu until input changes
@@ -106,13 +108,23 @@ export function Composer({
     setMenuIdx(0);
   }
 
-  function submit() {
-    const text = value;
+  async function submit() {
+    const text = value.trim();
+    const imgs = [...attached];
     setValue("");
     setCursor(0);
     setMenuIdx(0);
     setHistPos(-1);
-    onSubmit(text);
+    setAttached([]);
+    // if the buffer is exactly an image file path, attach it instead of sending as text
+    if (!imgs.length && text && !/\s/.test(text)) {
+      const fromPath = await readImageFile(text);
+      if (fromPath) {
+        onSubmit("", [fromPath]);
+        return;
+      }
+    }
+    onSubmit(text, imgs.length ? imgs : undefined);
   }
 
   useInput(
@@ -173,10 +185,19 @@ export function Composer({
         setHistPos(-1);
         return;
       }
+      // Ctrl+V → try to grab an image off the OS clipboard; fall through to text paste if none
+      if (key.ctrl && input === "v") {
+        void readImageFromClipboard().then((img) => {
+          if (img) setAttached((a) => [...a, img]);
+          // if no image, Ctrl+V in a terminal usually inserts ^V — intentionally do nothing;
+          // regular text pasting flows through the terminal emulator as normal stdin input.
+        });
+        return;
+      }
       if (key.return) {
         if (menu && sel) {
           // if the full command is already typed, RUN it; otherwise complete the menu.
-          if (menu.kind === "slash" && sel.insert.trim() === value.trim()) return submit();
+          if (menu.kind === "slash" && sel.insert.trim() === value.trim()) { void submit(); return; }
           return complete();
         }
         if (value[cursor - 1] === "\\") {
@@ -184,9 +205,15 @@ export function Composer({
           setValue((v) => v.slice(0, cursor - 1) + "\n" + v.slice(cursor));
           return;
         }
-        return submit();
+        void submit();
+        return;
       }
       if (key.backspace || key.delete) {
+        // if buffer is empty and there are attached images, remove the last one
+        if (value.length === 0 && attached.length > 0) {
+          setAttached((a) => a.slice(0, -1));
+          return;
+        }
         if (cursor > 0) {
           setValue((v) => v.slice(0, cursor - 1) + v.slice(cursor));
           setCursor((c) => c - 1);
@@ -209,10 +236,18 @@ export function Composer({
 
   return (
     <Box flexDirection="column">
+      {attached.length > 0 && (
+        <Box marginBottom={0}>
+          {attached.map((img, i) => (
+            <Text key={i} color={colors.iqCyan}>[{img.name ?? "image"}] </Text>
+          ))}
+          <Text dimColor>(↵ sends · ⌫ removes last)</Text>
+        </Box>
+      )}
       <Box>
         <Text color={colors.iqCyan}>❯ </Text>
-        {empty ? (
-          <Text dimColor>message · / for commands · @ for files</Text>
+        {empty && !attached.length ? (
+          <Text dimColor>message · / for commands · @ for files · Ctrl+V image</Text>
         ) : (
           <Text>
             {head}

--- a/surfaces/cli/src/hooks/useChat.ts
+++ b/surfaces/cli/src/hooks/useChat.ts
@@ -130,10 +130,10 @@ export function useChat(
   }, [runtime, opts.cwd, opts.approval, wire]);
 
   const send = useCallback(
-    async (text: string) => {
+    async (text: string, images?: import("@iqlabs-official/agent-sdk/runtime/contract").ImageInput[]) => {
       setBusy(true);
       const h = await ensureHandle();
-      h.send(text);
+      h.send(text, images && images.length ? images : undefined);
     },
     [ensureHandle],
   );

--- a/surfaces/cli/src/views/Chat.tsx
+++ b/surfaces/cli/src/views/Chat.tsx
@@ -579,13 +579,13 @@ export function Chat({
     }
   }
 
-  function onSubmit(value: string) {
+  function onSubmit(value: string, images?: import("@iqlabs-official/agent-sdk/runtime/contract").ImageInput[]) {
     const text = value.trim();
-    if (!text) return;
+    if (!text && !images?.length) return;
     setNotice("");
     if (text.startsWith("/")) return runSlash(text);
     if (text.startsWith("!")) return chat.runBash(text.slice(1)); // quick local shell
-    void chat.send(text);
+    void chat.send(text, images);
   }
 
   const mood: Mood = eggMood ?? (pendingApproval ? "tool" : chat.busy ? "thinking" : idle ? "sleeping" : "idle");

--- a/surfaces/vscode/src/extension.ts
+++ b/surfaces/vscode/src/extension.ts
@@ -196,12 +196,24 @@ async function openChat(context: vscode.ExtensionContext, column = vscode.ViewCo
 
   // marketplace search/buy/install — needs the wallet + a chain connection. The RPC is
   // resolved inside (registered Helius key wins; else env; else public-devnet default).
-  const market = await marketplaceEnv(wallet!);
+  const marketPromise = marketplaceEnv(wallet!);
   const chat = createChatSession(runtime!, transport, {
     cwd: getCwd,
     approval,
     claimSession,
-    ...market,
+    searchSkills: async (query, kind) => (await marketPromise).searchSkills(query, kind),
+    getSkillDetail: async (mint) => (await marketPromise).getSkillDetail(mint),
+    buySkill: async (skillId, creatorWallet) => (await marketPromise).buySkill(skillId, creatorWallet),
+    postNote: async (skillId, skillType, text, gitLink) => (await marketPromise).postNote(skillId, skillType, text, gitLink),
+    ownedSkills: async () => (await marketPromise).ownedSkills(),
+    ownedNftSkills: async () => (await marketPromise).ownedNftSkills(),
+    listAgents: async () => (await marketPromise).listAgents(),
+    getAgentProfile: async (w) => (await marketPromise).getAgentProfile(w),
+    buyAllSkills: async (w) => (await marketPromise).buyAllSkills(w),
+    postAgentNote: async (w, t, l) => (await marketPromise).postAgentNote(w, t, l),
+    solBalance: async () => (await marketPromise).solBalance(),
+    publishSkill: async (input) => (await marketPromise).publishSkill(input),
+    loadOwnedSkills: async () => (await marketPromise).loadOwnedSkills(),
     // RPC config (issue #23): capture the Helius key via a native secret input — it
     // never passes through the webview as plain text — then save it like an OAuth token.
     setHeliusKey: async () => {

--- a/surfaces/webview/src/chat/ApprovalDock.tsx
+++ b/surfaces/webview/src/chat/ApprovalDock.tsx
@@ -16,18 +16,22 @@ export function ApprovalDock() {
   const { state, send, resolveApproval } = useStore();
   if (state.approvals.length === 0) return null;
 
-  function decide(req: ApprovalRequest, outcome: ApprovalOutcome, questionResponses?: ApprovalQuestionResponse[]) {
+  function decide(
+    req: ApprovalRequest,
+    outcome: ApprovalOutcome,
+    extra?: { reason?: string; updatedInput?: Record<string, unknown>; questionResponses?: ApprovalQuestionResponse[] },
+  ) {
     resolveApproval(req.id);
-    send({ type: "approvalDecision", id: req.id, outcome, questionResponses });
+    send({ type: "approvalDecision", id: req.id, outcome, ...extra });
   }
 
   return (
     <div className="flex flex-col gap-2 px-3 pt-2">
       {state.approvals.map((req) =>
         req.kind === "question" && req.questions?.length ? (
-          <QuestionCard key={req.id} req={req} onAnswer={(a) => decide(req, "once", a)} />
+          <QuestionCard key={req.id} req={req} onAnswer={(a) => decide(req, "once", { questionResponses: a })} />
         ) : (
-          <ApprovalCard key={req.id} req={req} onDecide={(o) => decide(req, o)} />
+          <ApprovalCard key={req.id} req={req} onDecide={(o, extra) => decide(req, o, extra)} />
         ),
       )}
     </div>
@@ -44,7 +48,6 @@ function QuestionCard({
   onAnswer: (questionResponses: ApprovalQuestionResponse[]) => void;
 }) {
   const questions = req.questions ?? [];
-  // selections[qIndex] = set of chosen labels for that question
   const [selections, setSelections] = useState<Record<number, string[]>>({});
   const [customInput, setCustomInput] = useState<Record<number, string>>({});
 
@@ -164,23 +167,54 @@ function ApprovalCard({
   onDecide,
 }: {
   req: ApprovalRequest;
-  onDecide: (o: ApprovalOutcome) => void;
+  onDecide: (o: ApprovalOutcome, extra?: { reason?: string; updatedInput?: Record<string, unknown> }) => void;
 }) {
   const isPlan = req.kind === "plan";
+  const isDanger = req.risk === "danger";
+  const [editMode, setEditMode] = useState(false);
+  const [editedCmd, setEditedCmd] = useState(req.command ?? "");
+  const [showReason, setShowReason] = useState(false);
+  const [reason, setReason] = useState("");
+
+  const borderColor = isDanger ? "border-red-700/60" : "border-emerald-700/50";
+  const bgColor = isDanger ? "bg-red-950/20" : "bg-emerald-950/30";
+
   return (
-    <div className="overflow-hidden rounded-lg border border-emerald-700/50 bg-emerald-950/30 text-sm">
+    <div className={`overflow-hidden rounded-lg border ${borderColor} ${bgColor} text-sm`}>
+      {/* header */}
       <div className="flex items-center gap-2 px-3 py-1.5">
+        {isDanger && (
+          <span className="font-bold text-red-400">⚠ DANGER</span>
+        )}
         <span className="font-mono text-emerald-400">
           {req.kind === "bash" ? "$" : req.kind === "read" ? "□" : isPlan ? "✦" : "✎"}
         </span>
         <span className="truncate font-medium">{req.title || req.tool}</span>
         <span className="ml-auto text-xs text-zinc-500">{req.cli}</span>
+        {/* bash: edit toggle */}
+        {req.kind === "bash" && req.command && (
+          <button
+            onClick={() => setEditMode((e) => !e)}
+            className="text-xs text-zinc-500 hover:text-zinc-300"
+          >
+            {editMode ? "cancel" : "edit"}
+          </button>
+        )}
       </div>
 
-      {req.command && (
+      {/* detail */}
+      {req.command && !editMode && (
         <pre className="overflow-x-auto px-3 pb-2 font-mono text-xs text-zinc-200">
           {req.command}
         </pre>
+      )}
+      {req.kind === "bash" && editMode && (
+        <textarea
+          value={editedCmd}
+          onChange={(e) => setEditedCmd(e.target.value)}
+          rows={3}
+          className="w-full resize-y bg-zinc-950 px-3 py-2 font-mono text-xs text-zinc-100 outline-none border-t border-zinc-700"
+        />
       )}
       {req.plan && (
         <div className="max-h-64 overflow-y-auto whitespace-pre-wrap px-3 pb-2 text-xs leading-relaxed text-zinc-300 [overflow-wrap:anywhere]">
@@ -209,28 +243,76 @@ function ApprovalCard({
         </pre>
       )}
 
-      <div className="flex gap-2 border-t border-emerald-700/40 px-3 py-2">
-        <button
-          autoFocus
-          onClick={() => onDecide("once")}
-          className="rounded bg-emerald-600 px-3 py-1 text-xs font-medium text-white"
-        >
-          {isPlan ? "Approve plan" : "Approve"}
-        </button>
-        {!isPlan && (
+      {/* deny-with-reason input */}
+      {showReason && (
+        <div className="flex items-center gap-2 border-t border-zinc-700 px-3 py-2">
+          <input
+            type="text"
+            value={reason}
+            onChange={(e) => setReason(e.target.value)}
+            placeholder="Reason (optional)"
+            autoFocus
+            className="flex-1 rounded border border-zinc-700 bg-zinc-950 px-2 py-1 text-xs text-zinc-100 outline-none focus:border-zinc-500 placeholder:text-zinc-600"
+            onKeyDown={(e) => {
+              if (e.key === "Enter") onDecide("deny", { reason: reason.trim() || undefined });
+              if (e.key === "Escape") { setShowReason(false); setReason(""); }
+            }}
+          />
           <button
-            onClick={() => onDecide("always")}
-            className="rounded bg-emerald-800 px-3 py-1 text-xs text-emerald-100"
+            onClick={() => onDecide("deny", { reason: reason.trim() || undefined })}
+            className="rounded bg-red-900/60 px-2 py-1 text-xs text-red-200"
           >
-            Always
+            Deny
           </button>
+          <button
+            onClick={() => { setShowReason(false); setReason(""); }}
+            className="text-xs text-zinc-500 hover:text-zinc-300"
+          >
+            ↩
+          </button>
+        </div>
+      )}
+
+      {/* action buttons */}
+      <div className="flex flex-wrap gap-2 border-t border-emerald-700/40 px-3 py-2">
+        {isPlan ? (
+          <>
+            <button autoFocus onClick={() => onDecide("once")} className="rounded bg-emerald-600 px-3 py-1 text-xs font-medium text-white">
+              Approve plan
+            </button>
+            <button onClick={() => onDecide("deny")} className="rounded bg-red-900/60 px-3 py-1 text-xs text-red-200">
+              Keep planning
+            </button>
+          </>
+        ) : editMode ? (
+          <>
+            <button
+              autoFocus
+              onClick={() => onDecide("once", { updatedInput: { ...(req.input ?? {}), command: editedCmd } })}
+              className="rounded bg-emerald-600 px-3 py-1 text-xs font-medium text-white"
+            >
+              Approve edited
+            </button>
+            <button onClick={() => setEditMode(false)} className="rounded bg-zinc-700 px-3 py-1 text-xs text-zinc-200">
+              Cancel
+            </button>
+          </>
+        ) : (
+          <>
+            <button autoFocus onClick={() => onDecide("once")} className="rounded bg-emerald-600 px-3 py-1 text-xs font-medium text-white">
+              Approve
+            </button>
+            <button onClick={() => onDecide("always")} className="rounded bg-emerald-800 px-3 py-1 text-xs text-emerald-100">
+              Always
+            </button>
+            <button
+              onClick={() => { setShowReason((s) => !s); }}
+              className="rounded bg-red-900/60 px-3 py-1 text-xs text-red-200"
+            >
+              Deny…
+            </button>
+          </>
         )}
-        <button
-          onClick={() => onDecide("deny")}
-          className="rounded bg-red-900/60 px-3 py-1 text-xs text-red-200"
-        >
-          {isPlan ? "Keep planning" : "Deny"}
-        </button>
       </div>
     </div>
   );

--- a/surfaces/webview/src/chat/Composer.tsx
+++ b/surfaces/webview/src/chat/Composer.tsx
@@ -34,11 +34,13 @@ const MODES: Record<Cli, { value: string; label: string; title: string }[]> = {
 };
 
 // Slash commands handled locally in this surface (not forwarded to the agent).
-const SLASH_CMDS: { name: string; desc: string }[] = [
+const SLASH_CMDS = [
   { name: "new",    desc: "start a fresh session" },
   { name: "clear",  desc: "clear on-screen log" },
+  { name: "copy",   desc: "copy last reply to clipboard" },
   { name: "engine", desc: "switch engine — claude|codex" },
   { name: "model",  desc: "change model" },
+  { name: "mode",   desc: "change permission mode" },
   { name: "effort", desc: "set reasoning effort" },
   { name: "help",   desc: "list commands" },
 ];
@@ -63,6 +65,103 @@ export function Composer() {
   const fileInputRef = useRef<HTMLInputElement>(null);
   const busy = state.typing;
   const frozen = state.approvals.length > 0;
+
+  const [slashIdx, setSlashIdx] = useState(0);
+  const [suppressSlash, setSuppressSlash] = useState(false);
+
+  // Derived state: active slash matches
+  let activeMatches: { name: string; desc: string; insert: string }[] = [];
+  let subCmd: string | null = null;
+  if (!suppressSlash) {
+    // 1. Engine options
+    let m = /^\/engine(?:\s+(\S*))?$/.exec(text);
+    if (m) {
+      subCmd = 'engine';
+      const prefix = (m[1] || '').toLowerCase();
+      const options = [
+        { name: 'claude', desc: 'switch to Claude engine', insert: '/engine claude' },
+        { name: 'codex',  desc: 'switch to Codex engine',  insert: '/engine codex' }
+      ];
+      activeMatches = options.filter(opt => opt.name.toLowerCase().startsWith(prefix));
+    }
+    // 2. Model options
+    if (!subCmd) {
+      m = /^\/model(?:\s+(\S*))?$/.exec(text);
+      if (m) {
+        subCmd = 'model';
+        const prefix = (m[1] || '').toLowerCase();
+        const list = MODELS[state.cli] || [];
+        const options = list.map(o => ({ name: o.value, desc: o.label, insert: '/model ' + o.value }));
+        activeMatches = options.filter(opt => opt.name.toLowerCase().startsWith(prefix));
+      }
+    }
+    // 3. Mode options
+    if (!subCmd) {
+      m = /^\/mode(?:\s+(\S*))?$/.exec(text);
+      if (m) {
+        subCmd = 'mode';
+        const prefix = (m[1] || '').toLowerCase();
+        const list = MODES[state.cli] || [];
+        const options = list.map(o => ({ name: o.value, desc: o.label + ' - ' + o.title, insert: '/mode ' + o.value }));
+        activeMatches = options.filter(opt => opt.name.toLowerCase().startsWith(prefix));
+      }
+    }
+    // 4. Effort options
+    if (!subCmd) {
+      m = /^\/effort(?:\s+(\S*))?$/.exec(text);
+      if (m) {
+        subCmd = 'effort';
+        const prefix = (m[1] || '').toLowerCase();
+        const options = EFFORTS.map(o => ({ name: o.value, desc: o.label, insert: '/effort ' + o.value }));
+        activeMatches = options.filter(opt => opt.name.toLowerCase().startsWith(prefix));
+      }
+    }
+    // 5. Main options
+    if (!subCmd) {
+      m = /^\/(\S*)$/.exec(text);
+      if (m) {
+        const prefix = m[1].toLowerCase();
+        const options = SLASH_CMDS.map(c => ({
+          name: c.name,
+          desc: c.desc,
+          insert: '/' + c.name + (['engine', 'model', 'mode', 'effort'].includes(c.name) ? ' ' : '')
+        }));
+        activeMatches = options.filter(opt => opt.name.toLowerCase().startsWith(prefix));
+      }
+    }
+  }
+
+  // If the user fully typed the sub-command argument, hide the menu
+  const isFullyTyped = !!(subCmd && activeMatches.length === 1 && activeMatches[0].name.toLowerCase() === (text.split(/\s+/)[1] || '').toLowerCase());
+  const showMenu = activeMatches.length > 0 && !isFullyTyped;
+
+  function completeSlash(c: { name: string; desc: string; insert: string }) {
+    setText(c.insert);
+    setSuppressSlash(false);
+    setSlashIdx(0);
+    if (taRef.current) {
+      taRef.current.focus();
+      // Auto-grow height immediately
+      setTimeout(() => {
+        if (taRef.current) {
+          taRef.current.style.height = "auto";
+          taRef.current.style.height = `${taRef.current.scrollHeight}px`;
+        }
+      }, 0);
+    }
+  }
+
+  // Outside click listener
+  useEffect(() => {
+    if (!showMenu) return;
+    const handleOutsideClick = (e: MouseEvent) => {
+      if (taRef.current && !taRef.current.parentElement?.contains(e.target as Node)) {
+        setSuppressSlash(true);
+      }
+    };
+    document.addEventListener("click", handleOutsideClick);
+    return () => document.removeEventListener("click", handleOutsideClick);
+  }, [showMenu]);
 
   function encodeFile(file: File): Promise<ImageInput & { dataUrl: string }> {
     return new Promise((resolve, reject) => {
@@ -123,7 +222,7 @@ export function Composer() {
           if (arg) { setEffort(arg); send({ type: "effort", effort: arg === "default" ? undefined : arg }); }
           setText(""); return;
         case "help": {
-          const lines = [...SLASH_CMDS, { name: "copy", desc: "copy last reply to clipboard" }, { name: "mode", desc: "set permission mode" }]
+          const lines = SLASH_CMDS
             .map((c) => `/${c.name} — ${c.desc}`).join("\n");
           setSlashNotice(lines);
           setText(""); return;
@@ -262,12 +361,41 @@ export function Composer() {
       )}
 
       <div
-        className={`flex items-end gap-2 rounded-xl border border-zinc-800 bg-zinc-900 px-3 py-2 ${
+        className={`relative flex items-end gap-2 rounded-xl border border-zinc-800 bg-zinc-900 px-3 py-2 ${
           frozen ? "opacity-60" : ""
         }`}
         onDragOver={(e) => { e.preventDefault(); }}
         onDrop={(e) => { e.preventDefault(); if (e.dataTransfer.files) void addFiles(e.dataTransfer.files); }}
       >
+        {showMenu && (
+          <div className="absolute bottom-[calc(100%+6px)] left-0 right-0 z-50 flex flex-col gap-0.5 rounded-lg border border-zinc-800 bg-zinc-950 p-1 shadow-2xl max-h-48 overflow-y-auto">
+            {activeMatches.map((cmd, idx) => {
+              const isSel = idx === slashIdx;
+              const label = subCmd ? cmd.name : '/' + cmd.name;
+              return (
+                <button
+                  key={cmd.name}
+                  type="button"
+                  onClick={(e) => {
+                    e.stopPropagation();
+                    completeSlash(cmd);
+                  }}
+                  className={`flex items-center gap-2 rounded px-2 py-1.5 text-left text-xs transition-colors ${
+                    isSel
+                      ? "bg-zinc-800 text-zinc-100"
+                      : "text-zinc-400 hover:bg-zinc-900 hover:text-zinc-200"
+                  }`}
+                >
+                  <span className="font-semibold text-zinc-200">{label}</span>
+                  <span className="opacity-60 text-[10px] truncate">{cmd.desc}</span>
+                </button>
+              );
+            })}
+            <div className="border-t border-zinc-900 mt-1 px-2 pt-1.5 pb-0.5 text-[9px] text-zinc-600 select-none">
+              Use ↑↓ to navigate, Tab/Enter to select, Esc to close
+            </div>
+          </div>
+        )}
         {/* paperclip attach button */}
         <button
           type="button"
@@ -292,10 +420,42 @@ export function Composer() {
           rows={1}
           value={text}
           disabled={frozen}
-          onChange={(e) => { setText(e.target.value); autoGrow(e.target); }}
+          onChange={(e) => {
+            setText(e.target.value);
+            autoGrow(e.target);
+            setSuppressSlash(false);
+            setSlashIdx(0);
+          }}
           onPaste={onPaste}
           onKeyDown={(e) => {
             if (e.nativeEvent.isComposing) return;
+
+            if (showMenu) {
+              if (e.key === "ArrowDown") {
+                e.preventDefault();
+                setSlashIdx((slashIdx + 1) % activeMatches.length);
+                return;
+              }
+              if (e.key === "ArrowUp") {
+                e.preventDefault();
+                setSlashIdx((slashIdx - 1 + activeMatches.length) % activeMatches.length);
+                return;
+              }
+              if (e.key === "Tab" || e.key === "Enter") {
+                e.preventDefault();
+                if (activeMatches[slashIdx]) {
+                  completeSlash(activeMatches[slashIdx]);
+                }
+                return;
+              }
+              if (e.key === "Escape") {
+                e.preventDefault();
+                e.stopPropagation();
+                setSuppressSlash(true);
+                return;
+              }
+            }
+
             if (e.key === "Enter" && !e.shiftKey) {
               e.preventDefault();
               submit();

--- a/surfaces/webview/src/chat/Composer.tsx
+++ b/surfaces/webview/src/chat/Composer.tsx
@@ -1,6 +1,6 @@
 import { useEffect, useRef, useState } from "react";
 import { useStore } from "../state/store";
-import type { Cli } from "../transport/protocol";
+import type { Cli, ImageInput } from "../transport/protocol";
 
 const MODELS: Record<Cli, { value: string; label: string }[]> = {
   claude: [
@@ -11,23 +11,135 @@ const MODELS: Record<Cli, { value: string; label: string }[]> = {
   codex: [{ value: "default", label: "default" }],
 };
 
-// Input + engine tabs + model picker. FROZEN while an approval is pending: the textarea
-// keeps its value (only disabled is toggled, never the text), so a half-typed message
-// survives the wait — same contract as the vscode webview fix.
+const EFFORTS = [
+  { value: "default", label: "default" },
+  { value: "low",    label: "low" },
+  { value: "medium", label: "medium" },
+  { value: "high",   label: "high" },
+  { value: "xhigh",  label: "x-high" },
+  { value: "max",    label: "max" },
+];
+
+const MODES: Record<Cli, { value: string; label: string; title: string }[]> = {
+  claude: [
+    { value: "acceptEdits", label: "Auto edit",  title: "Auto-accept file edits; still ask for other tools" },
+    { value: "default",     label: "Ask edits",  title: "Ask before each file edit (default)" },
+    { value: "plan",        label: "Plan",        title: "Plan mode: read-only until you approve the plan" },
+  ],
+  codex: [
+    { value: "auto",     label: "Auto accept", title: "Auto-accept edits + run inside the workspace (default)" },
+    { value: "readonly", label: "Read only",   title: "Read-only sandbox; ask before edits, commands, network" },
+    { value: "full",     label: "Full access", title: "Full disk + network access, never ask (use with care)" },
+  ],
+};
+
+// Slash commands handled locally in this surface (not forwarded to the agent).
+const SLASH_CMDS: { name: string; desc: string }[] = [
+  { name: "new",    desc: "start a fresh session" },
+  { name: "clear",  desc: "clear on-screen log" },
+  { name: "engine", desc: "switch engine — claude|codex" },
+  { name: "model",  desc: "change model" },
+  { name: "effort", desc: "set reasoning effort" },
+  { name: "help",   desc: "list commands" },
+];
+
+// Input + engine tabs + model/effort pickers. FROZEN while an approval is pending.
 export function Composer() {
   const { state, send } = useStore();
   const [text, setText] = useState("");
+  const [effort, setEffort] = useState("default");
+  const [modeByCli, setModeByCli] = useState<Record<string, string>>({
+    claude: "acceptEdits",
+    codex: "auto",
+  });
+  const mode = modeByCli[state.cli] ?? MODES[state.cli][0].value;
+  function changeMode(v: string) {
+    setModeByCli((prev) => ({ ...prev, [state.cli]: v }));
+    send({ type: "mode", mode: v });
+  }
+  const [attached, setAttached] = useState<(ImageInput & { dataUrl: string })[]>([]);
+  const [slashNotice, setSlashNotice] = useState<string | null>(null);
   const taRef = useRef<HTMLTextAreaElement>(null);
+  const fileInputRef = useRef<HTMLInputElement>(null);
   const busy = state.typing;
   const frozen = state.approvals.length > 0;
+
+  function encodeFile(file: File): Promise<ImageInput & { dataUrl: string }> {
+    return new Promise((resolve, reject) => {
+      const reader = new FileReader();
+      reader.onload = () => {
+        const dataUrl = reader.result as string;
+        const comma = dataUrl.indexOf(",");
+        if (comma < 0) { reject(new Error("bad dataUrl")); return; }
+        resolve({ mime: file.type || "image/png", dataBase64: dataUrl.slice(comma + 1), name: file.name, dataUrl });
+      };
+      reader.onerror = reject;
+      reader.readAsDataURL(file);
+    });
+  }
+
+  async function addFiles(files: FileList | File[]) {
+    const arr = Array.from(files).filter((f) => f.type.startsWith("image/"));
+    const encoded = await Promise.all(arr.map(encodeFile));
+    setAttached((a) => [...a, ...encoded]);
+  }
+
+  function removeAttached(i: number) {
+    setAttached((a) => a.filter((_, idx) => idx !== i));
+  }
 
   function submit() {
     if (frozen || busy) return;
     const t = text.trim();
-    if (!t) return;
-    send({ type: "send", text: t });
+    if (!t && !attached.length) return;
+
+    // slash command handling
+    if (t.startsWith("/")) {
+      const [cmd, ...rest] = t.slice(1).split(" ");
+      const arg = rest.join(" ").trim();
+      switch (cmd) {
+        case "new":
+          send({ type: "new" });
+          setText(""); return;
+        case "clear":
+          // can't clear the log from here; dispatch a "new" which triggers a clear paint
+          send({ type: "new" });
+          setText(""); return;
+        case "copy": {
+          const lastAsst = [...state.log].reverse().find((m) => m.role === "assistant");
+          if (lastAsst && navigator.clipboard) void navigator.clipboard.writeText(lastAsst.text);
+          setText(""); return;
+        }
+        case "engine":
+          if (arg === "claude" || arg === "codex") send({ type: "platform", cli: arg });
+          setText(""); return;
+        case "model":
+          if (arg) send({ type: "model", model: arg });
+          setText(""); return;
+        case "mode":
+          if (arg) changeMode(arg);
+          setText(""); return;
+        case "effort":
+          if (arg) { setEffort(arg); send({ type: "effort", effort: arg === "default" ? undefined : arg }); }
+          setText(""); return;
+        case "help": {
+          const lines = [...SLASH_CMDS, { name: "copy", desc: "copy last reply to clipboard" }, { name: "mode", desc: "set permission mode" }]
+            .map((c) => `/${c.name} — ${c.desc}`).join("\n");
+          setSlashNotice(lines);
+          setText(""); return;
+        }
+        default:
+          setSlashNotice(`Unknown command: /${cmd} — type /help for the list`);
+          setText(""); return;
+      }
+    }
+
+    const images = attached.map(({ mime, dataBase64, name }) => ({ mime, dataBase64, name }));
+    send({ type: "send", text: t, images: images.length ? images : undefined });
     setText("");
-    if (taRef.current) taRef.current.style.height = "auto"; // collapse back to one row
+    setAttached([]);
+    setSlashNotice(null);
+    if (taRef.current) taRef.current.style.height = "auto";
   }
 
   function interrupt() {
@@ -45,11 +157,20 @@ export function Composer() {
     return () => document.removeEventListener("keydown", onKeyDown);
   }, [busy]);
 
-  // Grow the textarea with its content (up to the max-height the CSS caps), so a long
-  // message wraps onto multiple lines instead of scrolling a single cramped row.
   function autoGrow(el: HTMLTextAreaElement) {
     el.style.height = "auto";
     el.style.height = `${el.scrollHeight}px`;
+  }
+
+  // paste: capture image items, fall through to default text paste otherwise
+  function onPaste(e: React.ClipboardEvent<HTMLTextAreaElement>) {
+    const items = Array.from(e.clipboardData.items || []);
+    const imgFiles = items.filter((it) => it.kind === "file" && it.type.startsWith("image/")).map((it) => it.getAsFile()).filter(Boolean) as File[];
+    if (imgFiles.length) {
+      e.preventDefault();
+      void addFiles(imgFiles);
+    }
+    // non-image pastes fall through to default textarea behaviour
   }
 
   return (
@@ -57,7 +178,8 @@ export function Composer() {
       className="border-t border-zinc-800 px-3 pt-2"
       style={{ paddingBottom: "max(0.5rem, env(safe-area-inset-bottom))" }}
     >
-      <div className="mb-1.5 flex items-center justify-between text-xs">
+      {/* engine tabs + model/effort pickers */}
+      <div className="mb-1.5 flex flex-wrap items-center gap-1.5 text-xs">
         <div className="flex gap-1">
           {(["claude", "codex"] as Cli[]).map((c) => (
             <button
@@ -76,34 +198,104 @@ export function Composer() {
           ))}
         </div>
         <select
-          onChange={(e) =>
-            send({ type: "model", model: e.target.value === "default" ? undefined : e.target.value })
-          }
+          value={MODELS[state.cli].map((m) => m.value).includes(state.cli) ? state.cli : "default"}
+          onChange={(e) => send({ type: "model", model: e.target.value === "default" ? undefined : e.target.value })}
           className="rounded border border-zinc-800 bg-zinc-900 px-2 py-0.5 text-zinc-300"
         >
           {MODELS[state.cli].map((m) => (
-            <option key={m.value} value={m.value}>
-              {m.label}
-            </option>
+            <option key={m.value} value={m.value}>{m.label}</option>
           ))}
         </select>
+        <select
+          value={effort}
+          onChange={(e) => {
+            const v = e.target.value;
+            setEffort(v);
+            send({ type: "effort", effort: v === "default" ? undefined : v });
+          }}
+          className="rounded border border-zinc-800 bg-zinc-900 px-2 py-0.5 text-zinc-300"
+          title="Reasoning effort"
+        >
+          {EFFORTS.map((e) => (
+            <option key={e.value} value={e.value}>{e.label}</option>
+          ))}
+        </select>
+        <select
+          value={mode}
+          onChange={(e) => changeMode(e.target.value)}
+          className="rounded border border-zinc-800 bg-zinc-900 px-2 py-0.5 text-zinc-300"
+          title="Permission mode: how tools run before asking you"
+        >
+          {MODES[state.cli].map((m) => (
+            <option key={m.value} value={m.value} title={m.title}>{m.label}</option>
+          ))}
+        </select>
+        {/* context token meter — populated by store.contextTokens */}
+        {state.contextTokens !== undefined && (
+          <span className="ml-auto text-zinc-500">
+            ctx: {state.contextTokens >= 1000 ? Math.round(state.contextTokens / 1000) + "k" : state.contextTokens}
+          </span>
+        )}
       </div>
+
+      {/* attached image thumbnails */}
+      {attached.length > 0 && (
+        <div className="mb-1.5 flex flex-wrap gap-1.5">
+          {attached.map((img, i) => (
+            <div key={i} className="relative">
+              <img src={img.dataUrl} alt={img.name ?? "attachment"} className="h-14 w-14 rounded object-cover border border-zinc-700" />
+              <button
+                onClick={() => removeAttached(i)}
+                className="absolute -right-1 -top-1 flex h-4 w-4 items-center justify-center rounded-full bg-zinc-700 text-[10px] text-zinc-200 hover:bg-zinc-500"
+              >×</button>
+            </div>
+          ))}
+        </div>
+      )}
+
+      {/* slash command notice */}
+      {slashNotice && (
+        <pre className="mb-1.5 whitespace-pre-wrap rounded bg-zinc-900 px-3 py-2 text-xs text-zinc-400">
+          {slashNotice}
+          <button onClick={() => setSlashNotice(null)} className="ml-2 text-zinc-600 hover:text-zinc-400">✕</button>
+        </pre>
+      )}
 
       <div
         className={`flex items-end gap-2 rounded-xl border border-zinc-800 bg-zinc-900 px-3 py-2 ${
           frozen ? "opacity-60" : ""
         }`}
+        onDragOver={(e) => { e.preventDefault(); }}
+        onDrop={(e) => { e.preventDefault(); if (e.dataTransfer.files) void addFiles(e.dataTransfer.files); }}
       >
+        {/* paperclip attach button */}
+        <button
+          type="button"
+          onClick={() => fileInputRef.current?.click()}
+          disabled={frozen}
+          className="shrink-0 self-end text-zinc-500 hover:text-zinc-300 disabled:opacity-40"
+          title="Attach image"
+        >
+          📎
+        </button>
+        <input
+          ref={fileInputRef}
+          type="file"
+          accept="image/*"
+          multiple
+          hidden
+          onChange={(e) => { if (e.target.files) void addFiles(e.target.files); e.target.value = ""; }}
+        />
+
         <textarea
           ref={taRef}
           rows={1}
           value={text}
           disabled={frozen}
           onChange={(e) => { setText(e.target.value); autoGrow(e.target); }}
+          onPaste={onPaste}
           onKeyDown={(e) => {
-            if (e.nativeEvent.isComposing) return; // mid-IME (Korean/JP/CN)
-            // Esc-to-interrupt is handled once at the document level (above), so it works
-            // regardless of focus — don't also handle it here or interrupt fires twice.
+            if (e.nativeEvent.isComposing) return;
             if (e.key === "Enter" && !e.shiftKey) {
               e.preventDefault();
               submit();
@@ -114,7 +306,7 @@ export function Composer() {
               ? "Answer the approval above to continue…"
               : busy
                 ? `Message ${state.cli}… (Esc to stop)`
-                : `Message ${state.cli}… (Enter to send)`
+                : `Message ${state.cli}… (Enter · paste image)`
           }
           className="max-h-40 min-w-0 flex-1 resize-none overflow-y-auto bg-transparent text-sm leading-relaxed outline-none [overflow-wrap:anywhere] disabled:cursor-not-allowed"
         />

--- a/surfaces/webview/src/state/store.tsx
+++ b/surfaces/webview/src/state/store.tsx
@@ -62,6 +62,7 @@ export interface State {
   hasMore: boolean;
   cursor: number;
   toast: string | null;
+  contextTokens?: number;
 }
 
 const initialState: State = {
@@ -181,8 +182,10 @@ function reducer(state: State, ev: Action): State {
       return ev.status === "done"
         ? { ...state, phase: "chat", codexLoginUrl: null, codexLoginCode: null, codexLoginError: null }
         : { ...state, codexLoginUrl: null, codexLoginCode: null, codexLoginError: ev.error ?? "Login failed." };
+    case "usage":
+      return { ...state, contextTokens: ev.contextTokens };
     case "clear":
-      return { ...state, log: [], approvals: [], typing: false, loading: false };
+      return { ...state, log: [], approvals: [], typing: false, loading: false, contextTokens: undefined };
     case "message":
       return { ...state, log: appendMessage(state.log, ev.msg) };
     case "turnEnd":

--- a/surfaces/webview/src/transport/protocol.ts
+++ b/surfaces/webview/src/transport/protocol.ts
@@ -64,11 +64,18 @@ export interface ApprovalRequest {
   questions?: ApprovalQuestion[]; // kind === "question"
   plan?: string;                  // kind === "plan"
   input?: Record<string, unknown>;
+  risk?: "danger";                // flagged destructive/irreversible action — surface should alarm
 }
 
 export type ApprovalOutcome = "once" | "always" | "deny";
 
 // ── UI → server (POST /rpc) ──
+
+export interface ImageInput {
+  mime: string;
+  dataBase64: string;
+  name?: string;
+}
 
 export type ClientMessage =
   | { type: "ready" }
@@ -77,7 +84,9 @@ export type ClientMessage =
   | { type: "open"; sessionId: string }
   | { type: "platform"; cli: Cli }
   | { type: "model"; model?: string }
-  | { type: "send"; text: string }
+  | { type: "mode"; mode?: string }
+  | { type: "effort"; effort?: string }
+  | { type: "send"; text: string; images?: ImageInput[] }
   | { type: "interrupt" }
   | { type: "loadMore"; cursor: number }
   | { type: "delete"; sessionId: string }
@@ -90,7 +99,7 @@ export type ClientMessage =
   // passive skill-shopping toggle (issue #21)
   | { type: "getSkillShopping" }
   | { type: "setSkillShopping"; on: boolean }
-  | { type: "approvalDecision"; id: string; outcome: ApprovalOutcome; reason?: string; questionResponses?: ApprovalQuestionResponse[] }
+  | { type: "approvalDecision"; id: string; outcome: ApprovalOutcome; reason?: string; updatedInput?: Record<string, unknown>; questionResponses?: ApprovalQuestionResponse[] }
   // onboarding-only:
   | { type: "connectWallet"; address: string; signature: number[] }
   | { type: "startClaudeLogin" }
@@ -109,6 +118,7 @@ export type ClientMessage =
 
 export type ServerMessage =
   | { type: "clear" }
+  | { type: "usage"; contextTokens: number }
   | { type: "message"; msg: ChatMessage }
   | { type: "turnEnd" }
   | { type: "page"; hasMore: boolean; cursor: number }


### PR DESCRIPTION
## What

Closes #38. Closes the capability gaps identified in the issue matrix across all three surfaces — CLI, VSCode webview, and localhost/Android React app.

## Changes

### Core — `packages/core/src/chat/session.ts`
- **Effort wire-through fix** (real dispatcher bug): `effort` was missing from the `Slot` type and the `startSession()` call even though the engine spawn layer (Claude + Codex) already supported it. Added `effort` to `Slot`, passed it into `startSession()`, and added a `case "effort":` handler with the same lazy-restage pattern as `model`/`mode` (never kills a live turn).
- **Token usage emission**: `wire()` now registers `h.onUsage()` and forwards `{ type: "usage", contextTokens }` to the active surface, gated to the active engine tab like `onMessage`/`onSkill`.

### CLI — `surfaces/cli/src/`
- **`clipboardImage.ts`** (new): `readImageFromClipboard()` using platform tools — `pngpaste`/`osascript` on macOS, `xclip` on Linux, PowerShell on Windows. `readImageFile(path)` encodes a file by extension. Best-effort, no dependency.
- **`Composer.tsx`**: Ctrl+V grabs a clipboard image and shows a `<image.png>` chip; submitting a bare image file path encodes it as an attachment; Backspace on empty input removes the last chip. `onSubmit` signature extended to `(text, images?)`.
- **`useChat.ts` + `Chat.tsx`**: `send(text, images?)` threaded through to `h.send(text, images)`.

### VSCode webview — `packages/core/src/chat/ui/webview.ts`
- **Effort chip**: new `#effortWrap`/`#effortBtn`/`#effortMenu` chip+popover mirroring the existing mode/model chips. `effortByCli` persists choice per engine across tab switches. Posts `{ type: 'effort' }`.
- **Slash commands & Autocomplete dropdown**:
  - `/new` `/clear` `/copy` `/engine` `/model` `/mode` `/effort` `/help` parsed in `send()` before forwarding to the agent. Unknown slash → inline notice.
  - **Auto-recommendation menu**: Added a CLI-parity floating dropdown menu (`#slashMenu`) that shows matching commands when typing `/` at the start of the input.
  - **Sub-command options**: Displays available values for `/model `, `/mode `, `/effort `, and `/engine ` (e.g. lists of models dynamically filtered according to the current active engine).
  - **UX & Bindings**: Fully supports `ArrowUp`/`ArrowDown` navigation, `Tab`/`Enter` completion, `Escape` dismissal, and closes automatically when clicking outside.
- **Token meter**: `case 'usage':` in the message handler updates `#ctxMeter` chip (`ctx: Nk`). Cleared on session clear.
- **Approval UX**:
  - `risk === 'danger'` → red `⚠ DANGER` header accent
  - Bash cards: `[edit]` toggle swaps the command `<pre>` for an editable textarea; "Approve edited" posts `updatedInput: { command: edited }`
  - Deny-with-reason: clicking Deny reveals a one-line input; confirm posts `{ outcome: 'deny', reason }`

### localhost/Android React app — `surfaces/webview/src/`
- **`protocol.ts`**: `ImageInput` type; `images?` on `send`; `{ type: "mode" }` and `{ type: "effort" }` in `ClientMessage`; `updatedInput?` on `approvalDecision`; `{ type: "usage" }` in `ServerMessage`; `risk?` on `ApprovalRequest`.
- **`Composer.tsx`**:
  - File picker + drag-drop + paste image attach with thumbnail strip; effort `<select>`; mode `<select>` with `modeByCli` per-engine memory; `/copy` and `/mode` slash commands.
  - **React-based autocomplete dropdown**: Implemented the exact same floating dropdown autocomplete for commands and command-specific sub-arguments. Styled with premium Tailwind dark zinc classes, keyboard listener intercepts, and outside click hooks.
- **`store.tsx`**: `contextTokens?: number` in `State`; `case "usage":` reducer; reset on clear.
- **`ApprovalDock.tsx`**: danger flag (red border + ⚠ badge); bash edit mode (textarea + "Approve edited" → `updatedInput`); deny-with-reason input row. `QuestionCard` untouched.

## Not included (per issue scope)
- Codex MCP servers — blocked on upstream SDK
- Codex approval-bridge audit — investigation task, separate issue
- Export full transcript, custom slash commands, user-extensible MCP UI — nice-to-haves, no surface has them yet
