### PR TITLE
feat(ui): marketplace, agent directory, RPC onboarding, mode sync (#46)

### DIFF
--- a/packages/core/src/chat/session.ts
+++ b/packages/core/src/chat/session.ts
@@ -290,7 +290,11 @@ export function createChatSession(
         // takes effect from the next message.
         if (typeof m.mode === "string") {
           slot().mode = m.mode;
-          if (slot().handle) slot().restage = true;
+          const h = slot().handle;
+          if (h) {
+            h.updateMode?.(m.mode);
+            slot().restage = true;
+          }
         }
         break;
       case "effort": {

--- a/packages/core/src/core/rpc.ts
+++ b/packages/core/src/core/rpc.ts
@@ -90,3 +90,36 @@ export async function maskedHeliusKey(): Promise<string | null> {
   const tail = key.slice(-4);
   return key.length <= 4 ? tail : "••••" + tail;
 }
+
+// ── GitHub Personal Access Token ──────────────────────────────────────────────
+// Stored same way as Helius key: secret, per-device, 0o600, never synced.
+// Used so the agent can `git push` (§0b round-trips) and for cross-device
+// GitHub-based session sync (§2 continuity).
+
+const GITHUB_PROVIDER = "github";
+
+interface StoredGithubToken {
+  token: string;
+}
+
+export async function saveGithubToken(token: string): Promise<void> {
+  await ensureDir(tokensDir());
+  const data: StoredGithubToken = { token: token.trim() };
+  await writeFile(tokenFile(GITHUB_PROVIDER), JSON.stringify(data), { mode: 0o600 });
+}
+
+export async function loadGithubToken(): Promise<StoredGithubToken | null> {
+  try {
+    const t = JSON.parse(await readFile(tokenFile(GITHUB_PROVIDER), "utf8")) as StoredGithubToken;
+    return t.token ? t : null;
+  } catch {
+    return null;
+  }
+}
+
+export async function maskedGithubToken(): Promise<string | null> {
+  const t = await loadGithubToken();
+  if (!t) return null;
+  const tail = t.token.slice(-4);
+  return "••••" + tail;
+}

--- a/packages/core/src/index.ts
+++ b/packages/core/src/index.ts
@@ -47,11 +47,11 @@ export { resolveMinter, tryMinterPubkey, resetMinterCache } from "./nft/minter.j
 export { postNote, readNotes, deleteNote, postAgentNote, readAgentNotes, getBalance, getSolBalance, canAffordSkill, TX_FEE_BUFFER_LAMPORTS } from "./notes/index.js";
 export type { PostNoteInput, ReadNotesOptions, PostAgentNoteInput } from "./notes/index.js";
 // RPC resolution (issue #23): a registered Helius key wins over env over the default
-export { resolveRpcUrl, saveHeliusKey, loadHeliusKey, hasDasRpc, heliusUrl, maskedHeliusKey } from "./core/rpc.js";
+export { resolveRpcUrl, saveHeliusKey, loadHeliusKey, hasDasRpc, heliusUrl, maskedHeliusKey, saveGithubToken, loadGithubToken, maskedGithubToken } from "./core/rpc.js";
 export { getNetwork, NETWORK } from "./core/seed.js";
 export type { Network } from "./core/seed.js";
 // the marketplace UI<->host message contract (shared by every surface's UI)
-export type { SkillCard, SkillDetail, MarketRequest, MarketEvent, MarketMessage, RpcStatus } from "./chat/marketMessages.js";
+export type { SkillCard, SkillDetail, MarketRequest, MarketEvent, MarketMessage, RpcStatus, AgentProfile } from "./chat/marketMessages.js";
 // active-skill injection (install a bought skill's SKILL.md into a runtime's skills dir)
 export { SkillSync } from "./skill-market/ingest/index.js";
 export { toSkillMd, skillSlug } from "./skill-market/ingest/convert.js";

--- a/packages/core/src/runtime/contract.ts
+++ b/packages/core/src/runtime/contract.ts
@@ -101,6 +101,7 @@ export interface SessionHandle {
   // stop(), which tears the whole handle down.
   interrupt(): void;
   stop(): void;
+  updateMode?(mode: string): void;
 }
 
 // ── the engine the UI calls ─────────────────────────────

--- a/packages/core/src/runtime/index.ts
+++ b/packages/core/src/runtime/index.ts
@@ -217,6 +217,9 @@ export function createRuntime(
           stopped = true; // mark so the resulting exit isn't reported as a failure
           cli.stop();
         },
+        updateMode(mode) {
+          cli.updateMode?.(mode);
+        },
       };
     },
 

--- a/packages/core/src/runtime/spawn.ts
+++ b/packages/core/src/runtime/spawn.ts
@@ -80,6 +80,7 @@ export interface Engine {
   send(text: string, images?: ImageInput[]): void;
   interrupt(): void; // stop the current turn, keep the session alive
   stop(): void;
+  updateMode?(mode: string): void;
 }
 
 export interface SpawnOpts {
@@ -234,6 +235,7 @@ function claudeEngine(opts: SpawnOpts): Engine {
   const cb = callbacks();
   const approval = opts.approval ?? autoApprove();
   let sessionId = opts.sessionId ?? "";
+  let currentMode = opts.mode;
 
   // streaming input: an async queue the SDK pulls user turns from. send() pushes;
   // the generator yields them. This keeps ONE query() alive across many turns.
@@ -258,6 +260,7 @@ function claudeEngine(opts: SpawnOpts): Engine {
   // default and killing the per-file-read approval spam.
   const allowed = loadPersistentWhitelist();
   const READONLY = new Set(["Read", "Glob", "Grep", "LS", "NotebookRead", "TodoWrite", "WebFetch", "WebSearch"]);
+  const EDIT_TOOLS = new Set(["Edit", "MultiEdit", "Write"]);
   const actionKey = (req: ApprovalRequest) =>
     req.kind === "bash" ? `bash:${req.command}` : `${req.tool}:${req.file || ""}`;
 
@@ -271,6 +274,10 @@ function claudeEngine(opts: SpawnOpts): Engine {
       return { behavior: "deny" as const, message: "Tool use is disabled for side-channel (/btw) queries." };
     }
     if (READONLY.has(toolName)) return { behavior: "allow" as const, updatedInput: input };
+    if (currentMode === "bypassPermissions") return { behavior: "allow" as const, updatedInput: input };
+    if (currentMode === "acceptEdits" && EDIT_TOOLS.has(toolName)) {
+      return { behavior: "allow" as const, updatedInput: input };
+    }
     const req = toApprovalRequest("claude", sessionId, toolName, input, opts.cwd);
     const key = actionKey(req);
     if (allowed.has(key)) return { behavior: "allow" as const, updatedInput: input };
@@ -382,6 +389,7 @@ function claudeEngine(opts: SpawnOpts): Engine {
     // the next send resumes the same session. (stop() also sets closed=true to end it.)
     interrupt: () => { void q.interrupt?.().catch(() => {}); },
     stop: () => { closed = true; wake?.(); void q.interrupt?.().catch(() => {}); },
+    updateMode: (mode) => { currentMode = mode; },
   };
 }
 
@@ -821,6 +829,7 @@ function codexEngine(opts: SpawnOpts): Engine {
       pendingImgCleanup?.(); pendingImgCleanup = null;
       child.kill();
     },
+    updateMode: (mode) => {},
   };
 }
 

--- a/surfaces/cli/src/components/WelcomePanel.tsx
+++ b/surfaces/cli/src/components/WelcomePanel.tsx
@@ -6,8 +6,8 @@ import { colors, glyph } from "../theme.js";
 // Focusable rows, in order. settings first, then one row per owned skill, then the market
 // entry. A single focus index walks all of them (Ctrl+S enters; [tab]/[↑↓] move). The
 // key on a settings row drives onEdit; skill/market rows are handled by their own index.
-export type PanelField = "wallet" | "cloud" | "engine" | "github" | "helius";
-const SETTINGS: PanelField[] = ["wallet", "cloud", "engine", "github", "helius"];
+export type PanelField = "wallet" | "cloud" | "engine" | "helius";
+const SETTINGS: PanelField[] = ["wallet", "cloud", "engine", "helius"];
 
 // Where to get a (free) Helius key — shown when the user opens the key editor.
 const HELIUS_QUICKSTART = "https://www.helius.dev/docs/quickstart";
@@ -75,26 +75,16 @@ export function WelcomePanel({
 }: {
   name?: string;
   walletAddr: string;
-  // { kind, account? } from getStorageInfo(); null = local only (no cloud mirror).
   cloud: { kind: string; account?: string } | null;
   engine: "claude" | "codex";
-  // maskedHeliusKey() → "••••AB12", or null when no key is set.
   heliusMasked: string | null;
-  // the wallet's owned skills (hydrated id+name). null = still loading; [] = none owned.
   skills: OwnedSkill[] | null;
-  // bundled/built-in skill slugs present on disk (skill-shopping, make-skill). Rendered as
-  // a small plain list — these aren't bought NFTs, so no color/effects and not focusable.
   passive?: string[];
-  // hasDasRpc(): false on the public default RPC, which can't read owned skills.
-  // Lets the empty state say "set a Helius key" instead of a misleading "none yet".
   dasReady: boolean;
-  // when true, the panel has focus and owns tab/arrow/enter (entered via Ctrl+S in Chat).
   active: boolean;
   onEdit: (field: PanelField) => void;
-  // commit a new Helius key (raw — SDK normalizes URL/bare). "" clears it (use default RPC).
   onSetHelius: (key: string) => void;
   onOpenMarket: () => void;
-  // Esc leaves the panel and returns focus to the composer.
   onExit: () => void;
 }) {
   const [focus, setFocus] = React.useState(0);
@@ -111,11 +101,10 @@ export function WelcomePanel({
   function activate(i: number) {
     if (i < SETTINGS.length) {
       const field = SETTINGS[i];
-      if (field === "helius") return setKeyInput(""); // open the key line editor (blank)
+      if (field === "helius") return setKeyInput("");
       return onEdit(field);
     }
     if (i === marketIdx) return onOpenMarket();
-    // a skill row — nothing to do yet (detail/market view comes later).
   }
 
   useInput(
@@ -173,7 +162,6 @@ export function WelcomePanel({
         <SettingRow label="wallet" value={shortAddr} connected={!!walletAddr} focused={active && focus === 0} />
         <SettingRow label="cloud" value={cloudValue} connected={cloudConnected} focused={active && focus === 1} />
         <SettingRow label="engine" value={engine} connected focused={active && focus === 2} />
-        <SettingRow label="github" value="not linked" connected={false} focused={active && focus === 3} />
         {keyInput !== null ? (
           <Box>
             <Text color={colors.iqCyan}>{"▸ "}</Text>
@@ -186,7 +174,7 @@ export function WelcomePanel({
             label="helius"
             value={heliusMasked ?? "default rpc"}
             connected={!!heliusMasked}
-            focused={active && focus === 4}
+            focused={active && focus === 3}
           />
         )}
         {keyInput !== null ? (

--- a/surfaces/cli/src/hooks/useChat.ts
+++ b/surfaces/cli/src/hooks/useChat.ts
@@ -34,6 +34,14 @@ export function useChat(
   const [hasMore, setHasMore] = useState(false);
   const [cursor, setCursor] = useState<number | null>(null);
   const [epoch, setEpoch] = useState(0);
+  const [firingSkill, setFiringSkill] = useState<string | null>(null);
+
+  useEffect(() => {
+    if (firingSkill) {
+      const t = setTimeout(() => setFiringSkill(null), 1400);
+      return () => clearTimeout(t);
+    }
+  }, [firingSkill]);
 
   const handle = useRef<SessionHandle | null>(null);
   // keep latest cli/model in refs so ensureHandle (created once) reads current values.
@@ -100,6 +108,7 @@ export function useChat(
         }),
       );
       h.onUsage((n) => setContextTokens(n));
+      h.onSkill((name) => setFiringSkill(name));
       h.onTurnEnd(() => {
         // a fresh session reveals its canonical id now — adopt it so resume/switch work.
         const id = pendingRef.current || h.sessionId;
@@ -273,5 +282,6 @@ export function useChat(
     newSession,
     deleteSession,
     refreshSessions,
+    firingSkill,
   };
 }

--- a/surfaces/cli/src/views/Chat.tsx
+++ b/surfaces/cli/src/views/Chat.tsx
@@ -1,6 +1,6 @@
 import React, { useEffect, useMemo, useRef, useState, useCallback } from "react";
 import { Box, Text, Static, useApp, useInput } from "ink";
-import type { AgentRuntime, Wallet } from "@iqlabs-official/agent-sdk/runtime/contract";
+import type { AgentRuntime, Wallet, ChatMessage } from "@iqlabs-official/agent-sdk/runtime/contract";
 import type { CliReport } from "@iqlabs-official/agent-sdk";
 import type { ApprovalRequest } from "@iqlabs-official/agent-sdk/runtime/approval/channel";
 import type { AppOptions } from "../app.js";
@@ -73,6 +73,7 @@ export function Chat({
     approval: approval ?? undefined,
   });
   const [notice, setNotice] = useState("");
+  const [localLog, setLocalLog] = useState<ChatMessage[]>([]);
   // Welcome-panel data, fetched once on mount: cloud/storage (local-only → null), the
   // masked Helius key ("••••AB12" or null = default RPC), and the wallet's owned skills.
   const [cloud, setCloud] = useState<{ kind: string; account?: string } | null>(null);
@@ -391,9 +392,6 @@ export function Chat({
       setPanelFocused(false);
       return;
     }
-    // github
-    setNotice("github linking... coming soon");
-    setPanelFocused(false);
   }
 
   // commit a Helius key from the panel's key editor. "" clears it (back to default RPC).
@@ -461,6 +459,7 @@ export function Chat({
         }
         chat.changeModel(arg);
         setNotice(`model → ${arg}`);
+        setLocalLog((l) => [...l, { role: "summary", text: `─── model: ${arg} ───`, ts: Date.now() }]);
         return;
       case "models":
         setShowModels(true);
@@ -664,6 +663,7 @@ export function Chat({
         onPick={(v) => {
           chat.changeModel(v);
           setNotice(`model → ${v ?? "default"}`);
+          setLocalLog((l) => [...l, { role: "summary", text: `─── model: ${v ?? "default"} ───`, ts: Date.now() }]);
           setShowModels(false);
         }}
         onClose={() => setShowModels(false)}
@@ -761,7 +761,9 @@ export function Chat({
   // Static on wholesale changes (resume / new / scroll-back prepend).
   const lastMsg = chat.messages[chat.messages.length - 1];
   const streaming = chat.busy && lastMsg?.role === "assistant";
-  const committed = streaming ? chat.messages.slice(0, -1) : chat.messages;
+  const baseCommitted = streaming ? chat.messages.slice(0, -1) : chat.messages;
+  // Append local system messages (model-switch separators etc.) after committed chat history.
+  const committed = localLog.length ? [...baseCommitted, ...localLog] : baseCommitted;
   const liveMsg = streaming ? lastMsg : null;
 
   // the welcome control panel shows on an empty, idle session. Focus stays on the composer
@@ -802,6 +804,12 @@ export function Chat({
       {liveMsg ? <Message msg={liveMsg} live /> : null}
 
       {chat.busy && !pendingApproval ? <ThinkingLine /> : null}
+
+      {chat.firingSkill ? (
+        <Box paddingLeft={2} marginTop={1}>
+          <Text color={colors.ok}>{`⚡ Casting <${chat.firingSkill}>`}</Text>
+        </Box>
+      ) : null}
 
       {pendingApproval ? (
         <ApprovalCard

--- a/surfaces/cli/src/views/SkillMarket.tsx
+++ b/surfaces/cli/src/views/SkillMarket.tsx
@@ -1,31 +1,39 @@
 import React, { useEffect, useState } from "react";
 import { Box, Text, useInput } from "ink";
 import type { SkillCard, SkillDetail } from "@iqlabs-official/agent-sdk";
+import type { Reputation, AgentProfile } from "@iqlabs-official/agent-sdk";
 import { colors, glyph } from "../theme.js";
 
-// The market actions, injected by Chat (which owns the marketplaceEnv built from the
-// wallet). Same functions the VSCode market uses — we just drive them from a TUI.
 export interface MarketApi {
   searchSkills(query: string, kind?: "skill" | "workflow"): Promise<SkillCard[]>;
   getSkillDetail(mint: string): Promise<SkillDetail>;
   buySkill(skillId: string, creatorWallet?: string): Promise<{ ok: boolean; slug?: string; error?: string }>;
   solBalance(): Promise<number | null>;
+  postNote(skillId: string, skillType: "skill" | "workflow" | undefined, text: string, gitLink?: string): Promise<{ ok: boolean; error?: string }>;
+  publishSkill(input: { name: string; description: string; text: string; category?: string; hashtags?: string[]; priceSol: string }): Promise<{ ok: boolean; mint?: string; error?: string }>;
+  listAgents(): Promise<Reputation[]>;
+  getAgentProfile(wallet: string): Promise<AgentProfile>;
+  buyAllSkills(agentWallet: string): Promise<{ ok: boolean; bought: number; failed: number; error?: string }>;
 }
 
-// "page"-like states so it reads as navigating into a screen and back (zo's ask):
-//  list   → search box + result cards
-//  detail → one skill's body + required skills + buy
-//  confirm→ cost check before spending SOL (buy is irreversible)
-type Stage = "list" | "detail" | "confirm";
+type Stage =
+  | "list"
+  | "detail"
+  | "confirm"
+  | "comment"
+  | "publish"
+  | "agents"
+  | "agentProfile";
+
+// Publish form fields in order — tab/arrow cycles through them.
+type PublishField = "name" | "desc" | "text" | "category" | "hashtags" | "price";
+const PUBLISH_FIELDS: PublishField[] = ["name", "desc", "text", "category", "hashtags", "price"];
 
 const SOL = 1_000_000_000;
 function sol(lamports: number | null): string {
   return lamports == null ? "—" : `${(lamports / SOL).toFixed(3)} SOL`;
 }
 
-// A self-contained skill market: search, list, detail, buy. ↑/↓ move, ↵ open/confirm,
-// b buy, tab switch skills/workflows, / focus search, esc back-a-level (or close at list).
-// Mirrors the VSCode market over the same marketplaceEnv functions.
 export function SkillMarket({
   api,
   walletAddr,
@@ -35,8 +43,6 @@ export function SkillMarket({
 }: {
   api: MarketApi;
   walletAddr: string;
-  // installed skill slugs (so a card can show an "owned" badge). May be stale by a buy;
-  // onBought lets Chat refresh it after a successful purchase.
   ownedNames: string[];
   onBought: () => void;
   onClose: () => void;
@@ -44,21 +50,41 @@ export function SkillMarket({
   const [stage, setStage] = useState<Stage>("list");
   const [kind, setKind] = useState<"skill" | "workflow">("skill");
   const [query, setQuery] = useState("");
-  const [typing, setTyping] = useState(true); // search box has the cursor (list stage)
+  const [typing, setTyping] = useState(true);
   const [results, setResults] = useState<SkillCard[]>([]);
   const [loading, setLoading] = useState(false);
   const [error, setError] = useState<string | null>(null);
   const [idx, setIdx] = useState(0);
   const [detail, setDetail] = useState<SkillDetail | null>(null);
   const [balance, setBalance] = useState<number | null>(null);
-  const [busy, setBusy] = useState(false); // a buy is in flight
-  const [flash, setFlash] = useState<string | null>(null); // last buy outcome
+  const [busy, setBusy] = useState(false);
+  const [flash, setFlash] = useState<string | null>(null);
+
+  // comment stage
+  const [commentText, setCommentText] = useState("");
+  const [commentGitLink, setCommentGitLink] = useState("");
+  const [commentField, setCommentField] = useState<"text" | "gitLink">("text");
+
+  // publish stage
+  const [pubField, setPubField] = useState<PublishField>("name");
+  const [pubName, setPubName] = useState("");
+  const [pubDesc, setPubDesc] = useState("");
+  const [pubText, setPubText] = useState("");
+  const [pubCategory, setPubCategory] = useState("");
+  const [pubHashtags, setPubHashtags] = useState("");
+  const [pubPrice, setPubPrice] = useState("0.1");
+  const [pubResult, setPubResult] = useState<string | null>(null);
+
+  // agents stage
+  const [agents, setAgents] = useState<Reputation[]>([]);
+  const [agentIdx, setAgentIdx] = useState(0);
+  const [agentProfile, setAgentProfile] = useState<AgentProfile | null>(null);
+  const [agentBuyResult, setAgentBuyResult] = useState<string | null>(null);
 
   const owned = new Set(ownedNames);
   const clamped = Math.min(idx, Math.max(0, results.length - 1));
   const selected = results[clamped];
 
-  // run a search (debounced by Enter / tab, not per-keystroke — keeps it cheap).
   async function search(q: string, k: "skill" | "workflow") {
     setLoading(true);
     setError(null);
@@ -73,7 +99,6 @@ export function SkillMarket({
     }
   }
 
-  // initial load + balance.
   useEffect(() => {
     void search("", kind);
     void api.solBalance().then(setBalance).catch(() => setBalance(null));
@@ -109,9 +134,155 @@ export function SkillMarket({
     }
   }
 
-  useInput((input, key) => {
-    if (busy) return; // ignore input while a buy is settling
+  async function doComment() {
+    if (!detail || !commentText.trim()) return;
+    setBusy(true);
+    const res = await api.postNote(
+      detail.card.id,
+      detail.card.type,
+      commentText.trim(),
+      commentGitLink.trim() || undefined,
+    );
+    setBusy(false);
+    if (res.ok) {
+      setFlash("comment posted");
+      setCommentText("");
+      setCommentGitLink("");
+      setStage("detail");
+    } else {
+      setFlash(`comment failed: ${res.error ?? "unknown"}`);
+    }
+  }
 
+  async function doPublish() {
+    if (!pubName.trim() || !pubDesc.trim() || !pubText.trim()) return;
+    setBusy(true);
+    const res = await api.publishSkill({
+      name: pubName.trim(),
+      description: pubDesc.trim(),
+      text: pubText.trim(),
+      category: pubCategory.trim() || undefined,
+      hashtags: pubHashtags.trim() ? pubHashtags.split(",").map((h) => h.trim()).filter(Boolean) : undefined,
+      priceSol: pubPrice.trim() || "0.1",
+    });
+    setBusy(false);
+    if (res.ok) {
+      setPubResult(`published! mint: ${res.mint ?? "?"}`);
+    } else {
+      setPubResult(`failed: ${res.error ?? "unknown"}`);
+    }
+  }
+
+  async function loadAgents() {
+    setLoading(true);
+    try {
+      setAgents(await api.listAgents());
+      setAgentIdx(0);
+    } catch (e) {
+      setError(e instanceof Error ? e.message : String(e));
+    } finally {
+      setLoading(false);
+    }
+  }
+
+  async function openAgentProfile(wallet: string) {
+    setLoading(true);
+    try {
+      setAgentProfile(await api.getAgentProfile(wallet));
+      setStage("agentProfile");
+    } catch (e) {
+      setError(e instanceof Error ? e.message : String(e));
+    } finally {
+      setLoading(false);
+    }
+  }
+
+  async function doBuyAll(wallet: string) {
+    setBusy(true);
+    setAgentBuyResult(null);
+    const res = await api.buyAllSkills(wallet);
+    setBusy(false);
+    if (res.ok) {
+      setAgentBuyResult(`bought ${res.bought} skill${res.bought !== 1 ? "s" : ""}${res.failed ? `, ${res.failed} failed` : ""}`);
+      onBought();
+    } else {
+      setAgentBuyResult(`failed: ${res.error ?? "unknown"}`);
+    }
+  }
+
+  // get/set helpers for publish form fields
+  function pubGet(f: PublishField) {
+    return { name: pubName, desc: pubDesc, text: pubText, category: pubCategory, hashtags: pubHashtags, price: pubPrice }[f];
+  }
+  function pubSet(f: PublishField, v: string) {
+    ({ name: setPubName, desc: setPubDesc, text: setPubText, category: setPubCategory, hashtags: setPubHashtags, price: setPubPrice }[f])(v);
+  }
+
+  useInput((input, key) => {
+    if (busy) return;
+
+    // ── agent profile ──────────────────────────────────────────────────────
+    if (stage === "agentProfile") {
+      if (key.escape) { setStage("agents"); setAgentProfile(null); setAgentBuyResult(null); }
+      if (input === "b" && agentProfile) void doBuyAll(agentProfile.reputation.wallet);
+      return;
+    }
+
+    // ── agents list ────────────────────────────────────────────────────────
+    if (stage === "agents") {
+      if (key.escape) { setStage("list"); setAgents([]); setError(null); return; }
+      if (key.upArrow) return setAgentIdx((i) => Math.max(0, i - 1));
+      if (key.downArrow) return setAgentIdx((i) => Math.min(agents.length - 1, i + 1));
+      if (key.return && agents[agentIdx]) void openAgentProfile(agents[agentIdx].wallet);
+      return;
+    }
+
+    // ── publish ────────────────────────────────────────────────────────────
+    if (stage === "publish") {
+      if (pubResult) {
+        if (key.escape || key.return) { setPubResult(null); setStage("list"); }
+        return;
+      }
+      if (key.escape) { setStage("list"); return; }
+      const fi = PUBLISH_FIELDS.indexOf(pubField);
+      if (key.tab || key.downArrow) {
+        setPubField(PUBLISH_FIELDS[(fi + 1) % PUBLISH_FIELDS.length]);
+        return;
+      }
+      if (key.upArrow) {
+        setPubField(PUBLISH_FIELDS[(fi + PUBLISH_FIELDS.length - 1) % PUBLISH_FIELDS.length]);
+        return;
+      }
+      if (key.return) {
+        if (fi < PUBLISH_FIELDS.length - 1) {
+          setPubField(PUBLISH_FIELDS[fi + 1]);
+        } else {
+          void doPublish();
+        }
+        return;
+      }
+      if (key.backspace || key.delete) { pubSet(pubField, pubGet(pubField).slice(0, -1)); return; }
+      if (input && !key.ctrl && !key.meta) { pubSet(pubField, pubGet(pubField) + input); return; }
+      return;
+    }
+
+    // ── comment ────────────────────────────────────────────────────────────
+    if (stage === "comment") {
+      if (key.escape) { setStage("detail"); return; }
+      if (key.tab || key.downArrow) {
+        setCommentField((f) => f === "text" ? "gitLink" : "text");
+        return;
+      }
+      if (key.return && commentField === "gitLink") { void doComment(); return; }
+      if (key.return) { setCommentField("gitLink"); return; }
+      const setter = commentField === "text" ? setCommentText : setCommentGitLink;
+      const cur = commentField === "text" ? commentText : commentGitLink;
+      if (key.backspace || key.delete) { setter(cur.slice(0, -1)); return; }
+      if (input && !key.ctrl && !key.meta) { setter(cur + input); return; }
+      return;
+    }
+
+    // ── confirm ────────────────────────────────────────────────────────────
     if (stage === "confirm") {
       const card = detail?.card ?? selected;
       if (key.escape || input === "n") return setStage(detail ? "detail" : "list");
@@ -121,57 +292,189 @@ export function SkillMarket({
       return;
     }
 
+    // ── detail ─────────────────────────────────────────────────────────────
     if (stage === "detail") {
-      if (key.escape) {
-        setStage("list");
-        setDetail(null);
+      if (key.escape) { setStage("list"); setDetail(null); return; }
+      if (input === "b" && detail && !owned.has(detail.card.name)) { setStage("confirm"); return; }
+      if (input === "c" && detail) {
+        setCommentText(""); setCommentGitLink(""); setCommentField("text");
+        setStage("comment");
         return;
       }
-      if (input === "b" && detail && !owned.has(detail.card.name)) setStage("confirm");
       return;
     }
 
-    // list stage
+    // ── list ───────────────────────────────────────────────────────────────
     if (key.escape) return onClose();
-    // the search box owns text while typing; tab/↑/↓/↵ still navigate.
     if (typing) {
-      if (key.return) {
-        setTyping(false);
-        void search(query, kind);
-        return;
-      }
+      if (key.return) { setTyping(false); void search(query, kind); return; }
       if (key.tab) {
         const next = kind === "skill" ? "workflow" : "skill";
-        setKind(next);
-        void search(query, next);
-        return;
+        setKind(next); void search(query, next); return;
       }
       if (key.backspace || key.delete) return setQuery((q) => q.slice(0, -1));
       if (key.downArrow) return setTyping(false);
       if (input && !key.ctrl && !key.meta) return setQuery((q) => q + input);
       return;
     }
-    // results navigation
     if (input === "/") return setTyping(true);
+    if (input === "a") { setStage("agents"); void loadAgents(); return; }
+    if (input === "p") { setPubResult(null); setPubField("name"); setStage("publish"); return; }
     if (key.tab) {
       const next = kind === "skill" ? "workflow" : "skill";
-      setKind(next);
-      void search(query, next);
-      return;
+      setKind(next); void search(query, next); return;
     }
-    if (key.upArrow) {
-      if (clamped === 0) return setTyping(true);
-      return setIdx((i) => Math.max(0, i - 1));
-    }
+    if (key.upArrow) { if (clamped === 0) return setTyping(true); return setIdx((i) => Math.max(0, i - 1)); }
     if (key.downArrow) return setIdx((i) => Math.min(results.length - 1, i + 1));
     if (key.return && selected) return void openDetail(selected.id);
-    if (input === "b" && selected && !owned.has(selected.name)) {
-      setDetail(null);
-      setStage("confirm");
-    }
+    if (input === "b" && selected && !owned.has(selected.name)) { setDetail(null); setStage("confirm"); }
   });
 
-  // ── confirm (cost check before spending SOL) ──────────────────────────────
+  // ── agent profile ─────────────────────────────────────────────────────────
+  if (stage === "agentProfile" && agentProfile) {
+    const r = agentProfile.reputation;
+    const short = (w: string) => `${w.slice(0, 4)}…${w.slice(-4)}`;
+    return (
+      <Box flexDirection="column" paddingX={1} borderStyle="round" borderColor={colors.iqViolet}>
+        <Box>
+          <Text bold color={colors.iqCyan}>{short(r.wallet)}</Text>
+          <Text dimColor>   {r.skillsPublished} skills · ×{r.totalSupply} total supply · {r.notesReceived} notes</Text>
+        </Box>
+        {agentProfile.createdSkills && agentProfile.createdSkills.length ? (
+          <Box flexDirection="column" marginTop={1}>
+            <Text dimColor>skills:</Text>
+            {agentProfile.createdSkills.slice(0, 8).map((s: any) => (
+              <Box key={s.id}>
+                <Text>  · </Text>
+                <Text color={owned.has(s.name) ? colors.ok : undefined}>{s.name}</Text>
+                {owned.has(s.name) ? <Text color={colors.ok}> owned</Text> : null}
+              </Box>
+            ))}
+          </Box>
+        ) : null}
+        {agentProfile.notes.length ? (
+          <Box flexDirection="column" marginTop={1}>
+            <Text dimColor>notes:</Text>
+            {agentProfile.notes.slice(0, 4).map((n, i) => (
+              <Text key={i} dimColor>  "{n.text.slice(0, 60)}"</Text>
+            ))}
+          </Box>
+        ) : null}
+        {agentBuyResult ? (
+          <Box marginTop={1}><Text color={colors.ok}>{glyph.sparkle} {agentBuyResult}</Text></Box>
+        ) : null}
+        <Box marginTop={1}>
+          <Text dimColor>[b] buy all skills · [esc] back</Text>
+        </Box>
+      </Box>
+    );
+  }
+
+  // ── agents list ────────────────────────────────────────────────────────────
+  if (stage === "agents") {
+    const short = (w: string) => `${w.slice(0, 6)}…${w.slice(-4)}`;
+    return (
+      <Box flexDirection="column" paddingX={1} borderStyle="round" borderColor={colors.iqViolet}>
+        <Text bold color={colors.iqMagenta}>❖ agent directory</Text>
+        <Box flexDirection="column" marginTop={1}>
+          {loading ? (
+            <Text dimColor>loading agents…</Text>
+          ) : error ? (
+            <Text color={colors.err}>{error}</Text>
+          ) : agents.length === 0 ? (
+            <Text dimColor>no agents found</Text>
+          ) : (
+            agents.slice(0, 12).map((a, i) => {
+              const on = i === agentIdx;
+              return (
+                <Box key={a.wallet}>
+                  <Text color={on ? colors.iqCyan : undefined}>{on ? "› " : "  "}</Text>
+                  <Box width={14}><Text dimColor>{short(a.wallet)}</Text></Box>
+                  <Text dimColor>  ×{a.totalSupply} supply · {a.skillsPublished} skills</Text>
+                </Box>
+              );
+            })
+          )}
+        </Box>
+        <Box marginTop={1}><Text dimColor>↑/↓ move · ↵ profile · esc back</Text></Box>
+      </Box>
+    );
+  }
+
+  // ── publish form ──────────────────────────────────────────────────────────
+  if (stage === "publish") {
+    if (pubResult) {
+      return (
+        <Box flexDirection="column" paddingX={1} borderStyle="round" borderColor={pubResult.startsWith("published") ? colors.ok : colors.err}>
+          <Text bold color={pubResult.startsWith("published") ? colors.ok : colors.err}>{pubResult}</Text>
+          <Box marginTop={1}><Text dimColor>[esc] / [↵] close</Text></Box>
+        </Box>
+      );
+    }
+    const fieldLabels: Record<PublishField, string> = {
+      name: "name      ", desc: "desc      ", text: "skill text",
+      category: "category  ", hashtags: "hashtags  ", price: "price (SOL)",
+    };
+    const fieldValues: Record<PublishField, string> = {
+      name: pubName, desc: pubDesc, text: pubText.slice(0, 60) + (pubText.length > 60 ? "…" : ""),
+      category: pubCategory, hashtags: pubHashtags, price: pubPrice,
+    };
+    return (
+      <Box flexDirection="column" paddingX={1} borderStyle="round" borderColor={colors.iqViolet}>
+        <Text bold color={colors.iqMagenta}>❖ publish skill</Text>
+        <Box flexDirection="column" marginTop={1}>
+          {PUBLISH_FIELDS.map((f) => {
+            const on = f === pubField;
+            return (
+              <Box key={f}>
+                <Text color={on ? colors.iqCyan : colors.dim}>{on ? "▸ " : "  "}</Text>
+                <Box width={12}><Text color={on ? colors.iqCyan : colors.dim} bold={on}>{fieldLabels[f]}</Text></Box>
+                <Text color={on ? undefined : colors.dim}>{fieldValues[f]}</Text>
+                {on ? <Text inverse> </Text> : null}
+              </Box>
+            );
+          })}
+        </Box>
+        {busy ? (
+          <Box marginTop={1}>
+            <Text dimColor>publishing…</Text>
+          </Box>
+        ) : null}
+        <Box marginTop={1}>
+          <Text dimColor>↑/↓/[tab] field · ↵ next / submit on price · esc cancel</Text>
+        </Box>
+        <Box><Text dimColor>hashtags = comma-separated · skill text = raw SKILL.md body</Text></Box>
+      </Box>
+    );
+  }
+
+  // ── comment ────────────────────────────────────────────────────────────────
+  if (stage === "comment") {
+    return (
+      <Box flexDirection="column" paddingX={1} borderStyle="round" borderColor={colors.iqViolet}>
+        <Text bold color={colors.iqMagenta}>❖ post comment</Text>
+        <Box marginTop={1} flexDirection="column">
+          <Box>
+            <Text color={commentField === "text" ? colors.iqCyan : colors.dim}>{commentField === "text" ? "▸ " : "  "}</Text>
+            <Box width={10}><Text color={commentField === "text" ? colors.iqCyan : colors.dim}>comment</Text></Box>
+            <Text>{commentText}</Text>
+            {commentField === "text" ? <Text inverse> </Text> : null}
+          </Box>
+          <Box>
+            <Text color={commentField === "gitLink" ? colors.iqCyan : colors.dim}>{commentField === "gitLink" ? "▸ " : "  "}</Text>
+            <Box width={10}><Text color={commentField === "gitLink" ? colors.iqCyan : colors.dim}>gitLink</Text></Box>
+            <Text dimColor={!commentGitLink}>{commentGitLink || "(optional)"}</Text>
+            {commentField === "gitLink" ? <Text inverse> </Text> : null}
+          </Box>
+        </Box>
+        {flash ? <Box marginTop={1}><Text color={colors.ok}>{flash}</Text></Box> : null}
+        {busy ? <Text dimColor>posting…</Text> : null}
+        <Box marginTop={1}><Text dimColor>[tab] next field · ↵ post on gitLink field · esc cancel</Text></Box>
+      </Box>
+    );
+  }
+
+  // ── confirm ────────────────────────────────────────────────────────────────
   if (stage === "confirm") {
     const card = detail?.card ?? selected;
     return (
@@ -187,14 +490,14 @@ export function SkillMarket({
           <Text dimColor>this signs an on-chain transaction and can't be undone</Text>
         </Box>
         <Box marginTop={1}>
-          <Text color={colors.warn}>buy “{card?.name}”?  </Text>
+          <Text color={colors.warn}>buy "{card?.name}"?  </Text>
           <Text dimColor>[y] yes · [n] no</Text>
         </Box>
       </Box>
     );
   }
 
-  // ── detail ────────────────────────────────────────────────────────────────
+  // ── detail ─────────────────────────────────────────────────────────────────
   if (stage === "detail" && detail) {
     const c = detail.card;
     const isOwned = owned.has(c.name);
@@ -227,16 +530,28 @@ export function SkillMarket({
             <Text>{detail.skillText.slice(0, 1200)}</Text>
           </Box>
         ) : null}
+        {detail.notes && detail.notes.length ? (
+          <Box flexDirection="column" marginTop={1}>
+            <Text dimColor>── comments ({detail.notes.length}) ──</Text>
+            {detail.notes.slice(0, 4).map((n, i) => (
+              <Box key={i} flexDirection="column">
+                <Text dimColor>  "{n.text.slice(0, 80)}"</Text>
+                {n.gitLink ? <Text dimColor>    {glyph.sparkle} {n.gitLink}</Text> : null}
+              </Box>
+            ))}
+          </Box>
+        ) : null}
+        {flash ? <Box marginTop={1}><Text color={colors.ok}>{glyph.sparkle} {flash}</Text></Box> : null}
         <Box marginTop={1}>
           <Text dimColor>
-            {isOwned ? "owned · " : "[b] buy · "}[esc] back
+            {isOwned ? "owned · " : "[b] buy · "}[c] comment · [esc] back
           </Text>
         </Box>
       </Box>
     );
   }
 
-  // ── list ──────────────────────────────────────────────────────────────────
+  // ── list ───────────────────────────────────────────────────────────────────
   return (
     <Box flexDirection="column" paddingX={1} borderStyle="round" borderColor={colors.iqViolet}>
       <Box>
@@ -248,6 +563,8 @@ export function SkillMarket({
         <Text color={kind === "skill" ? colors.iqCyan : colors.dim} bold={kind === "skill"}>skills</Text>
         <Text dimColor>  ·  </Text>
         <Text color={kind === "workflow" ? colors.iqCyan : colors.dim} bold={kind === "workflow"}>workflows</Text>
+        <Text dimColor>  ·  </Text>
+        <Text color={colors.dim}>[a] agents  [p] publish</Text>
       </Box>
       {/* search box */}
       <Box marginTop={1}>
@@ -291,7 +608,7 @@ export function SkillMarket({
         <Text dimColor>
           {typing
             ? "type to search · ↵ run · [tab] skills/workflows · ↓ results · esc close"
-            : "↑/↓ move · ↵ open · [b] buy · [tab] switch · [/] search · esc close"}
+            : "↑/↓ move · ↵ open · [b] buy · [tab] switch · [/] search · [a] agents · [p] publish · esc close"}
         </Text>
       </Box>
     </Box>

--- a/surfaces/localhost/src/index.ts
+++ b/surfaces/localhost/src/index.ts
@@ -59,6 +59,9 @@ import {
   maskedHeliusKey,
   hasDasRpc,
   getNetwork,
+  saveGithubToken,
+  loadGithubToken,
+  maskedGithubToken,
 } from "@iqlabs-official/agent-sdk";
 
 const PORT = Number(process.env.AGENTNET_PORT ?? 4317);
@@ -411,6 +414,28 @@ function attachChat(id: string, c: Client, rt: AgentRuntime) {
         }
         return;
       }
+    }
+  });
+
+  // ── GitHub token handlers (outside market recv, no wallet required) ──
+  c.recvs.push(async (m: any) => {
+    if (m?.type === "submitGithubToken" && typeof m.token === "string" && m.token.trim()) {
+      await saveGithubToken(m.token.trim());
+      const masked = await maskedGithubToken();
+      const login = await loadGithubToken().then((t) => t?.token ? "configured" : undefined).catch(() => undefined);
+      c.send({ type: "githubStatus", hasToken: true, masked: masked ?? undefined });
+      c.send({ type: "toast", text: "GitHub token saved." });
+      return;
+    }
+    if (m?.type === "clearGithubToken") {
+      await saveGithubToken("");
+      c.send({ type: "githubStatus", hasToken: false });
+      return;
+    }
+    if (m?.type === "getGithubStatus") {
+      const masked = await maskedGithubToken();
+      c.send({ type: "githubStatus", hasToken: !!masked, masked: masked ?? undefined });
+      return;
     }
   });
 

--- a/surfaces/localhost/src/index.ts
+++ b/surfaces/localhost/src/index.ts
@@ -54,6 +54,11 @@ import {
   saveGoogleCreds,
   hasGoogleCreds,
   isCloudConnected,
+  marketplaceEnv,
+  saveHeliusKey,
+  maskedHeliusKey,
+  hasDasRpc,
+  getNetwork,
 } from "@iqlabs-official/agent-sdk";
 
 const PORT = Number(process.env.AGENTNET_PORT ?? 4317);
@@ -277,6 +282,135 @@ function attachChat(id: string, c: Client, rt: AgentRuntime) {
       googleLoginSession?.cancel();
       googleLoginSession = null;
       return;
+    }
+  });
+
+  // ── market handlers ──
+  // Mirror exactly what VSCode's extension.ts passes to createChatSession, but as a
+  // standalone recv subscriber rather than chatSession options — localhost wires market
+  // messages here (HTTP surface can't use native dialogs, so setHeliusKey = submitHeliusKey).
+  const mktPromise = wallet ? marketplaceEnv(wallet) : null;
+  c.recvs.push(async (m: any) => {
+    if (!m?.type) return;
+    const mkt = await mktPromise;
+    if (!mkt) { c.send({ type: "toast", text: "Wallet not connected." }); return; }
+    switch (m.type) {
+      case "searchSkills": {
+        try {
+          const results = await mkt.searchSkills(m.query ?? "", m.kind);
+          c.send({ type: "searchResults", results });
+        } catch (e) {
+          c.send({ type: "searchError", message: (e as Error).message });
+        }
+        return;
+      }
+      case "getSkillDetail": {
+        try {
+          const detail = await mkt.getSkillDetail(m.mint);
+          c.send({ type: "skillDetail", detail });
+        } catch (e) {
+          c.send({ type: "toast", text: "Failed to load skill: " + (e as Error).message });
+        }
+        return;
+      }
+      case "buySkill": {
+        try {
+          const r = await mkt.buySkill(m.skillId, m.creatorWallet);
+          c.send({ type: "buyResult", skillId: m.skillId, ...r });
+        } catch (e) {
+          c.send({ type: "buyResult", skillId: m.skillId, ok: false, error: (e as Error).message });
+        }
+        return;
+      }
+      case "ownedSkills": {
+        try {
+          const r = await mkt.ownedSkills();
+          c.send({ type: "ownedSkills", ...r });
+        } catch (e) {
+          c.send({ type: "toast", text: "Failed to load owned skills: " + (e as Error).message });
+        }
+        return;
+      }
+      case "getBalance": {
+        try {
+          const lamports = await mkt.solBalance();
+          c.send({ type: "balance", lamports });
+        } catch { c.send({ type: "balance", lamports: null }); }
+        return;
+      }
+      case "getRpcStatus": {
+        const masked = await maskedHeliusKey();
+        c.send({ type: "rpcStatus", status: { dasReady: await hasDasRpc(), hasKey: !!masked, masked, network: getNetwork() } });
+        return;
+      }
+      case "submitHeliusKey": {
+        if (typeof m.key === "string" && m.key.trim()) {
+          await saveHeliusKey(m.key.trim());
+          const masked = await maskedHeliusKey();
+          c.send({ type: "rpcStatus", status: { dasReady: await hasDasRpc(), hasKey: !!masked, masked, network: getNetwork() } });
+          c.send({ type: "toast", text: "Helius key saved." });
+        }
+        return;
+      }
+      case "useDefaultRpc": {
+        await saveHeliusKey("");
+        c.send({ type: "rpcStatus", status: { dasReady: false, hasKey: false, masked: null, network: getNetwork() } });
+        return;
+      }
+      case "publishSkill": {
+        try {
+          const r = await mkt.publishSkill({ name: m.name, description: m.description, text: m.text, category: m.category, hashtags: m.hashtags, priceSol: m.priceSol, image: m.image });
+          c.send({ type: "publishResult", ...r });
+        } catch (e) {
+          c.send({ type: "publishResult", ok: false, error: (e as Error).message });
+        }
+        return;
+      }
+      case "postNote": {
+        try {
+          const r = await mkt.postNote(m.skillId, m.skillType, m.text, m.gitLink);
+          c.send({ type: "postNoteResult", skillId: m.skillId, ...r });
+        } catch (e) {
+          c.send({ type: "postNoteResult", skillId: m.skillId, ok: false, error: (e as Error).message });
+        }
+        return;
+      }
+      case "listAgents": {
+        try {
+          const r = await mkt.listAgents();
+          c.send({ type: "agents", agents: r });
+        } catch (e) {
+          c.send({ type: "toast", text: "Failed to list agents: " + (e as Error).message });
+        }
+        return;
+      }
+      case "getAgentProfile": {
+        try {
+          const profile = await mkt.getAgentProfile(m.wallet);
+          c.send({ type: "agentProfile", profile });
+        } catch (e) {
+          c.send({ type: "toast", text: "Failed to load agent: " + (e as Error).message });
+        }
+        return;
+      }
+      case "buyAllSkills": {
+        try {
+          const r = await mkt.buyAllSkills(m.wallet);
+          c.send({ type: "buyAllResult", wallet: m.wallet, ...r });
+        } catch (e) {
+          c.send({ type: "buyAllResult", wallet: m.wallet, ok: false, bought: 0, failed: 0, error: (e as Error).message });
+        }
+        return;
+      }
+      case "postAgentNote": {
+        try {
+          const r = await mkt.postAgentNote(m.agentWallet, m.text, m.gitLink);
+          c.send({ type: "agentNoteResult", agentWallet: m.agentWallet, ...r });
+        } catch (e) {
+          c.send({ type: "agentNoteResult", agentWallet: m.agentWallet, ok: false, error: (e as Error).message });
+        }
+        return;
+      }
     }
   });
 

--- a/surfaces/webview/src/App.tsx
+++ b/surfaces/webview/src/App.tsx
@@ -5,6 +5,7 @@ import { PickEngine } from "./onboarding/PickEngine";
 import { ConnectClaude } from "./onboarding/ConnectClaude";
 import { ConnectCodex } from "./onboarding/ConnectCodex";
 import { ChatScreen } from "./chat/ChatScreen";
+import { MarketScreen } from "./market/MarketScreen";
 import { Toast } from "./Toast";
 
 // Phase router:
@@ -25,7 +26,8 @@ export function App() {
       {state.phase === "engineSelect" && <PickEngine />}
       {state.phase === "claudeAuth" && <ConnectClaude />}
       {state.phase === "codexAuth" && <ConnectCodex />}
-      {state.phase === "chat" && <ChatScreen />}
+      {state.phase === "chat" && !state.marketOpen && <ChatScreen />}
+      {state.phase === "chat" && state.marketOpen && <MarketScreen />}
       <Toast />
     </>
   );

--- a/surfaces/webview/src/chat/ApprovalDock.tsx
+++ b/surfaces/webview/src/chat/ApprovalDock.tsx
@@ -23,6 +23,9 @@ export function ApprovalDock() {
   ) {
     resolveApproval(req.id);
     send({ type: "approvalDecision", id: req.id, outcome, ...extra });
+    if (req.kind === "plan" && outcome === "once") {
+      send({ type: "mode", mode: "acceptEdits" });
+    }
   }
 
   return (

--- a/surfaces/webview/src/chat/ApprovalDock.tsx
+++ b/surfaces/webview/src/chat/ApprovalDock.tsx
@@ -1,4 +1,4 @@
-import { useState } from "react";
+import { useEffect, useRef, useState } from "react";
 import type {
   ApprovalOutcome,
   ApprovalQuestionResponse,
@@ -175,12 +175,31 @@ function ApprovalCard({
   const [editedCmd, setEditedCmd] = useState(req.command ?? "");
   const [showReason, setShowReason] = useState(false);
   const [reason, setReason] = useState("");
+  const cardRef = useRef<HTMLDivElement>(null);
+  const { savePlan, send, resolveApproval } = useStore();
+
+  // Plan cards: Enter = approve, Escape = save plan to log + keep planning (Claude Code parity)
+  useEffect(() => {
+    if (!isPlan) return;
+    cardRef.current?.focus();
+    function onKey(e: KeyboardEvent) {
+      if (e.key === "Enter" && !e.shiftKey) { e.preventDefault(); onDecide("once"); }
+      if (e.key === "Escape") {
+        e.preventDefault();
+        if (req.plan) savePlan(req.plan);
+        resolveApproval(req.id);
+        send({ type: "interrupt" });
+      }
+    }
+    window.addEventListener("keydown", onKey);
+    return () => window.removeEventListener("keydown", onKey);
+  }, [isPlan]);
 
   const borderColor = isDanger ? "border-red-700/60" : "border-emerald-700/50";
   const bgColor = isDanger ? "bg-red-950/20" : "bg-emerald-950/30";
 
   return (
-    <div className={`overflow-hidden rounded-lg border ${borderColor} ${bgColor} text-sm`}>
+    <div ref={cardRef} tabIndex={-1} className={`overflow-hidden rounded-lg border ${borderColor} ${bgColor} text-sm outline-none`}>
       {/* header */}
       <div className="flex items-center gap-2 px-3 py-1.5">
         {isDanger && (
@@ -280,9 +299,12 @@ function ApprovalCard({
             <button autoFocus onClick={() => onDecide("once")} className="rounded bg-emerald-600 px-3 py-1 text-xs font-medium text-white">
               Approve plan
             </button>
-            <button onClick={() => onDecide("deny")} className="rounded bg-red-900/60 px-3 py-1 text-xs text-red-200">
+            <button onClick={() => { if (req.plan) savePlan(req.plan); onDecide("deny"); }} className="rounded bg-red-900/60 px-3 py-1 text-xs text-red-200">
               Keep planning
             </button>
+            <span className="ml-auto text-[10px] text-zinc-600 self-center select-none">
+              ↩ approve · esc interrupt
+            </span>
           </>
         ) : editMode ? (
           <>

--- a/surfaces/webview/src/chat/ChatScreen.tsx
+++ b/surfaces/webview/src/chat/ChatScreen.tsx
@@ -4,22 +4,26 @@ import { MessageList } from "./MessageList";
 import { ApprovalDock } from "./ApprovalDock";
 import { Composer } from "./Composer";
 import { Sessions } from "./Sessions";
+import { ConnectGithub } from "../onboarding/ConnectGithub";
 
 // Chat shell: header (sessions toggle + wallet) over the scrolling log, with the approval
 // dock + composer pinned at the bottom. Uses --vvh (visual viewport height) so the layout
 // shrinks above the on-screen keyboard instead of being covered by it.
 export function ChatScreen() {
-  const { state, openMarket } = useStore();
+  const { state, openMarket, send, clearFiringSkill } = useStore();
   const [drawer, setDrawer] = useState(false);
+  const [githubOpen, setGithubOpen] = useState(false);
   // Clear the firing skill glow after the dwell time
   const firingTimer = useRef<ReturnType<typeof setTimeout> | null>(null);
   useEffect(() => {
     if (state.firingSkill) {
       if (firingTimer.current) clearTimeout(firingTimer.current);
-      firingTimer.current = setTimeout(() => {}, 1400);
+      firingTimer.current = setTimeout(() => {
+        clearFiringSkill();
+      }, 1400);
     }
     return () => { if (firingTimer.current) clearTimeout(firingTimer.current); };
-  }, [state.firingSkill]);
+  }, [state.firingSkill, clearFiringSkill]);
 
   // Track the visual viewport so the composer stays above the mobile keyboard. We set a
   // CSS var on the root and size the shell to it; on desktop this is just window height.
@@ -60,6 +64,13 @@ export function ChatScreen() {
             </span>
           )}
           <button
+            onClick={() => { send({ type: "getGithubStatus" }); setGithubOpen(true); }}
+            className={`text-xs border rounded-lg px-2 py-1 active:bg-zinc-800 ${state.githubStatus?.hasToken ? "text-green-400 border-green-700/50" : "text-zinc-400 border-zinc-700"}`}
+            title="GitHub token"
+          >
+            {state.githubStatus?.hasToken ? "⎇" : "⎇?"}
+          </button>
+          <button
             onClick={openMarket}
             className="text-xs text-zinc-400 border border-zinc-700 rounded-lg px-2 py-1 active:bg-zinc-800"
           >
@@ -84,6 +95,11 @@ export function ChatScreen() {
       <Composer />
 
       {drawer && <Sessions onClose={() => setDrawer(false)} />}
+      {githubOpen && (
+        <div className="absolute inset-0 z-50 bg-zinc-950">
+          <ConnectGithub onDone={() => setGithubOpen(false)} />
+        </div>
+      )}
     </div>
   );
 }

--- a/surfaces/webview/src/chat/ChatScreen.tsx
+++ b/surfaces/webview/src/chat/ChatScreen.tsx
@@ -1,4 +1,4 @@
-import { useEffect, useState } from "react";
+import { useEffect, useRef, useState } from "react";
 import { useStore } from "../state/store";
 import { MessageList } from "./MessageList";
 import { ApprovalDock } from "./ApprovalDock";
@@ -9,8 +9,17 @@ import { Sessions } from "./Sessions";
 // dock + composer pinned at the bottom. Uses --vvh (visual viewport height) so the layout
 // shrinks above the on-screen keyboard instead of being covered by it.
 export function ChatScreen() {
-  const { state } = useStore();
+  const { state, openMarket } = useStore();
   const [drawer, setDrawer] = useState(false);
+  // Clear the firing skill glow after the dwell time
+  const firingTimer = useRef<ReturnType<typeof setTimeout> | null>(null);
+  useEffect(() => {
+    if (state.firingSkill) {
+      if (firingTimer.current) clearTimeout(firingTimer.current);
+      firingTimer.current = setTimeout(() => {}, 1400);
+    }
+    return () => { if (firingTimer.current) clearTimeout(firingTimer.current); };
+  }, [state.firingSkill]);
 
   // Track the visual viewport so the composer stays above the mobile keyboard. We set a
   // CSS var on the root and size the shell to it; on desktop this is just window height.
@@ -44,11 +53,24 @@ export function ChatScreen() {
           ☰
         </button>
         <span className="truncate text-sm font-medium">{activeTitle}</span>
-        {addr && (
-          <span className="ml-auto shrink-0 font-mono text-xs text-zinc-500">
-            {addr.slice(0, 4)}…{addr.slice(-4)}
-          </span>
-        )}
+        <div className="ml-auto flex items-center gap-2 shrink-0">
+          {state.firingSkill && (
+            <span className="text-xs text-green-400 animate-pulse skill-firing-badge">
+              ✨ {state.firingSkill}
+            </span>
+          )}
+          <button
+            onClick={openMarket}
+            className="text-xs text-zinc-400 border border-zinc-700 rounded-lg px-2 py-1 active:bg-zinc-800"
+          >
+            Markets
+          </button>
+          {addr && (
+            <span className="font-mono text-xs text-zinc-500">
+              {addr.slice(0, 4)}…{addr.slice(-4)}
+            </span>
+          )}
+        </div>
       </header>
 
       {state.loading && (

--- a/surfaces/webview/src/chat/Composer.tsx
+++ b/surfaces/webview/src/chat/Composer.tsx
@@ -47,16 +47,11 @@ const SLASH_CMDS = [
 
 // Input + engine tabs + model/effort pickers. FROZEN while an approval is pending.
 export function Composer() {
-  const { state, send } = useStore();
+  const { state, send, queueCount } = useStore();
   const [text, setText] = useState("");
   const [effort, setEffort] = useState("default");
-  const [modeByCli, setModeByCli] = useState<Record<string, string>>({
-    claude: "acceptEdits",
-    codex: "auto",
-  });
-  const mode = modeByCli[state.cli] ?? MODES[state.cli][0].value;
+  const mode = state.modeByCli[state.cli] ?? MODES[state.cli][0].value;
   function changeMode(v: string) {
-    setModeByCli((prev) => ({ ...prev, [state.cli]: v }));
     send({ type: "mode", mode: v });
   }
   const [attached, setAttached] = useState<(ImageInput & { dataUrl: string })[]>([]);
@@ -188,7 +183,7 @@ export function Composer() {
   }
 
   function submit() {
-    if (frozen || busy) return;
+    if (frozen) return;
     const t = text.trim();
     if (!t && !attached.length) return;
 
@@ -335,6 +330,11 @@ export function Composer() {
             ctx: {state.contextTokens >= 1000 ? Math.round(state.contextTokens / 1000) + "k" : state.contextTokens}
           </span>
         )}
+        {queueCount > 0 && (
+          <span className="ml-auto text-amber-400 animate-pulse text-[10px]">
+            ⏳ {queueCount} queued
+          </span>
+        )}
       </div>
 
       {/* attached image thumbnails */}
@@ -464,9 +464,11 @@ export function Composer() {
           placeholder={
             frozen
               ? "Answer the approval above to continue…"
-              : busy
-                ? `Message ${state.cli}… (Esc to stop)`
-                : `Message ${state.cli}… (Enter · paste image)`
+              : busy && queueCount > 0
+                ? `Queued (${queueCount}) — agent will pick up next…`
+                : busy
+                  ? `Message ${state.cli}… (queues while busy · Esc to stop)`
+                  : `Message ${state.cli}… (Enter · paste image)`
           }
           className="max-h-40 min-w-0 flex-1 resize-none overflow-y-auto bg-transparent text-sm leading-relaxed outline-none [overflow-wrap:anywhere] disabled:cursor-not-allowed"
         />

--- a/surfaces/webview/src/chat/Message.tsx
+++ b/surfaces/webview/src/chat/Message.tsx
@@ -10,8 +10,17 @@ export function Message({ msg }: { msg: ChatMessage }) {
   if (msg.role === "user") {
     return (
       <div className="flex justify-end">
-        <div className="max-w-[85%] min-w-0 overflow-hidden rounded-2xl bg-zinc-700 px-3.5 py-2 text-sm whitespace-pre-wrap break-words [overflow-wrap:anywhere]">
+        <div
+          className={`max-w-[85%] min-w-0 overflow-hidden rounded-2xl px-3.5 py-2 text-sm whitespace-pre-wrap break-words [overflow-wrap:anywhere] ${
+            msg._pending
+              ? "bg-zinc-700/50 text-zinc-400"
+              : "bg-zinc-700 text-white"
+          }`}
+        >
           {msg.text}
+          {msg._pending && (
+            <span className="ml-2 inline-block animate-pulse text-[10px] text-zinc-500">⏳</span>
+          )}
         </div>
       </div>
     );

--- a/surfaces/webview/src/index.css
+++ b/surfaces/webview/src/index.css
@@ -95,3 +95,36 @@ body {
   border: 1px solid #3f3f46;
   padding: 4px 8px;
 }
+
+/* Market input fields */
+.input-field {
+  width: 100%;
+  border-radius: 0.5rem;
+  background: #18181b;
+  border: 1px solid #3f3f46;
+  padding: 0.5rem 0.75rem;
+  font-size: 0.875rem;
+  color: #e4e4e7;
+  outline: none;
+  resize: vertical;
+}
+.input-field:focus {
+  border-color: rgba(34, 197, 94, 0.4);
+}
+.input-field::placeholder {
+  color: #52525b;
+}
+
+/* God-mode: skill firing glow — a breathing green aura on the card while casting */
+@keyframes skill-breath {
+  0%, 100% { box-shadow: 0 0 8px 2px rgba(34, 197, 94, 0.3); }
+  50%       { box-shadow: 0 0 20px 6px rgba(34, 197, 94, 0.6); }
+}
+.skill-firing {
+  animation: skill-breath 1.4s ease-in-out infinite;
+}
+
+/* God-mode: firing badge in chat header pulses green */
+.skill-firing-badge {
+  text-shadow: 0 0 8px rgba(134, 239, 172, 0.8);
+}

--- a/surfaces/webview/src/index.css
+++ b/surfaces/webview/src/index.css
@@ -128,3 +128,16 @@ body {
 .skill-firing-badge {
   text-shadow: 0 0 8px rgba(134, 239, 172, 0.8);
 }
+
+/* Buy celebration burst */
+@keyframes buy-particle {
+  0%   { transform: translate(0, 0) scale(1.2); opacity: 1; }
+  100% { transform: translate(calc(cos(var(--angle)) * 90px), calc(sin(var(--angle)) * -90px)) scale(0.2); opacity: 0; }
+}
+@keyframes buy-pop {
+  0%   { transform: scale(0); opacity: 0; }
+  55%  { transform: scale(1.4); opacity: 1; }
+  100% { transform: scale(0.9); opacity: 0; }
+}
+.buy-particle { animation: buy-particle 1.4s cubic-bezier(0.22, 1, 0.36, 1) forwards; }
+.buy-pop      { animation: buy-pop 1.4s cubic-bezier(0.22, 1, 0.36, 1) forwards; }

--- a/surfaces/webview/src/market/AgentDirectory.tsx
+++ b/surfaces/webview/src/market/AgentDirectory.tsx
@@ -1,0 +1,50 @@
+import { useEffect } from "react";
+import { useStore } from "../state/store";
+
+export function AgentDirectory() {
+  const { state, send, loadingAgents } = useStore();
+
+  useEffect(() => {
+    loadingAgents();
+    send({ type: "listAgents" });
+  }, []);
+
+  function openProfile(wallet: string) {
+    send({ type: "getAgentProfile", wallet });
+  }
+
+  if (state.agentsLoading) {
+    return <div className="py-12 text-center text-sm text-zinc-600">Loading agents…</div>;
+  }
+
+  if (state.agents.length === 0) {
+    return <div className="py-12 text-center text-sm text-zinc-600">No agents found.</div>;
+  }
+
+  return (
+    <div className="space-y-2 pt-1">
+      {state.agents.map((agent) => (
+        <button
+          key={agent.wallet}
+          onClick={() => openProfile(agent.wallet)}
+          className="w-full text-left rounded-xl border border-zinc-800 bg-zinc-900 px-3 py-3 active:bg-zinc-800 transition-colors"
+        >
+          <div className="flex items-center gap-2">
+            <div className="h-8 w-8 rounded-full bg-zinc-700 flex items-center justify-center text-sm shrink-0">
+              🤖
+            </div>
+            <div className="min-w-0 flex-1">
+              <p className="text-sm font-mono text-zinc-200 truncate">
+                {agent.wallet.slice(0, 6)}…{agent.wallet.slice(-4)}
+              </p>
+              <p className="text-[11px] text-zinc-500">
+                {agent.skillsPublished ?? 0} skills · {agent.totalSupply ?? 0} holders
+              </p>
+            </div>
+            <span className="shrink-0 text-zinc-600 text-xs">›</span>
+          </div>
+        </button>
+      ))}
+    </div>
+  );
+}

--- a/surfaces/webview/src/market/AgentProfileView.tsx
+++ b/surfaces/webview/src/market/AgentProfileView.tsx
@@ -1,0 +1,150 @@
+import { useState } from "react";
+import { useStore } from "../state/store";
+import type { AgentProfile, SkillCard } from "../transport/protocol";
+
+interface Props {
+  profile: AgentProfile;
+  onBack: () => void;
+  onOpenSkill: (card: SkillCard) => void;
+}
+
+export function AgentProfileView({ profile, onBack, onOpenSkill }: Props) {
+  const { send } = useStore();
+  const [noteText, setNoteText] = useState("");
+  const [buyingAll, setBuyingAll] = useState(false);
+  const [noteGitLink, setNoteGitLink] = useState("");
+
+  function handleBuyAll() {
+    setBuyingAll(true);
+    send({ type: "buyAllSkills", wallet: profile.wallet });
+    setTimeout(() => setBuyingAll(false), 8000);
+  }
+
+  function handleNote() {
+    if (!noteText.trim()) return;
+    send({
+      type: "postAgentNote",
+      agentWallet: profile.wallet,
+      text: noteText.trim(),
+      gitLink: noteGitLink.trim() || undefined,
+    });
+    setNoteText("");
+    setNoteGitLink("");
+  }
+
+  const allSkills = [...(profile.createdSkills ?? [])];
+
+  return (
+    <div className="flex flex-col h-full">
+      <header className="flex items-center gap-2 border-b border-zinc-800 px-3 py-2 shrink-0">
+        <button onClick={onBack} className="text-zinc-400 active:text-zinc-200 px-1 text-lg">←</button>
+        <span className="font-mono text-sm truncate">
+          {profile.wallet.slice(0, 6)}…{profile.wallet.slice(-4)}
+        </span>
+        {profile.self && (
+          <span className="ml-auto shrink-0 rounded px-1.5 py-0.5 text-[10px] font-semibold bg-blue-900/60 text-blue-400">you</span>
+        )}
+      </header>
+
+      <div className="flex-1 overflow-y-auto p-3 space-y-4">
+        {/* Stats row */}
+        <div className="flex gap-3 rounded-xl border border-zinc-800 bg-zinc-900 p-3 text-center">
+          <div className="flex-1">
+            <p className="text-lg font-semibold text-zinc-200">{profile.createdSkills?.length ?? 0}</p>
+            <p className="text-[10px] text-zinc-500 uppercase">Created</p>
+          </div>
+          <div className="w-px bg-zinc-800" />
+          <div className="flex-1">
+            <p className="text-lg font-semibold text-zinc-200">{profile.ownedSkills?.length ?? 0}</p>
+            <p className="text-[10px] text-zinc-500 uppercase">Owned</p>
+          </div>
+          <div className="w-px bg-zinc-800" />
+          <div className="flex-1">
+            <p className="text-lg font-semibold text-zinc-200">{profile.reputation?.totalSupply ?? 0}</p>
+            <p className="text-[10px] text-zinc-500 uppercase">Holders</p>
+          </div>
+        </div>
+
+        {/* Skills grid */}
+        {allSkills.length > 0 && (
+          <div>
+            <p className="text-[11px] text-zinc-500 uppercase tracking-wide mb-2">Skills</p>
+            <div className="grid grid-cols-2 gap-2">
+              {allSkills.map((card) => (
+                <button
+                  key={card.id}
+                  onClick={() => onOpenSkill(card)}
+                  className="text-left rounded-lg border border-zinc-800 bg-zinc-900 p-2.5 active:bg-zinc-800"
+                >
+                  {card.image ? (
+                    <img src={card.image} alt="" className="h-8 w-8 rounded-lg object-cover mb-1.5" />
+                  ) : (
+                    <div className="h-8 w-8 rounded-lg bg-zinc-800 flex items-center justify-center text-base mb-1.5">🔮</div>
+                  )}
+                  <p className="text-xs font-medium text-zinc-200 truncate">{card.name}</p>
+                  <p className="text-[10px] text-zinc-500">{card.price ? `${(Number(card.price) / 1e9).toFixed(3)} SOL` : "free"}</p>
+                </button>
+              ))}
+            </div>
+          </div>
+        )}
+
+        {/* Notes/blog */}
+        {profile.notes && profile.notes.length > 0 && (
+          <div>
+            <p className="text-[11px] text-zinc-500 uppercase tracking-wide mb-2">Notes</p>
+            <div className="space-y-2">
+              {(profile.notes as any[]).map((n: any, i) => (
+                <div key={i} className="rounded-lg bg-zinc-900 border border-zinc-800 p-2.5 text-xs text-zinc-300">
+                  <p className="text-zinc-600 text-[10px] mb-0.5">{n.author?.slice(0, 6)}…</p>
+                  <p>{n.text}</p>
+                  {n.gitLink && (
+                    <a href={n.gitLink} target="_blank" rel="noreferrer" className="text-blue-400 text-[10px] mt-0.5 block truncate">{n.gitLink}</a>
+                  )}
+                </div>
+              ))}
+            </div>
+          </div>
+        )}
+
+        {/* Leave note */}
+        <div className="space-y-1.5">
+          <p className="text-[11px] text-zinc-500 uppercase tracking-wide">Leave a note</p>
+          <textarea
+            className="w-full rounded-lg bg-zinc-900 border border-zinc-800 p-2 text-xs text-zinc-200 resize-none focus:outline-none focus:border-green-500/50"
+            rows={2}
+            placeholder="Your message…"
+            value={noteText}
+            onChange={(e) => setNoteText(e.target.value)}
+          />
+          <input
+            className="w-full rounded-lg bg-zinc-900 border border-zinc-800 px-2 py-1.5 text-xs text-zinc-300 placeholder-zinc-600 focus:outline-none focus:border-blue-500/50"
+            placeholder="GitHub link (optional)"
+            value={noteGitLink}
+            onChange={(e) => setNoteGitLink(e.target.value)}
+          />
+          <button
+            onClick={handleNote}
+            disabled={!noteText.trim()}
+            className="text-xs px-3 py-1.5 rounded-lg bg-zinc-800 text-zinc-300 disabled:opacity-40 active:bg-zinc-700"
+          >
+            Post
+          </button>
+        </div>
+      </div>
+
+      {/* Buy all footer */}
+      {!profile.self && allSkills.length > 0 && (
+        <div className="shrink-0 border-t border-zinc-800 p-3 pb-[max(0.75rem,env(safe-area-inset-bottom))]">
+          <button
+            onClick={handleBuyAll}
+            disabled={buyingAll}
+            className="w-full rounded-xl bg-green-600 py-3 text-sm font-semibold text-white active:bg-green-500 disabled:opacity-50"
+          >
+            {buyingAll ? "Buying…" : `Buy all ${allSkills.length} skill${allSkills.length !== 1 ? "s" : ""}`}
+          </button>
+        </div>
+      )}
+    </div>
+  );
+}

--- a/surfaces/webview/src/market/BuyCelebration.tsx
+++ b/surfaces/webview/src/market/BuyCelebration.tsx
@@ -1,0 +1,28 @@
+import { useEffect } from "react";
+import { useStore } from "../state/store";
+
+const PARTICLES = ["✨", "🎉", "⭐", "💫", "🌟"];
+
+export function BuyCelebration() {
+  const { clearCelebrate } = useStore();
+
+  useEffect(() => {
+    const t = setTimeout(clearCelebrate, 1600);
+    return () => clearTimeout(t);
+  }, []);
+
+  return (
+    <div className="pointer-events-none fixed inset-0 z-50 flex items-center justify-center">
+      {PARTICLES.map((p, i) => (
+        <span
+          key={i}
+          className="absolute text-2xl buy-particle"
+          style={{ "--angle": `${i * 72}deg` } as React.CSSProperties}
+        >
+          {p}
+        </span>
+      ))}
+      <span className="text-5xl buy-pop">🎉</span>
+    </div>
+  );
+}

--- a/surfaces/webview/src/market/MarketScreen.tsx
+++ b/surfaces/webview/src/market/MarketScreen.tsx
@@ -3,12 +3,14 @@ import { useStore } from "../state/store";
 import { SkillCardTile } from "./SkillCardTile";
 import { SkillDetailView } from "./SkillDetailView";
 import { PublishForm } from "./PublishForm";
+import { AgentDirectory } from "./AgentDirectory";
+import { AgentProfileView } from "./AgentProfileView";
 import type { SkillCard } from "../transport/protocol";
 
-type MarketView = "browse" | "publish" | "helius";
+type MarketView = "browse" | "publish" | "helius" | "agents";
 
 export function MarketScreen() {
-  const { state, send, closeMarket, setMarketTab, setMarketQuery, marketSearching, clearMarketDetail } = useStore();
+  const { state, send, closeMarket, setMarketTab, setMarketQuery, marketSearching, clearMarketDetail, clearAgentProfile } = useStore();
   const [view, setView] = useState<MarketView>("browse");
 
   // On first open: load owned skills, RPC status, and initial search
@@ -18,6 +20,11 @@ export function MarketScreen() {
     send({ type: "getBalance" });
     send({ type: "searchSkills", query: "", kind: state.marketTab });
   }, []);
+
+  // When agent profile loads, switch to agents view to show it
+  useEffect(() => {
+    if (state.agentProfile) setView("agents");
+  }, [state.agentProfile]);
 
   function runSearch(q: string, tab?: "skill" | "workflow") {
     marketSearching();
@@ -51,6 +58,19 @@ export function MarketScreen() {
     return (
       <div className="flex flex-col h-full bg-zinc-950">
         <PublishForm onBack={() => setView("browse")} />
+      </div>
+    );
+  }
+
+  // Agent profile
+  if (view === "agents" && state.agentProfile) {
+    return (
+      <div className="flex flex-col h-full bg-zinc-950">
+        <AgentProfileView
+          profile={state.agentProfile}
+          onBack={() => clearAgentProfile()}
+          onOpenSkill={(card) => send({ type: "getSkillDetail", mint: card.id })}
+        />
       </div>
     );
   }
@@ -106,10 +126,10 @@ export function MarketScreen() {
         {(["skill", "workflow"] as const).map((tab) => (
           <button
             key={tab}
-            onClick={() => handleTabChange(tab)}
+            onClick={() => { setView("browse"); handleTabChange(tab); }}
             className={[
               "px-4 py-2 text-sm capitalize border-b-2 transition-colors",
-              state.marketTab === tab
+              view === "browse" && state.marketTab === tab
                 ? "border-green-500 text-green-400"
                 : "border-transparent text-zinc-500 active:text-zinc-300",
             ].join(" ")}
@@ -117,6 +137,17 @@ export function MarketScreen() {
             {tab}s
           </button>
         ))}
+        <button
+          onClick={() => setView("agents")}
+          className={[
+            "px-4 py-2 text-sm border-b-2 transition-colors",
+            view === "agents"
+              ? "border-green-500 text-green-400"
+              : "border-transparent text-zinc-500 active:text-zinc-300",
+          ].join(" ")}
+        >
+          Agents
+        </button>
       </div>
 
       {/* Search */}
@@ -140,30 +171,36 @@ export function MarketScreen() {
         </form>
       </div>
 
-      {/* Results */}
+      {/* Results / Agent directory */}
       <div className="flex-1 overflow-y-auto px-3 pb-[max(0.75rem,env(safe-area-inset-bottom))]">
-        {state.marketSearching && (
-          <div className="py-8 text-center text-sm text-zinc-600">Searching…</div>
+        {view === "agents" ? (
+          <AgentDirectory />
+        ) : (
+          <>
+            {state.marketSearching && (
+              <div className="py-8 text-center text-sm text-zinc-600">Searching…</div>
+            )}
+            {state.marketSearchError && (
+              <div className="py-6 text-center text-sm text-red-400">{state.marketSearchError}</div>
+            )}
+            {!state.marketSearching && state.marketResults?.length === 0 && (
+              <div className="py-8 text-center text-sm text-zinc-600">
+                No {state.marketTab}s found.{!state.rpcStatus?.hasKey && " Add a Helius key for better results."}
+              </div>
+            )}
+            <div className="space-y-2 pt-1">
+              {state.marketResults?.map((card) => (
+                <SkillCardTile
+                  key={card.id}
+                  card={card}
+                  owned={state.marketOwned.includes(card.name)}
+                  firing={state.firingSkill === card.name}
+                  onOpen={handleOpenCard}
+                />
+              ))}
+            </div>
+          </>
         )}
-        {state.marketSearchError && (
-          <div className="py-6 text-center text-sm text-red-400">{state.marketSearchError}</div>
-        )}
-        {!state.marketSearching && state.marketResults?.length === 0 && (
-          <div className="py-8 text-center text-sm text-zinc-600">
-            No {state.marketTab}s found.{!state.rpcStatus?.hasKey && " Add a Helius key for better results."}
-          </div>
-        )}
-        <div className="space-y-2 pt-1">
-          {state.marketResults?.map((card) => (
-            <SkillCardTile
-              key={card.id}
-              card={card}
-              owned={state.marketOwned.includes(card.name)}
-              firing={state.firingSkill === card.name}
-              onOpen={handleOpenCard}
-            />
-          ))}
-        </div>
       </div>
     </div>
   );

--- a/surfaces/webview/src/market/MarketScreen.tsx
+++ b/surfaces/webview/src/market/MarketScreen.tsx
@@ -1,0 +1,224 @@
+import { useEffect, useState } from "react";
+import { useStore } from "../state/store";
+import { SkillCardTile } from "./SkillCardTile";
+import { SkillDetailView } from "./SkillDetailView";
+import { PublishForm } from "./PublishForm";
+import type { SkillCard } from "../transport/protocol";
+
+type MarketView = "browse" | "publish" | "helius";
+
+export function MarketScreen() {
+  const { state, send, closeMarket, setMarketTab, setMarketQuery, marketSearching, clearMarketDetail } = useStore();
+  const [view, setView] = useState<MarketView>("browse");
+
+  // On first open: load owned skills, RPC status, and initial search
+  useEffect(() => {
+    send({ type: "ownedSkills" });
+    send({ type: "getRpcStatus" });
+    send({ type: "getBalance" });
+    send({ type: "searchSkills", query: "", kind: state.marketTab });
+  }, []);
+
+  function runSearch(q: string, tab?: "skill" | "workflow") {
+    marketSearching();
+    send({ type: "searchSkills", query: q, kind: tab ?? state.marketTab });
+  }
+
+  function handleTabChange(tab: "skill" | "workflow") {
+    setMarketTab(tab);
+    runSearch(state.marketQuery, tab);
+  }
+
+  function handleOpenCard(card: SkillCard) {
+    send({ type: "getSkillDetail", mint: card.id });
+  }
+
+  // Detail view
+  if (state.marketDetail) {
+    return (
+      <div className="flex flex-col h-full bg-zinc-950">
+        <SkillDetailView
+          detail={state.marketDetail}
+          owned={state.marketOwned.includes(state.marketDetail.card.name)}
+          onBack={() => { send({ type: "ownedSkills" }); clearMarketDetail(); }}
+        />
+      </div>
+    );
+  }
+
+  // Publish form
+  if (view === "publish") {
+    return (
+      <div className="flex flex-col h-full bg-zinc-950">
+        <PublishForm onBack={() => setView("browse")} />
+      </div>
+    );
+  }
+
+  // Helius key setup
+  if (view === "helius") {
+    return <HeliusSetup onBack={() => setView("browse")} />;
+  }
+
+  const balanceSol = state.marketBalance != null ? (state.marketBalance / 1_000_000_000).toFixed(3) : null;
+
+  return (
+    <div className="flex flex-col h-full bg-zinc-950" style={{ height: "var(--vvh, 100dvh)" }}>
+      {/* Header */}
+      <header
+        className="flex items-center gap-2 border-b border-zinc-800 px-3 py-2 shrink-0"
+        style={{ paddingTop: "max(0.5rem, env(safe-area-inset-top))" }}
+      >
+        <button onClick={closeMarket} className="shrink-0 text-zinc-400 active:text-zinc-200 px-1 text-lg">←</button>
+        <span className="font-semibold text-sm">Markets</span>
+        {balanceSol && (
+          <span className="ml-auto text-xs text-zinc-500 font-mono">{balanceSol} SOL</span>
+        )}
+        <button
+          onClick={() => setView("publish")}
+          className="shrink-0 text-xs text-green-400 border border-green-700/50 rounded-lg px-2 py-1 active:bg-green-900/30"
+        >
+          + Publish
+        </button>
+      </header>
+
+      {/* RPC status nudge */}
+      {state.rpcStatus && !state.rpcStatus.hasKey && (
+        <button
+          onClick={() => setView("helius")}
+          className="mx-3 mt-2 shrink-0 flex items-center gap-2 rounded-lg border border-amber-700/40 bg-amber-900/20 px-3 py-2 text-xs text-amber-400 active:bg-amber-900/40"
+        >
+          <span>⚡</span>
+          <span className="flex-1 text-left">Add Helius key for faster results</span>
+          <span>›</span>
+        </button>
+      )}
+      {state.rpcStatus?.hasKey && (
+        <div className="mx-3 mt-2 shrink-0 flex items-center gap-1.5 rounded-lg border border-green-800/40 bg-green-900/10 px-3 py-1.5 text-[11px] text-green-500">
+          <span>●</span>
+          <span>{state.rpcStatus.network} · {state.rpcStatus.masked}</span>
+          <button onClick={() => setView("helius")} className="ml-auto text-zinc-600 hover:text-zinc-400">⚙</button>
+        </div>
+      )}
+
+      {/* Tabs */}
+      <div className="flex gap-0 border-b border-zinc-800 px-3 mt-2 shrink-0">
+        {(["skill", "workflow"] as const).map((tab) => (
+          <button
+            key={tab}
+            onClick={() => handleTabChange(tab)}
+            className={[
+              "px-4 py-2 text-sm capitalize border-b-2 transition-colors",
+              state.marketTab === tab
+                ? "border-green-500 text-green-400"
+                : "border-transparent text-zinc-500 active:text-zinc-300",
+            ].join(" ")}
+          >
+            {tab}s
+          </button>
+        ))}
+      </div>
+
+      {/* Search */}
+      <div className="px-3 py-2 shrink-0">
+        <form
+          onSubmit={(e) => { e.preventDefault(); runSearch(state.marketQuery); }}
+          className="flex gap-2"
+        >
+          <input
+            className="flex-1 rounded-lg bg-zinc-900 border border-zinc-800 px-3 py-2 text-sm text-zinc-200 placeholder-zinc-600 focus:outline-none focus:border-green-500/50"
+            placeholder={`Search ${state.marketTab}s…`}
+            value={state.marketQuery}
+            onChange={(e) => setMarketQuery(e.target.value)}
+          />
+          <button
+            type="submit"
+            className="rounded-lg bg-zinc-800 px-3 py-2 text-sm text-zinc-300 active:bg-zinc-700"
+          >
+            Search
+          </button>
+        </form>
+      </div>
+
+      {/* Results */}
+      <div className="flex-1 overflow-y-auto px-3 pb-[max(0.75rem,env(safe-area-inset-bottom))]">
+        {state.marketSearching && (
+          <div className="py-8 text-center text-sm text-zinc-600">Searching…</div>
+        )}
+        {state.marketSearchError && (
+          <div className="py-6 text-center text-sm text-red-400">{state.marketSearchError}</div>
+        )}
+        {!state.marketSearching && state.marketResults?.length === 0 && (
+          <div className="py-8 text-center text-sm text-zinc-600">
+            No {state.marketTab}s found.{!state.rpcStatus?.hasKey && " Add a Helius key for better results."}
+          </div>
+        )}
+        <div className="space-y-2 pt-1">
+          {state.marketResults?.map((card) => (
+            <SkillCardTile
+              key={card.id}
+              card={card}
+              owned={state.marketOwned.includes(card.name)}
+              firing={state.firingSkill === card.name}
+              onOpen={handleOpenCard}
+            />
+          ))}
+        </div>
+      </div>
+    </div>
+  );
+}
+
+function HeliusSetup({ onBack }: { onBack: () => void }) {
+  const { send } = useStore();
+  const [key, setKey] = useState("");
+  const [saving, setSaving] = useState(false);
+
+  function save() {
+    if (!key.trim()) return;
+    setSaving(true);
+    send({ type: "submitHeliusKey", key: key.trim() });
+    setTimeout(onBack, 1200);
+  }
+
+  function clear() {
+    send({ type: "useDefaultRpc" });
+    onBack();
+  }
+
+  return (
+    <div className="flex flex-col h-full bg-zinc-950">
+      <header className="flex items-center gap-2 border-b border-zinc-800 px-3 py-2 shrink-0">
+        <button onClick={onBack} className="text-zinc-400 active:text-zinc-200 px-1 text-lg">←</button>
+        <span className="font-medium text-sm">Helius API Key</span>
+      </header>
+      <div className="flex-1 p-4 space-y-4">
+        <p className="text-sm text-zinc-400">
+          A Helius key enables fast NFT indexing and skill search. Stored locally, never synced.
+        </p>
+        <input
+          className="w-full rounded-lg bg-zinc-900 border border-zinc-800 px-3 py-2.5 text-sm text-zinc-200 placeholder-zinc-600 focus:outline-none focus:border-green-500/50 font-mono"
+          placeholder="xxxx-xxxx-xxxx or https://…helius-rpc.com/?api-key=…"
+          value={key}
+          onChange={(e) => setKey(e.target.value)}
+          type="password"
+        />
+        <div className="flex gap-2">
+          <button
+            onClick={save}
+            disabled={saving || !key.trim()}
+            className="flex-1 rounded-xl bg-green-600 py-2.5 text-sm font-semibold text-white active:bg-green-500 disabled:opacity-50"
+          >
+            {saving ? "Saving…" : "Save Key"}
+          </button>
+          <button
+            onClick={clear}
+            className="rounded-xl border border-zinc-700 px-4 py-2.5 text-sm text-zinc-400 active:bg-zinc-800"
+          >
+            Use Default
+          </button>
+        </div>
+      </div>
+    </div>
+  );
+}

--- a/surfaces/webview/src/market/MarketScreen.tsx
+++ b/surfaces/webview/src/market/MarketScreen.tsx
@@ -5,6 +5,7 @@ import { SkillDetailView } from "./SkillDetailView";
 import { PublishForm } from "./PublishForm";
 import { AgentDirectory } from "./AgentDirectory";
 import { AgentProfileView } from "./AgentProfileView";
+import { BuyCelebration } from "./BuyCelebration";
 import type { SkillCard } from "../transport/protocol";
 
 type MarketView = "browse" | "publish" | "helius" | "agents";
@@ -49,6 +50,7 @@ export function MarketScreen() {
           owned={state.marketOwned.includes(state.marketDetail.card.name)}
           onBack={() => { send({ type: "ownedSkills" }); clearMarketDetail(); }}
         />
+        {state.buyCelebrate && <BuyCelebration />}
       </div>
     );
   }

--- a/surfaces/webview/src/market/PublishForm.tsx
+++ b/surfaces/webview/src/market/PublishForm.tsx
@@ -1,0 +1,146 @@
+import { useState } from "react";
+import { useStore } from "../state/store";
+
+interface Props {
+  onBack: () => void;
+}
+
+export function PublishForm({ onBack }: Props) {
+  const { send, state, clearPublishResult } = useStore();
+  const [name, setName] = useState("");
+  const [description, setDescription] = useState("");
+  const [text, setText] = useState("");
+  const [category, setCategory] = useState("");
+  const [hashtags, setHashtags] = useState("");
+  const [priceSol, setPriceSol] = useState("0");
+  const [submitting, setSubmitting] = useState(false);
+
+  const result = state.publishResult;
+
+  function handleSubmit() {
+    if (!name.trim() || !text.trim()) return;
+    setSubmitting(true);
+    clearPublishResult();
+    send({
+      type: "publishSkill",
+      name: name.trim(),
+      description: description.trim(),
+      text: text.trim(),
+      category: category.trim() || undefined,
+      hashtags: hashtags.split(",").map((h) => h.trim()).filter(Boolean),
+      priceSol: priceSol || "0",
+    });
+    setTimeout(() => setSubmitting(false), 15000);
+  }
+
+  if (result) {
+    return (
+      <div className="flex flex-col h-full">
+        <header className="flex items-center gap-2 border-b border-zinc-800 px-3 py-2 shrink-0">
+          <button onClick={() => { clearPublishResult(); onBack(); }} className="text-zinc-400 active:text-zinc-200 px-1 text-lg">←</button>
+          <span className="font-medium text-sm">Publish Skill</span>
+        </header>
+        <div className="flex-1 flex flex-col items-center justify-center gap-3 p-6 text-center">
+          {result.ok ? (
+            <>
+              <div className="text-4xl">✨</div>
+              <p className="text-green-400 font-semibold">Skill minted!</p>
+              {result.mint && <p className="font-mono text-xs text-zinc-500">{result.mint}</p>}
+              <button onClick={() => { clearPublishResult(); onBack(); }} className="mt-2 text-sm text-zinc-400 underline">Back to market</button>
+            </>
+          ) : (
+            <>
+              <div className="text-4xl">⚠️</div>
+              <p className="text-red-400 font-semibold">Publish failed</p>
+              <p className="text-xs text-zinc-500">{result.error}</p>
+              <button onClick={() => { clearPublishResult(); setSubmitting(false); }} className="mt-2 text-sm text-zinc-400 underline">Try again</button>
+            </>
+          )}
+        </div>
+      </div>
+    );
+  }
+
+  return (
+    <div className="flex flex-col h-full">
+      <header className="flex items-center gap-2 border-b border-zinc-800 px-3 py-2 shrink-0">
+        <button onClick={onBack} className="text-zinc-400 active:text-zinc-200 px-1 text-lg">←</button>
+        <span className="font-medium text-sm">Publish Skill</span>
+      </header>
+
+      <div className="flex-1 overflow-y-auto p-3 space-y-3">
+        <Field label="Name *">
+          <input
+            className="input-field"
+            placeholder="My Skill"
+            value={name}
+            onChange={(e) => setName(e.target.value)}
+          />
+        </Field>
+        <Field label="Description">
+          <input
+            className="input-field"
+            placeholder="What does this skill do?"
+            value={description}
+            onChange={(e) => setDescription(e.target.value)}
+          />
+        </Field>
+        <Field label="SKILL.md content *">
+          <textarea
+            className="input-field font-mono text-xs"
+            rows={8}
+            placeholder="# My Skill&#10;&#10;## Description&#10;…"
+            value={text}
+            onChange={(e) => setText(e.target.value)}
+          />
+        </Field>
+        <Field label="Category">
+          <input
+            className="input-field"
+            placeholder="e.g. coding, writing"
+            value={category}
+            onChange={(e) => setCategory(e.target.value)}
+          />
+        </Field>
+        <Field label="Hashtags (comma-separated)">
+          <input
+            className="input-field"
+            placeholder="ai, productivity"
+            value={hashtags}
+            onChange={(e) => setHashtags(e.target.value)}
+          />
+        </Field>
+        <Field label="Price (SOL)">
+          <input
+            className="input-field"
+            type="number"
+            min="0"
+            step="0.001"
+            placeholder="0"
+            value={priceSol}
+            onChange={(e) => setPriceSol(e.target.value)}
+          />
+        </Field>
+      </div>
+
+      <div className="shrink-0 border-t border-zinc-800 p-3 pb-[max(0.75rem,env(safe-area-inset-bottom))]">
+        <button
+          onClick={handleSubmit}
+          disabled={submitting || !name.trim() || !text.trim()}
+          className="w-full rounded-xl bg-green-600 py-3 text-sm font-semibold text-white active:bg-green-500 disabled:opacity-50"
+        >
+          {submitting ? "Minting NFT…" : "Mint & Publish"}
+        </button>
+      </div>
+    </div>
+  );
+}
+
+function Field({ label, children }: { label: string; children: React.ReactNode }) {
+  return (
+    <div className="space-y-1">
+      <label className="text-[11px] text-zinc-500 uppercase tracking-wide">{label}</label>
+      {children}
+    </div>
+  );
+}

--- a/surfaces/webview/src/market/PublishForm.tsx
+++ b/surfaces/webview/src/market/PublishForm.tsx
@@ -1,4 +1,4 @@
-import { useState } from "react";
+import { useRef, useState } from "react";
 import { useStore } from "../state/store";
 
 interface Props {
@@ -13,7 +13,23 @@ export function PublishForm({ onBack }: Props) {
   const [category, setCategory] = useState("");
   const [hashtags, setHashtags] = useState("");
   const [priceSol, setPriceSol] = useState("0");
+  const [imageDataUrl, setImageDataUrl] = useState<string | null>(null);
+  const [imageBase64, setImageBase64] = useState<string | null>(null);
+  const [imageMime, setImageMime] = useState<string>("image/png");
   const [submitting, setSubmitting] = useState(false);
+  const imgInputRef = useRef<HTMLInputElement>(null);
+
+  function handleImageFile(file: File) {
+    setImageMime(file.type || "image/png");
+    const reader = new FileReader();
+    reader.onload = () => {
+      const dataUrl = reader.result as string;
+      setImageDataUrl(dataUrl);
+      const comma = dataUrl.indexOf(",");
+      if (comma >= 0) setImageBase64(dataUrl.slice(comma + 1));
+    };
+    reader.readAsDataURL(file);
+  }
 
   const result = state.publishResult;
 
@@ -29,6 +45,7 @@ export function PublishForm({ onBack }: Props) {
       category: category.trim() || undefined,
       hashtags: hashtags.split(",").map((h) => h.trim()).filter(Boolean),
       priceSol: priceSol || "0",
+      image: imageBase64 ? `data:${imageMime};base64,${imageBase64}` : undefined,
     });
     setTimeout(() => setSubmitting(false), 15000);
   }
@@ -120,6 +137,35 @@ export function PublishForm({ onBack }: Props) {
             value={priceSol}
             onChange={(e) => setPriceSol(e.target.value)}
           />
+        </Field>
+        <Field label="Cover Image (optional)">
+          <input
+            ref={imgInputRef}
+            type="file"
+            accept="image/*"
+            hidden
+            onChange={(e) => { if (e.target.files?.[0]) handleImageFile(e.target.files[0]); e.target.value = ""; }}
+          />
+          {imageDataUrl ? (
+            <div className="flex items-center gap-2">
+              <img src={imageDataUrl} alt="preview" className="h-14 w-14 rounded-lg object-cover border border-zinc-700" />
+              <button
+                type="button"
+                onClick={() => { setImageDataUrl(null); setImageBase64(null); }}
+                className="text-xs text-zinc-500 underline"
+              >
+                Remove
+              </button>
+            </div>
+          ) : (
+            <button
+              type="button"
+              onClick={() => imgInputRef.current?.click()}
+              className="flex items-center gap-2 rounded-lg border border-dashed border-zinc-700 px-3 py-3 text-xs text-zinc-500 active:bg-zinc-800 w-full"
+            >
+              📷 Choose image
+            </button>
+          )}
         </Field>
       </div>
 

--- a/surfaces/webview/src/market/SkillCardTile.tsx
+++ b/surfaces/webview/src/market/SkillCardTile.tsx
@@ -1,0 +1,56 @@
+import type { SkillCard } from "../transport/protocol";
+
+interface Props {
+  card: SkillCard;
+  owned?: boolean;
+  firing?: boolean;
+  onOpen: (card: SkillCard) => void;
+}
+
+export function SkillCardTile({ card, owned, firing, onOpen }: Props) {
+  const priceSol = card.price ? (Number(card.price) / 1_000_000_000).toFixed(3) : null;
+  return (
+    <button
+      onClick={() => onOpen(card)}
+      className={[
+        "w-full text-left rounded-xl border p-3 transition-all",
+        "bg-zinc-900 border-zinc-800 hover:border-zinc-600 active:scale-[0.98]",
+        firing ? "skill-firing border-green-500/60" : "",
+        owned ? "border-l-2 border-l-green-500" : "",
+      ].join(" ")}
+    >
+      <div className="flex items-start gap-2">
+        {card.image ? (
+          <img src={card.image} alt="" className="h-10 w-10 rounded-lg object-cover shrink-0" />
+        ) : (
+          <div className="h-10 w-10 rounded-lg bg-zinc-800 shrink-0 flex items-center justify-center text-lg">
+            {firing ? "✨" : "🔮"}
+          </div>
+        )}
+        <div className="min-w-0 flex-1">
+          <div className="flex items-center gap-1">
+            <span className="truncate font-medium text-sm text-zinc-100">{card.name}</span>
+            {owned && (
+              <span className="shrink-0 rounded px-1 py-0.5 text-[10px] font-semibold bg-green-900/60 text-green-400">
+                owned
+              </span>
+            )}
+            {firing && (
+              <span className="shrink-0 rounded px-1 py-0.5 text-[10px] font-semibold bg-green-500/20 text-green-300 animate-pulse">
+                casting
+              </span>
+            )}
+          </div>
+          {card.description && (
+            <p className="mt-0.5 text-xs text-zinc-500 line-clamp-2">{card.description}</p>
+          )}
+          <div className="mt-1 flex items-center gap-2 text-[11px] text-zinc-600">
+            {card.category && <span>{card.category}</span>}
+            {card.supply != null && <span>↑{card.supply}</span>}
+            {priceSol && <span className="text-green-500/80">{priceSol} SOL</span>}
+          </div>
+        </div>
+      </div>
+    </button>
+  );
+}

--- a/surfaces/webview/src/market/SkillDetailView.tsx
+++ b/surfaces/webview/src/market/SkillDetailView.tsx
@@ -12,6 +12,7 @@ export function SkillDetailView({ detail, owned, onBack }: Props) {
   const { send } = useStore();
   const [buying, setBuying] = useState(false);
   const [noteText, setNoteText] = useState("");
+  const [noteGitLink, setNoteGitLink] = useState("");
   const { card, skillText, notes } = detail;
   const priceSol = card.price ? (Number(card.price) / 1_000_000_000).toFixed(3) : null;
 
@@ -23,8 +24,9 @@ export function SkillDetailView({ detail, owned, onBack }: Props) {
 
   function handleNote() {
     if (!noteText.trim()) return;
-    send({ type: "postNote", skillId: card.id, skillType: card.type, text: noteText.trim() });
+    send({ type: "postNote", skillId: card.id, skillType: card.type, text: noteText.trim(), gitLink: noteGitLink.trim() || undefined });
     setNoteText("");
+    setNoteGitLink("");
   }
 
   return (
@@ -86,6 +88,12 @@ export function SkillDetailView({ detail, owned, onBack }: Props) {
               placeholder="Share your experience…"
               value={noteText}
               onChange={(e) => setNoteText(e.target.value)}
+            />
+            <input
+              className="w-full rounded-lg bg-zinc-900 border border-zinc-800 px-2 py-1.5 text-xs text-zinc-300 placeholder-zinc-600 focus:outline-none focus:border-blue-500/50"
+              placeholder="GitHub link (optional)"
+              value={noteGitLink}
+              onChange={(e) => setNoteGitLink(e.target.value)}
             />
             <button
               onClick={handleNote}

--- a/surfaces/webview/src/market/SkillDetailView.tsx
+++ b/surfaces/webview/src/market/SkillDetailView.tsx
@@ -1,0 +1,114 @@
+import { useState } from "react";
+import { useStore } from "../state/store";
+import type { SkillDetail } from "../transport/protocol";
+
+interface Props {
+  detail: SkillDetail;
+  owned: boolean;
+  onBack: () => void;
+}
+
+export function SkillDetailView({ detail, owned, onBack }: Props) {
+  const { send } = useStore();
+  const [buying, setBuying] = useState(false);
+  const [noteText, setNoteText] = useState("");
+  const { card, skillText, notes } = detail;
+  const priceSol = card.price ? (Number(card.price) / 1_000_000_000).toFixed(3) : null;
+
+  function handleBuy() {
+    setBuying(true);
+    send({ type: "buySkill", skillId: card.id, creatorWallet: card.creator });
+    setTimeout(() => setBuying(false), 5000);
+  }
+
+  function handleNote() {
+    if (!noteText.trim()) return;
+    send({ type: "postNote", skillId: card.id, skillType: card.type, text: noteText.trim() });
+    setNoteText("");
+  }
+
+  return (
+    <div className="flex flex-col h-full">
+      <header className="flex items-center gap-2 border-b border-zinc-800 px-3 py-2 shrink-0">
+        <button onClick={onBack} className="text-zinc-400 active:text-zinc-200 px-1 text-lg">←</button>
+        <span className="truncate font-medium text-sm">{card.name}</span>
+        {owned && (
+          <span className="ml-auto shrink-0 rounded px-1.5 py-0.5 text-[10px] font-semibold bg-green-900/60 text-green-400">
+            owned
+          </span>
+        )}
+      </header>
+
+      <div className="flex-1 overflow-y-auto p-3 space-y-4">
+        <div className="flex items-start gap-3">
+          {card.image ? (
+            <img src={card.image} alt="" className="h-14 w-14 rounded-xl object-cover shrink-0" />
+          ) : (
+            <div className="h-14 w-14 rounded-xl bg-zinc-800 shrink-0 flex items-center justify-center text-2xl">🔮</div>
+          )}
+          <div className="min-w-0">
+            <p className="text-sm text-zinc-300">{card.description}</p>
+            <div className="mt-1 flex flex-wrap gap-1.5 text-[11px]">
+              {card.category && <span className="bg-zinc-800 text-zinc-400 px-1.5 py-0.5 rounded">{card.category}</span>}
+              {card.hashtags?.map((h) => (
+                <span key={h} className="bg-zinc-800/60 text-zinc-500 px-1.5 py-0.5 rounded">#{h}</span>
+              ))}
+              {card.supply != null && <span className="text-zinc-600">↑{card.supply} holders</span>}
+            </div>
+          </div>
+        </div>
+
+        {skillText && (
+          <div className="rounded-lg bg-zinc-900 border border-zinc-800 p-3">
+            <p className="text-[11px] text-zinc-500 mb-1 uppercase tracking-wide">SKILL.md</p>
+            <pre className="text-xs text-zinc-300 whitespace-pre-wrap font-mono overflow-x-auto">{skillText}</pre>
+          </div>
+        )}
+
+        {Array.isArray(notes) && notes.length > 0 && (
+          <div className="space-y-2">
+            <p className="text-[11px] text-zinc-500 uppercase tracking-wide">Comments</p>
+            {(notes as any[]).map((n: any, i) => (
+              <div key={i} className="rounded-lg bg-zinc-900 border border-zinc-800 p-2.5 text-xs text-zinc-300">
+                <span className="font-mono text-zinc-600 text-[10px]">{n.author?.slice(0, 6)}…</span>
+                <p className="mt-0.5">{n.text}</p>
+              </div>
+            ))}
+          </div>
+        )}
+
+        {owned && (
+          <div className="space-y-1.5">
+            <p className="text-[11px] text-zinc-500 uppercase tracking-wide">Leave a comment</p>
+            <textarea
+              className="w-full rounded-lg bg-zinc-900 border border-zinc-800 p-2 text-xs text-zinc-200 resize-none focus:outline-none focus:border-green-500/50"
+              rows={3}
+              placeholder="Share your experience…"
+              value={noteText}
+              onChange={(e) => setNoteText(e.target.value)}
+            />
+            <button
+              onClick={handleNote}
+              disabled={!noteText.trim()}
+              className="text-xs px-3 py-1.5 rounded-lg bg-zinc-800 text-zinc-300 disabled:opacity-40 active:bg-zinc-700"
+            >
+              Post
+            </button>
+          </div>
+        )}
+      </div>
+
+      {!owned && (
+        <div className="shrink-0 border-t border-zinc-800 p-3 pb-[max(0.75rem,env(safe-area-inset-bottom))]">
+          <button
+            onClick={handleBuy}
+            disabled={buying}
+            className="w-full rounded-xl bg-green-600 py-3 text-sm font-semibold text-white active:bg-green-500 disabled:opacity-50"
+          >
+            {buying ? "Buying…" : priceSol ? `Buy for ${priceSol} SOL` : "Buy (free)"}
+          </button>
+        </div>
+      )}
+    </div>
+  );
+}

--- a/surfaces/webview/src/onboarding/ConnectGithub.tsx
+++ b/surfaces/webview/src/onboarding/ConnectGithub.tsx
@@ -1,0 +1,70 @@
+import { useEffect, useState } from "react";
+import { useStore } from "../state/store";
+import { OnboardingShell, OnboardingButton } from "./OnboardingShell";
+
+interface Props {
+  onDone: () => void;
+}
+
+export function ConnectGithub({ onDone }: Props) {
+  const { state, send } = useStore();
+  const [token, setToken] = useState("");
+  const [saving, setSaving] = useState(false);
+
+  // Fetch current status on mount
+  useEffect(() => {
+    send({ type: "getGithubStatus" });
+  }, []);
+
+  const status = state.githubStatus;
+
+  function save() {
+    if (!token.trim()) return;
+    setSaving(true);
+    send({ type: "submitGithubToken", token: token.trim() });
+    setTimeout(() => { setSaving(false); onDone(); }, 1200);
+  }
+
+  function clear() {
+    send({ type: "clearGithubToken" });
+    setToken("");
+  }
+
+  return (
+    <OnboardingShell
+      title="GitHub Token"
+      subtitle="Lets the agent push commits and sync sessions across devices via GitHub."
+    >
+      {status?.hasToken ? (
+        <div className="flex flex-col gap-3">
+          <div className="rounded-xl bg-zinc-900 px-3 py-3 text-sm text-zinc-300 ring-1 ring-zinc-800 font-mono">
+            {status.masked ?? "••••••••"}
+          </div>
+          <p className="text-xs text-green-400 text-center">✓ Token configured</p>
+          <OnboardingButton onClick={onDone}>Continue</OnboardingButton>
+          <OnboardingButton variant="outline" onClick={clear}>Remove Token</OnboardingButton>
+        </div>
+      ) : (
+        <div className="flex flex-col gap-3">
+          <p className="text-xs text-zinc-400 leading-relaxed">
+            Create a{" "}
+            <span className="text-zinc-200 font-medium">Personal Access Token</span> at GitHub with{" "}
+            <span className="text-zinc-200">repo</span> scope and paste it below.
+          </p>
+          <input
+            value={token}
+            onChange={(e) => setToken(e.target.value)}
+            onKeyDown={(e) => e.key === "Enter" && save()}
+            placeholder="ghp_…"
+            type="password"
+            className="rounded-xl bg-zinc-900 px-3 py-3 text-sm text-white outline-none ring-1 ring-zinc-800 focus:ring-[#00E673]/50 font-mono"
+          />
+          <OnboardingButton disabled={!token.trim() || saving} onClick={save}>
+            {saving ? "Saving…" : "Save Token"}
+          </OnboardingButton>
+          <OnboardingButton variant="outline" onClick={onDone}>Skip for now</OnboardingButton>
+        </div>
+      )}
+    </OnboardingShell>
+  );
+}

--- a/surfaces/webview/src/state/store.tsx
+++ b/surfaces/webview/src/state/store.tsx
@@ -81,6 +81,7 @@ export interface State {
   hasMore: boolean;
   cursor: number;
   toast: string | null;
+  buyCelebrate: boolean;
   contextTokens?: number;
   currentModel?: string;
   queuePending: number;
@@ -114,6 +115,7 @@ const initialState: State = {
   hasMore: false,
   cursor: 0,
   toast: null,
+  buyCelebrate: false,
   marketOpen: false,
   marketTab: "skill",
   marketQuery: "",
@@ -198,7 +200,8 @@ type LocalAction =
   | { type: "__loadingAgents" }
   | { type: "__clearAgentProfile" }
   | { type: "__changeMode"; mode: string }
-  | { type: "__clearFiringSkill" };
+  | { type: "__clearFiringSkill" }
+  | { type: "__clearCelebrate" };
 type Action = ServerMessage | LocalAction;
 
 function reducer(state: State, ev: Action): State {
@@ -339,7 +342,12 @@ function reducer(state: State, ev: Action): State {
     case "skillDetail":
       return { ...state, marketDetail: ev.detail };
     case "buyResult":
-      return { ...state, toast: ev.ok ? `Bought! Slug: ${ev.slug ?? ev.skillId}` : `Buy failed: ${ev.error ?? "unknown"}` };
+      return {
+        ...state,
+        toast: ev.ok ? `Bought! Slug: ${ev.slug ?? ev.skillId}` : `Buy failed: ${ev.error ?? "unknown"}`,
+        marketOwned: ev.ok ? [...state.marketOwned, ev.slug ?? ev.skillId] : state.marketOwned,
+        buyCelebrate: ev.ok ? true : state.buyCelebrate,
+      };
     case "ownedSkills":
       return { ...state, marketOwned: ev.names };
     case "balance":
@@ -378,6 +386,8 @@ function reducer(state: State, ev: Action): State {
       };
     case "__clearFiringSkill":
       return { ...state, firingSkill: null };
+    case "__clearCelebrate":
+      return { ...state, buyCelebrate: false };
     default:
       return state;
   }
@@ -404,6 +414,7 @@ interface Store {
   loadingAgents: () => void;
   clearAgentProfile: () => void;
   clearFiringSkill: () => void;
+  clearCelebrate: () => void;
 }
 
 const StoreContext = createContext<Store | null>(null);
@@ -501,6 +512,7 @@ export function StoreProvider({ children }: { children: ReactNode }) {
       loadingAgents: () => raw({ type: "__loadingAgents" }),
       clearAgentProfile: () => raw({ type: "__clearAgentProfile" }),
       clearFiringSkill: () => raw({ type: "__clearFiringSkill" }),
+      clearCelebrate: () => raw({ type: "__clearCelebrate" }),
     };
   }, [state]);
 

--- a/surfaces/webview/src/state/store.tsx
+++ b/surfaces/webview/src/state/store.tsx
@@ -14,15 +14,18 @@ import {
 } from "react";
 import { Transport } from "../transport/client";
 import type {
+  AgentProfile,
   ApprovalRequest,
   ChatMessage,
   Cli,
   ClientMessage,
+  ImageInput,
   ServerMessage,
   SessionMeta,
   SkillCard,
   SkillDetail,
   RpcStatus,
+  Reputation,
 } from "../transport/protocol";
 
 // A rendered log entry. We keep messages as-is and stream into the last assistant/
@@ -79,6 +82,13 @@ export interface State {
   cursor: number;
   toast: string | null;
   contextTokens?: number;
+  currentModel?: string;
+  queuePending: number;
+  agents: Reputation[];
+  agentProfile: AgentProfile | null;
+  agentsLoading: boolean;
+  githubStatus: { hasToken: boolean; masked?: string } | null;
+  modeByCli: Record<Cli, string>;
 }
 
 const initialState: State = {
@@ -116,11 +126,23 @@ const initialState: State = {
   rpcStatus: null,
   publishResult: null,
   firingSkill: null,
+  currentModel: undefined,
+  queuePending: 0,
+  agents: [],
+  agentProfile: null,
+  agentsLoading: false,
+  githubStatus: null,
+  modeByCli: {
+    claude: "acceptEdits",
+    codex: "auto",
+  },
 };
 
 // Append a streamed message: if the incoming partial continues the same role/cli as the
 // tail bubble, merge text into it; otherwise start a new bubble. A non-partial message is
 // a complete bubble (or a tool/summary/user entry) pushed as-is.
+// When server echoes a user message that matches a pending (_pending=true) optimistic bubble,
+// replace the pending one instead of appending — avoids duplicate user bubbles on queue flush.
 function appendMessage(log: ChatMessage[], msg: ChatMessage): ChatMessage[] {
   const tail = log[log.length - 1];
   const streamingInto =
@@ -133,6 +155,22 @@ function appendMessage(log: ChatMessage[], msg: ChatMessage): ChatMessage[] {
   if (streamingInto) {
     const merged: ChatMessage = { ...tail, ...msg, text: tail.text + msg.text };
     return [...log.slice(0, -1), merged];
+  }
+  // Server echoes user message → find and replace the matching pending bubble.
+  if (msg.role === "user" && !msg.partial) {
+    let pendingIdx = -1;
+    for (let i = log.length - 1; i >= 0; i--) {
+      const m = log[i];
+      if (m._pending && m.role === "user" && m.text === msg.text) {
+        pendingIdx = i;
+        break;
+      }
+    }
+    if (pendingIdx !== -1) {
+      const next = [...log];
+      next[pendingIdx] = msg; // replace pending with confirmed
+      return next;
+    }
   }
   return [...log, msg];
 }
@@ -153,7 +191,14 @@ type LocalAction =
   | { type: "__setMarketQuery"; query: string }
   | { type: "__marketSearching" }
   | { type: "__clearMarketDetail" }
-  | { type: "__clearPublishResult" };
+  | { type: "__clearPublishResult" }
+  | { type: "__modelChange"; model: string }
+  | { type: "__queueMsg"; text: string }
+  | { type: "__dequeueMsg" }
+  | { type: "__loadingAgents" }
+  | { type: "__clearAgentProfile" }
+  | { type: "__changeMode"; mode: string }
+  | { type: "__clearFiringSkill" };
 type Action = ServerMessage | LocalAction;
 
 function reducer(state: State, ev: Action): State {
@@ -272,6 +317,20 @@ function reducer(state: State, ev: Action): State {
       return { ...state, marketDetail: null };
     case "__clearPublishResult":
       return { ...state, publishResult: null };
+    case "__modelChange":
+      return {
+        ...state,
+        currentModel: ev.model,
+        log: [...state.log, { role: "summary" as const, text: `─── model: ${ev.model} ───` }],
+      };
+    case "__queueMsg":
+      return {
+        ...state,
+        queuePending: state.queuePending + 1,
+        log: [...state.log, { role: "user" as const, text: ev.text, _pending: true }],
+      };
+    case "__dequeueMsg":
+      return { ...state, queuePending: Math.max(0, state.queuePending - 1) };
     // ── market server events ──
     case "searchResults":
       return { ...state, marketResults: ev.results, marketSearching: false, marketSearchError: null };
@@ -294,11 +353,31 @@ function reducer(state: State, ev: Action): State {
     case "postNoteResult":
       return { ...state, toast: ev.ok ? "Comment posted." : `Comment failed: ${ev.error ?? "unknown"}` };
     case "agents":
+      return { ...state, agents: ev.agents as Reputation[], agentsLoading: false };
     case "agentProfile":
+      return { ...state, agentProfile: ev.profile };
     case "buyAllResult":
+      return { ...state, toast: ev.ok ? `Bought ${ev.bought} skills from agent.` : `Buy-all failed: ${ev.error ?? "unknown"}` };
     case "agentNoteResult":
+      return { ...state, toast: ev.ok ? "Note posted." : `Note failed: ${ev.error ?? "unknown"}` };
     case "notes":
       return state;
+    case "githubStatus":
+      return { ...state, githubStatus: { hasToken: ev.hasToken, masked: ev.masked } };
+    case "__loadingAgents":
+      return { ...state, agentsLoading: true };
+    case "__clearAgentProfile":
+      return { ...state, agentProfile: null };
+    case "__changeMode":
+      return {
+        ...state,
+        modeByCli: {
+          ...state.modeByCli,
+          [state.cli]: ev.mode,
+        },
+      };
+    case "__clearFiringSkill":
+      return { ...state, firingSkill: null };
     default:
       return state;
   }
@@ -321,6 +400,10 @@ interface Store {
   marketSearching: () => void;
   clearMarketDetail: () => void;
   clearPublishResult: () => void;
+  queueCount: number;
+  loadingAgents: () => void;
+  clearAgentProfile: () => void;
+  clearFiringSkill: () => void;
 }
 
 const StoreContext = createContext<Store | null>(null);
@@ -328,6 +411,8 @@ const StoreContext = createContext<Store | null>(null);
 export function StoreProvider({ children }: { children: ReactNode }) {
   const [state, raw] = useReducer(reducer, initialState);
   const transportRef = useRef<Transport | null>(null);
+  const msgQueue = useRef<{ text: string; images?: ImageInput[] }[]>([]);
+  const busyRef = useRef(false);
 
   useEffect(() => {
     const t = new Transport();
@@ -340,6 +425,19 @@ export function StoreProvider({ children }: { children: ReactNode }) {
       t.close();
     };
   }, []);
+
+  // Keep busyRef in sync so send() (stable closure) can read current busy state.
+  useEffect(() => { busyRef.current = state.typing; }, [state.typing]);
+
+  // Flush queued messages when agent becomes free.
+  useEffect(() => {
+    if (!state.typing && msgQueue.current.length > 0) {
+      const next = msgQueue.current.shift()!;
+      raw({ type: "__dequeueMsg" });
+      raw({ type: "__typing" });
+      void transportRef.current?.post({ type: "send", text: next.text, images: next.images });
+    }
+  }, [state.typing]);
 
   // When onboarding completes (phase enters "chat"), the first SSE stream is still bound
   // to the server's ONBOARDING handler — which ignores chat messages. Reopen the stream so
@@ -363,8 +461,22 @@ export function StoreProvider({ children }: { children: ReactNode }) {
 
   const store = useMemo<Store>(() => {
     const send = (msg: ClientMessage) => {
-      // Optimistically show typing dots on send; core's turnEnd clears them.
-      if (msg.type === "send") raw({ type: "__typing" });
+      if (msg.type === "send") {
+        if (busyRef.current) {
+          // Agent busy — show pending bubble immediately, flush when turn ends.
+          msgQueue.current.push({ text: msg.text, images: msg.images });
+          raw({ type: "__queueMsg", text: msg.text });
+          return;
+        }
+        raw({ type: "__typing" });
+      }
+      // Inject inline model-switch separator into chat log.
+      if (msg.type === "model" && msg.model) {
+        raw({ type: "__modelChange", model: msg.model });
+      }
+      if (msg.type === "mode" && typeof msg.mode === "string") {
+        raw({ type: "__changeMode", mode: msg.mode });
+      }
       void transportRef.current?.post(msg);
     };
     return {
@@ -385,6 +497,10 @@ export function StoreProvider({ children }: { children: ReactNode }) {
       marketSearching: () => raw({ type: "__marketSearching" }),
       clearMarketDetail: () => raw({ type: "__clearMarketDetail" }),
       clearPublishResult: () => raw({ type: "__clearPublishResult" }),
+      queueCount: state.queuePending,
+      loadingAgents: () => raw({ type: "__loadingAgents" }),
+      clearAgentProfile: () => raw({ type: "__clearAgentProfile" }),
+      clearFiringSkill: () => raw({ type: "__clearFiringSkill" }),
     };
   }, [state]);
 

--- a/surfaces/webview/src/state/store.tsx
+++ b/surfaces/webview/src/state/store.tsx
@@ -20,6 +20,9 @@ import type {
   ClientMessage,
   ServerMessage,
   SessionMeta,
+  SkillCard,
+  SkillDetail,
+  RpcStatus,
 } from "../transport/protocol";
 
 // A rendered log entry. We keep messages as-is and stream into the last assistant/
@@ -35,6 +38,19 @@ export interface State {
     | "claudeAuth"
     | "codexAuth"
     | "chat";
+  // market overlay (accessible from chat phase via "Markets" button)
+  marketOpen: boolean;
+  marketTab: "skill" | "workflow";
+  marketQuery: string;
+  marketResults: SkillCard[] | null;
+  marketSearching: boolean;
+  marketSearchError: string | null;
+  marketDetail: SkillDetail | null;
+  marketOwned: string[];
+  marketBalance: number | null;
+  rpcStatus: RpcStatus | null;
+  publishResult: { ok: boolean; mint?: string; error?: string } | null;
+  firingSkill: string | null; // currently casting skill name (god-mode glow)
   walletAddress: string | null;
   cli: Cli;
   googleLoginUrl: string | null;
@@ -88,6 +104,18 @@ const initialState: State = {
   hasMore: false,
   cursor: 0,
   toast: null,
+  marketOpen: false,
+  marketTab: "skill",
+  marketQuery: "",
+  marketResults: null,
+  marketSearching: false,
+  marketSearchError: null,
+  marketDetail: null,
+  marketOwned: [],
+  marketBalance: null,
+  rpcStatus: null,
+  publishResult: null,
+  firingSkill: null,
 };
 
 // Append a streamed message: if the incoming partial continues the same role/cli as the
@@ -117,7 +145,15 @@ type LocalAction =
   | { type: "__removeApproval"; id: string }
   | { type: "__clearToast" }
   | { type: "__selectEngine"; cli: Cli }
-  | { type: "__finishStorage" };
+  | { type: "__finishStorage" }
+  | { type: "__savePlan"; text: string }
+  | { type: "__openMarket" }
+  | { type: "__closeMarket" }
+  | { type: "__setMarketTab"; tab: "skill" | "workflow" }
+  | { type: "__setMarketQuery"; query: string }
+  | { type: "__marketSearching" }
+  | { type: "__clearMarketDetail" }
+  | { type: "__clearPublishResult" };
 type Action = ServerMessage | LocalAction;
 
 function reducer(state: State, ev: Action): State {
@@ -219,6 +255,50 @@ function reducer(state: State, ev: Action): State {
       return { ...state, approvals: [ev.req, ...state.approvals] };
     case "toast":
       return { ...state, toast: ev.text };
+    // ── market local actions ──
+    case "__savePlan":
+      return { ...state, log: [...state.log, { role: "summary" as const, text: `📋 Saved plan\n\n${ev.text}` }] };
+    case "__openMarket":
+      return { ...state, marketOpen: true };
+    case "__closeMarket":
+      return { ...state, marketOpen: false, marketDetail: null, publishResult: null };
+    case "__setMarketTab":
+      return { ...state, marketTab: ev.tab, marketResults: null, marketDetail: null };
+    case "__setMarketQuery":
+      return { ...state, marketQuery: ev.query };
+    case "__marketSearching":
+      return { ...state, marketSearching: true, marketSearchError: null };
+    case "__clearMarketDetail":
+      return { ...state, marketDetail: null };
+    case "__clearPublishResult":
+      return { ...state, publishResult: null };
+    // ── market server events ──
+    case "searchResults":
+      return { ...state, marketResults: ev.results, marketSearching: false, marketSearchError: null };
+    case "searchError":
+      return { ...state, marketSearching: false, marketSearchError: ev.message };
+    case "skillDetail":
+      return { ...state, marketDetail: ev.detail };
+    case "buyResult":
+      return { ...state, toast: ev.ok ? `Bought! Slug: ${ev.slug ?? ev.skillId}` : `Buy failed: ${ev.error ?? "unknown"}` };
+    case "ownedSkills":
+      return { ...state, marketOwned: ev.names };
+    case "balance":
+      return { ...state, marketBalance: ev.lamports };
+    case "rpcStatus":
+      return { ...state, rpcStatus: ev.status };
+    case "skillActive":
+      return { ...state, firingSkill: ev.name };
+    case "publishResult":
+      return { ...state, publishResult: ev };
+    case "postNoteResult":
+      return { ...state, toast: ev.ok ? "Comment posted." : `Comment failed: ${ev.error ?? "unknown"}` };
+    case "agents":
+    case "agentProfile":
+    case "buyAllResult":
+    case "agentNoteResult":
+    case "notes":
+      return state;
     default:
       return state;
   }
@@ -233,6 +313,14 @@ interface Store {
   clearToast: () => void;
   selectEngine: (cli: Cli) => void;
   finishStorage: () => void;
+  savePlan: (text: string) => void;
+  openMarket: () => void;
+  closeMarket: () => void;
+  setMarketTab: (tab: "skill" | "workflow") => void;
+  setMarketQuery: (q: string) => void;
+  marketSearching: () => void;
+  clearMarketDetail: () => void;
+  clearPublishResult: () => void;
 }
 
 const StoreContext = createContext<Store | null>(null);
@@ -289,6 +377,14 @@ export function StoreProvider({ children }: { children: ReactNode }) {
       // Activate the chosen engine; routing (login gate / chat) is decided in the reducer.
       selectEngine: (cli) => raw({ type: "__selectEngine", cli }),
       finishStorage: () => raw({ type: "__finishStorage" }),
+      savePlan: (text) => raw({ type: "__savePlan", text }),
+      openMarket: () => raw({ type: "__openMarket" }),
+      closeMarket: () => raw({ type: "__closeMarket" }),
+      setMarketTab: (tab) => raw({ type: "__setMarketTab", tab }),
+      setMarketQuery: (query) => raw({ type: "__setMarketQuery", query }),
+      marketSearching: () => raw({ type: "__marketSearching" }),
+      clearMarketDetail: () => raw({ type: "__clearMarketDetail" }),
+      clearPublishResult: () => raw({ type: "__clearPublishResult" }),
     };
   }, [state]);
 

--- a/surfaces/webview/src/transport/protocol.ts
+++ b/surfaces/webview/src/transport/protocol.ts
@@ -6,7 +6,7 @@
 
 // Market types are defined once in packages/core and re-exported here so every surface
 // that imports from this file gets compile-time checking on the market message contract.
-export type { SkillCard, SkillDetail, MarketRequest, MarketEvent, RpcStatus, AgentProfile } from "@iqlabs-official/agent-sdk";
+export type { SkillCard, SkillDetail, MarketRequest, MarketEvent, RpcStatus, AgentProfile, Reputation } from "@iqlabs-official/agent-sdk";
 
 // ── shared payload shapes ──
 
@@ -27,6 +27,7 @@ export interface ChatMessage {
     file?: string;
     diff?: string;
   };
+  _pending?: true; // local-only: queued user message shown optimistically, replaced on server echo
 }
 
 export interface SessionMeta {
@@ -140,7 +141,10 @@ export type ClientMessage =
       hashtags?: string[];
       priceSol: string;
       image?: string;
-    };
+    }
+  | { type: "submitGithubToken"; token: string }
+  | { type: "clearGithubToken" }
+  | { type: "getGithubStatus" };
 
 // ── server → UI (SSE /events) ──
 
@@ -191,4 +195,5 @@ export type ServerMessage =
   | { type: "agentProfile"; profile: import("@iqlabs-official/agent-sdk").AgentProfile }
   | { type: "buyAllResult"; wallet: string; ok: boolean; bought: number; failed: number; error?: string }
   | { type: "agentNoteResult"; agentWallet: string; ok: boolean; error?: string }
-  | { type: "publishResult"; ok: boolean; mint?: string; error?: string };
+  | { type: "publishResult"; ok: boolean; mint?: string; error?: string }
+  | { type: "githubStatus"; hasToken: boolean; masked?: string };

--- a/surfaces/webview/src/transport/protocol.ts
+++ b/surfaces/webview/src/transport/protocol.ts
@@ -4,6 +4,10 @@
 // webview already speaks — this surface is a second client of the SAME protocol, not a
 // new one. Keep these in sync with packages/core/src/chat/session.ts.
 
+// Market types are defined once in packages/core and re-exported here so every surface
+// that imports from this file gets compile-time checking on the market message contract.
+export type { SkillCard, SkillDetail, MarketRequest, MarketEvent, RpcStatus, AgentProfile } from "@iqlabs-official/agent-sdk";
+
 // ── shared payload shapes ──
 
 export type Cli = "claude" | "codex";
@@ -112,7 +116,31 @@ export type ClientMessage =
   | { type: "googleAuthCode"; code: string }
   | { type: "cancelGoogleLogin" }
   | { type: "setGoogleCredentials"; clientId: string; clientSecret: string }
-  | { type: "toast"; text: string };
+  | { type: "toast"; text: string }
+  // ── market (UI→server) ──
+  | { type: "searchSkills"; query: string; kind?: "skill" | "workflow" }
+  | { type: "getSkillDetail"; mint: string }
+  | { type: "buySkill"; skillId: string; creatorWallet?: string }
+  | { type: "ownedSkills" }
+  | { type: "getBalance" }
+  | { type: "getRpcStatus" }
+  | { type: "submitHeliusKey"; key: string }
+  | { type: "useDefaultRpc" }
+  | { type: "listAgents" }
+  | { type: "getAgentProfile"; wallet: string }
+  | { type: "buyAllSkills"; wallet: string }
+  | { type: "postNote"; skillId: string; skillType?: "skill" | "workflow"; text: string; gitLink?: string }
+  | { type: "postAgentNote"; agentWallet: string; text: string; gitLink?: string }
+  | {
+      type: "publishSkill";
+      name: string;
+      description: string;
+      text: string;
+      category?: string;
+      hashtags?: string[];
+      priceSol: string;
+      image?: string;
+    };
 
 // ── server → UI (SSE /events) ──
 
@@ -147,4 +175,20 @@ export type ServerMessage =
   // result of saving user-supplied Google OAuth client credentials (setGoogleCredentials).
   | { type: "googleCredsStatus"; status: "saved" | "error"; error?: string }
   | { type: "openUrl"; url: string }
-  | { type: "toast"; text: string };
+  | { type: "toast"; text: string }
+  // ── market (server→UI) ──
+  | { type: "searchResults"; results: import("@iqlabs-official/agent-sdk").SkillCard[] }
+  | { type: "searchError"; message: string }
+  | { type: "skillDetail"; detail: import("@iqlabs-official/agent-sdk").SkillDetail }
+  | { type: "buyResult"; skillId: string; ok: boolean; slug?: string; error?: string }
+  | { type: "ownedSkills"; names: string[]; mints?: Record<string, string> }
+  | { type: "balance"; lamports: number | null }
+  | { type: "skillActive"; name: string }
+  | { type: "rpcStatus"; status: import("@iqlabs-official/agent-sdk").RpcStatus }
+  | { type: "postNoteResult"; skillId: string; ok: boolean; error?: string }
+  | { type: "notes"; skillId: string; notes: unknown[] }
+  | { type: "agents"; agents: unknown[] }
+  | { type: "agentProfile"; profile: import("@iqlabs-official/agent-sdk").AgentProfile }
+  | { type: "buyAllResult"; wallet: string; ok: boolean; bought: number; failed: number; error?: string }
+  | { type: "agentNoteResult"; agentWallet: string; ok: boolean; error?: string }
+  | { type: "publishResult"; ok: boolean; mint?: string; error?: string };


### PR DESCRIPTION
## Summary

- **Skill marketplace** — search/filter by keyword, skill/workflow tabs, card grid with SOL price + supply
- **Buy flow** — on-chain price enforced server-side (client sends `skillId` only), button flips to Owned immediately on success, purchase celebration animation
- **Publish form** — full metadata form, image upload, mints NFT via PDA-signed collection enrollment
- **Agent directory + profile** — browse agents, view owned skills, buy-all support
- **Holder-gated comments** — comment input only renders when `owned=true`
- **GitHub connect** — PAT entry with `repo` scope, masked display
- **Helius RPC onboarding** — amber nudge when no key, key storage + masked display, network/key status badge
- **Permission mode sync** — `modeByCli` moved from local Composer state to global store; server-pushed mode changes now reflected in UI without round-trip lag

## Backend work still needed (out of scope for this branch)

- **Publish via MCP agent** — `/publish` tool call flow from agent side
- **Agent comments via MCP** — holder-gated write path through MCP tool
- **Cross-device session sync** — storage backend for multi-device state