### PR TITLE
fix(skill-market): share buy+equip path across UI + agent, fix agent RPC source

### DIFF
--- a/packages/core/src/runtime/index.ts
+++ b/packages/core/src/runtime/index.ts
@@ -12,6 +12,7 @@ import { MemorySync, updateSkillsSection } from "../memory/index.js";
 import { getSkillShopping } from "../account/login.js";
 import { setSkillShoppingActive } from "../skill-market/passive.js";
 import { createAgentSdkMcpServer, newVerifyGuard } from "../skill-market/index.js";
+import { resolveRpcUrl, hasDasRpc } from "../core/rpc.js";
 import { getCodexApiKey } from "../account/codexAuth.js";
 import type { ApprovalChannel } from "./approval/channel.js";
 import type {
@@ -55,11 +56,13 @@ async function buildPassiveSpawn(
   if (!on || cli === "codex") return {};
 
   // Claude + ON: wire the marketplace MCP tools (search → verify → buy) with a per-spawn
-  // verify guard. Needs a DAS-capable RPC; without one the tools can't read the market, so
-  // leave them off (the skill is present but inert) rather than wire dead tools.
-  const rpcUrl = process.env.DAS_RPC_URL || process.env.SOLANA_RPC_URL;
-  if (!rpcUrl) return {};
-  const conn = new Connection(rpcUrl, "confirmed");
+  // verify guard. Use the SAME RPC resolution as the rest of the app (resolveRpcUrl: a
+  // stored Helius key — probed for liveness — beats env beats the public default), so a key
+  // set in the UI powers the agent's tools too, not just env vars. Still gate on hasDasRpc:
+  // without a key or explicit env RPC the catalog read (search_skills) is empty, so leave
+  // the tools off rather than wire a market the agent can't read.
+  if (!(await hasDasRpc())) return {};
+  const conn = new Connection(await resolveRpcUrl(), "confirmed");
   const server = createAgentSdkMcpServer(conn, wallet, wallet.address, newVerifyGuard());
   return { mcpServers: { "agentnet-marketplace": server }, allowedTools: MARKET_TOOLS };
 }

--- a/packages/core/src/skill-market/index.spec.ts
+++ b/packages/core/src/skill-market/index.spec.ts
@@ -3,12 +3,12 @@ import { getAgentNetTools, handleToolCall, newVerifyGuard } from "./index.js";
 import { searchSkills } from "../search/search.js";
 import { buySkill, publishSkill } from "../nft/skill.js";
 import { postNote, postAgentNote } from "../notes/notes.js";
-import { readSkillText } from "../nft/token2022.js";
+import { readSkillText, readSkillMintMetadata } from "../nft/token2022.js";
 import { Keypair } from "@solana/web3.js";
 
 vi.mock("../search/search.js", () => ({ searchSkills: vi.fn() }));
 vi.mock("../nft/skill.js", () => ({ buySkill: vi.fn(), publishSkill: vi.fn() }));
-vi.mock("../nft/token2022.js", () => ({ readSkillText: vi.fn() }));
+vi.mock("../nft/token2022.js", () => ({ readSkillText: vi.fn(), readSkillMintMetadata: vi.fn() }));
 vi.mock("../notes/notes.js", () => ({
   postNote: vi.fn(),
   postAgentNote: vi.fn(),
@@ -89,8 +89,10 @@ describe("skill-market", () => {
   it("should handle buy_skill tool call", async () => {
     vi.mocked(buySkill).mockResolvedValue("mockTxSig");
     const result = await handleToolCall(mockConn, signer, "defaultCreator", "buy_skill", { skillId: "skill1" });
-    expect(result.content[0].text).toContain("Successfully purchased");
+    expect(result.content[0].text).toContain("Purchased skill");
     expect(result.content[0].text).toContain("mockTxSig");
+    // buy now also equips: it reads the mint's metadata to install the SKILL.md.
+    expect(readSkillMintMetadata).toHaveBeenCalled();
     // Price is read from the item's on-chain config now — the client doesn't pass it.
     expect(buySkill).toHaveBeenCalledWith(mockConn, signer, {
       skillId: "skill1",
@@ -183,7 +185,7 @@ describe("skill-market", () => {
     expect(guard.isVerified("skill1")).toBe(true);
 
     const bought = await handleToolCall(mockConn, signer, "defaultCreator", "buy_skill", { skillId: "skill1" }, guard);
-    expect(bought.content[0].text).toContain("Successfully purchased");
+    expect(bought.content[0].text).toContain("Purchased skill");
     expect(buySkill).toHaveBeenCalledTimes(1);
   });
 

--- a/packages/core/src/skill-market/index.ts
+++ b/packages/core/src/skill-market/index.ts
@@ -26,9 +26,9 @@ import { z } from "zod";
 import type { Connection } from "@solana/web3.js";
 import type { SignerInput } from "@iqlabs-official/solana-sdk/utils";
 import { searchSkills } from "../search/search.js";
-import { buySkill, publishSkill } from "../nft/skill.js";
+import { publishSkill } from "../nft/skill.js";
 import { readSkillText } from "../nft/token2022.js";
-import { signerAddress } from "../core/chain.js";
+import { SkillSync } from "./ingest/index.js";
 import { postNote, postAgentNote } from "../notes/notes.js";
 import { getSkillsCollectionMint, getWorkflowsCollectionMint } from "../core/seed.js";
 import { scanSkillText } from "./scan.js";
@@ -258,12 +258,15 @@ export async function handleToolCall(
     }
 
     // Price is read from the item's on-chain config (set at publish) — the client doesn't
-    // pass it, so it can't be forged.
+    // pass it, so it can't be forged. buyAndEquip is the SAME buy+install path the human UI
+    // uses, so the agent's purchase is actually equipped (SKILL.md written), not just owned.
     const creatorWallet = (args?.creatorWallet as string) || defaultCreatorWallet;
-    const buyerWallet = await signerAddress(signer);
     try {
-      const txSig = await buySkill(conn, signer, { skillId, buyerWallet, creatorWallet });
-      return { content: [{ type: "text", text: `Successfully purchased and equipped skill ${skillId}.\nTransaction Signature: ${txSig}` }] };
+      const { txSig, slug } = await new SkillSync(conn).buyAndEquip(signer, skillId, creatorWallet);
+      const where = slug
+        ? ` and equipped it as "${slug}" (usable now)`
+        : " (purchase landed; its SKILL.md will install once the mint metadata is readable)";
+      return { content: [{ type: "text", text: `Purchased skill ${skillId}${where}.\nTransaction Signature: ${txSig}` }] };
     } catch (err: any) {
       return { isError: true, content: [{ type: "text", text: `Failed to buy skill: ${err.message}` }] };
     }

--- a/packages/core/src/skill-market/ingest/env.ts
+++ b/packages/core/src/skill-market/ingest/env.ts
@@ -141,10 +141,9 @@ export async function marketplaceEnv(wallet: Wallet) {
     // program pays the creator on a priced buy. Falls back to the buyer if absent.
     async buySkill(skillId: string, creatorWallet?: string) {
       try {
-        await buySkill(conn, wallet, {
-          skillId, buyerWallet: wallet.address, creatorWallet: creatorWallet || wallet.address,
-        });
-        const slug = await skills.installBoughtAll(skillId); // equip: drop SKILL.md into skills dirs
+        // buy on-chain + equip (install SKILL.md) in one shared call — the SAME path the
+        // agent's buy_skill MCP tool uses, so a UI buy and an agent buy equip identically.
+        const { slug } = await skills.buyAndEquip(wallet, skillId, creatorWallet || wallet.address);
         return { ok: true, slug: slug ?? undefined };
       } catch (e) {
         return { ok: false, error: e instanceof Error ? e.message : String(e) };

--- a/packages/core/src/skill-market/ingest/index.ts
+++ b/packages/core/src/skill-market/ingest/index.ts
@@ -4,16 +4,19 @@
 // runtime discovers it and loads the body on demand (last30days pattern — see
 // plans/skill-ingestion.md §3, §8a).
 //
-// Trigger THIS PR: "I bought a skill in the marketplace" → installBought(). Reading a
-// wallet's whole owned set at session start, the agent's own search-and-buy, and the
-// passive verify gate are deliberately out of scope (next PR).
+// buyAndEquip() is the shared "buy on-chain + equip locally" path used by BOTH the human
+// marketplace UI (marketplaceEnv.buySkill) and the agent's buy_skill MCP tool, so a
+// purchase equips identically however it was triggered.
 
 import { access, rm, writeFile } from "node:fs/promises";
 import { join } from "node:path";
 import type { Connection } from "@solana/web3.js";
+import type { SignerInput } from "@iqlabs-official/solana-sdk/utils";
 import { claudeSkillsDir, codexSkillsDir, ensureDir } from "../../core/paths.js";
 import { readSkillMintMetadata } from "../../nft/token2022.js";
 import { ownedSkillMints } from "../../core/skillSource.js";
+import { buySkill } from "../../nft/skill.js";
+import { signerAddress } from "../../core/chain.js";
 import { recordNftSkill, forgetNftSkill } from "../registry.js";
 import { toSkillMd, skillSlug } from "./convert.js";
 
@@ -54,6 +57,27 @@ export class SkillSync {
       this.installBought("codex", skillMint),
     ]);
     return slug;
+  }
+
+  /**
+   * Buy a skill on-chain AND equip it (write its SKILL.md into both runtimes' skills dirs)
+   * in one call — the single source of truth for "a purchase = owned + usable now". Shared
+   * by the human marketplace UI and the agent's buy_skill MCP tool so both paths equip
+   * identically. Returns the buy tx signature and the installed slug (slug is null when the
+   * mint has no readable metadata to install — the on-chain purchase still succeeded).
+   */
+  async buyAndEquip(
+    signer: SignerInput,
+    skillId: string,
+    creatorWallet: string,
+  ): Promise<{ txSig: string; slug: string | null }> {
+    const buyerWallet = await signerAddress(signer);
+    const txSig = await buySkill(this.conn, signer, { skillId, buyerWallet, creatorWallet });
+    // Equip is best-effort: the purchase already landed on-chain (irreversible), so a
+    // content/fs hiccup during install must NOT surface as a failed buy — that could
+    // prompt a costly re-buy. slug=null just means "owned, equips on the next owned-sync".
+    const slug = await this.installBoughtAll(skillId).catch(() => null);
+    return { txSig, slug };
   }
 
   /**


### PR DESCRIPTION
## Problem

Yesterday's good buy path (`marketplaceEnv.buySkill`) does **buy on-chain + equip** (install the SKILL.md so the skill is usable). The agent's autonomous **\"Shop for me\"** path only reused *half* of it:

1. **No equip.** `buy_skill` MCP tool bought the skill on-chain but never installed the SKILL.md — so an agent-bought skill was **not usable in the same session**, and the tool's `"...purchased and equipped"` message was a lie. Only the human UI path equipped.
2. **Wrong RPC source.** `buildPassiveSpawn` wired the agent's marketplace tools off raw `process.env.DAS_RPC_URL/SOLANA_RPC_URL`, **ignoring a Helius key set in the UI** (every other read site uses `resolveRpcUrl`). So the tools often didn't wire at all.

## Fix

- **`SkillSync.buyAndEquip()`** — one shared *\"buy on-chain + install SKILL.md\"* path. Both the marketplace UI (`env.buySkill`) and the agent's `buy_skill` MCP handler now call it, so a purchase equips **identically** however it was triggered. Install is **best-effort**: the irreversible on-chain purchase must never report as failed (which could trigger a costly re-buy) just because a content/fs hiccup blocked the local install.
- **`buildPassiveSpawn`** — resolve the RPC via `resolveRpcUrl()` / `hasDasRpc()` like the rest of the app, so a UI-set (liveness-probed, per the just-landed `7c93383`) Helius key powers the agent tools too, not just env vars.

## Tests

`tsc --noEmit` clean; full core suite **276 pass**. Updated `index.spec.ts` to cover that `buy_skill` now reads the mint metadata to equip.

🤖 Generated with [Claude Code](https://claude.com/claude-code)