### PR TITLE
Implement slash command parity in webview

### DIFF
--- a/packages/core/src/chat/session.spec.ts
+++ b/packages/core/src/chat/session.spec.ts
@@ -5,6 +5,9 @@
 // send carrying the live sessionId so the turn finishes and the new mode applies next.
 import { describe, it, expect, vi } from "vitest";
 import { createChatSession } from "./session.js";
+import { mkdtemp, readFile, rm } from "node:fs/promises";
+import { join } from "node:path";
+import { tmpdir } from "node:os";
 
 function fakeHandle(id: string, cli: "claude" | "codex") {
   const usageCbs: Array<(n: number) => void> = [];
@@ -29,7 +32,7 @@ const flush = async () => {
   await new Promise((r) => setTimeout(r, 0));
 };
 
-function harness() {
+function harness(opts: { cwd?: string; ownedSkills?: string[] } = {}) {
   const handles: ReturnType<typeof fakeHandle>[] = [];
   const startSession = vi.fn(async (opts: any) => {
     const h = fakeHandle("sess-" + handles.length, opts.cli);
@@ -41,10 +44,11 @@ function harness() {
   const transport = { send: vi.fn(), onRecv: (cb: (m: any) => void) => recv.push(cb) };
   const fromUI = (m: any) => recv.forEach((cb) => cb(m));
   const env: any = {
-    cwd: () => "/tmp",
+    cwd: () => opts.cwd ?? "/tmp",
     approval: { onDecision: () => {}, request: async () => "deny" },
     walletAddress: () => null,
     storageInfo: async () => ({ info: {}, options: [] }),
+    ownedSkills: opts.ownedSkills ? async () => opts.ownedSkills : undefined,
   };
   const chat = createChatSession(startSessionRuntime(startSession), transport as any, env);
   return { handles, startSession, fromUI, chat, transport };
@@ -189,5 +193,77 @@ describe("chat/session — slash commands", () => {
     await flush();
     expect(transport.send).toHaveBeenCalledWith({ type: "sessions", list: [], activeId: undefined });
     expect(transport.send).toHaveBeenCalledWith({ type: "notice", text: "Resume: open a session from History." });
+  });
+
+  it("aliases /cost to the same status payload", async () => {
+    const { handles, fromUI, transport } = harness();
+
+    fromUI({ type: "send", text: "hi" });
+    await flush();
+    handles[0].emitUsage(77);
+
+    fromUI({ type: "slashCommand", command: "cost" });
+    await flush();
+    expect(transport.send).toHaveBeenCalledWith(expect.objectContaining({
+      type: "status",
+      status: expect.objectContaining({ contextTokens: 77 }),
+    }));
+  });
+
+  it("/permissions reports current mode and available modes", async () => {
+    const { fromUI, transport } = harness();
+
+    fromUI({ type: "slashCommand", command: "permissions" });
+    await flush();
+    expect(transport.send).toHaveBeenCalledWith({
+      type: "notice",
+      text: expect.stringContaining("Current permission mode: acceptEdits"),
+    });
+  });
+
+  it("/skills refreshes owned skills", async () => {
+    const { fromUI, transport } = harness({ ownedSkills: ["clean-code"] });
+
+    fromUI({ type: "slashCommand", command: "skills" });
+    await flush();
+    expect(transport.send).toHaveBeenCalledWith({
+      type: "ownedSkills",
+      names: ["clean-code"],
+      mints: {},
+      disposedMints: {},
+    });
+  });
+
+  it("/review and /mcp route to the active engine handle", async () => {
+    const { handles, fromUI } = harness();
+
+    fromUI({ type: "slashCommand", command: "review", arg: "security" });
+    await flush();
+    expect(handles[0].runSlashCommand).toHaveBeenCalledWith("review", "security");
+
+    fromUI({ type: "slashCommand", command: "mcp" });
+    await flush();
+    expect(handles[0].runSlashCommand).toHaveBeenCalledWith("mcp", undefined);
+  });
+
+  it("/init creates CLAUDE.md for Claude and AGENTS.md for Codex", async () => {
+    const cwd = await mkdtemp(join(tmpdir(), "agentnet-init-"));
+    try {
+      const { fromUI, transport } = harness({ cwd });
+
+      fromUI({ type: "slashCommand", command: "init" });
+      await flush();
+      await expect(readFile(join(cwd, "CLAUDE.md"), "utf8")).resolves.toContain("Project instructions for Claude Code.");
+      expect(transport.send).toHaveBeenCalledWith({ type: "notice", text: "Created CLAUDE.md." });
+
+      fromUI({ type: "platform", cli: "codex" });
+      await flush();
+      fromUI({ type: "slashCommand", command: "init" });
+      await flush();
+      await expect(readFile(join(cwd, "AGENTS.md"), "utf8")).resolves.toContain("Project instructions for Codex.");
+      expect(transport.send).toHaveBeenCalledWith({ type: "notice", text: "Created AGENTS.md." });
+    } finally {
+      await rm(cwd, { recursive: true, force: true });
+    }
   });
 });

--- a/packages/core/src/chat/session.spec.ts
+++ b/packages/core/src/chat/session.spec.ts
@@ -7,14 +7,18 @@ import { describe, it, expect, vi } from "vitest";
 import { createChatSession } from "./session.js";
 
 function fakeHandle(id: string, cli: "claude" | "codex") {
+  const usageCbs: Array<(n: number) => void> = [];
   return {
     sessionId: id,
     cli,
     send: vi.fn(),
+    runSlashCommand: vi.fn(),
     onMessage: vi.fn(),
     onTurnEnd: vi.fn(),
     onSkill: vi.fn(),
-    onUsage: vi.fn(),
+    onUsage: vi.fn((cb: (n: number) => void) => usageCbs.push(cb)),
+    emitUsage: (n: number) => usageCbs.forEach((cb) => cb(n)),
+    interrupt: vi.fn(),
     stop: vi.fn(),
   };
 }
@@ -126,5 +130,64 @@ describe("chat/session — image attachments pass through to the engine", () => 
     fromUI({ type: "send", text: "", images: [] });
     await flush();
     expect(startSession).not.toHaveBeenCalled();
+  });
+});
+
+describe("chat/session — slash commands", () => {
+  it("routes /compact and /diff to the active engine handle", async () => {
+    const { handles, fromUI } = harness();
+
+    fromUI({ type: "slashCommand", command: "compact", arg: "repo state" });
+    await flush();
+    expect(handles[0].runSlashCommand).toHaveBeenCalledWith("compact", "repo state");
+
+    fromUI({ type: "slashCommand", command: "diff" });
+    await flush();
+    expect(handles[0].runSlashCommand).toHaveBeenCalledWith("diff");
+  });
+
+  it("/clear resets the active context without spawning an engine turn", async () => {
+    const { handles, startSession, fromUI, transport } = harness();
+
+    fromUI({ type: "send", text: "hi" });
+    await flush();
+    expect(startSession).toHaveBeenCalledTimes(1);
+
+    fromUI({ type: "clear" });
+    await flush();
+    expect(handles[0].stop).toHaveBeenCalledTimes(1);
+    expect(startSession).toHaveBeenCalledTimes(1);
+    expect(transport.send).toHaveBeenCalledWith({ type: "clear" });
+  });
+
+  it("/status surfaces active engine, session, config, and last usage", async () => {
+    const { handles, fromUI, transport } = harness();
+
+    fromUI({ type: "send", text: "hi" });
+    await flush();
+    handles[0].emitUsage(1234);
+
+    fromUI({ type: "slashCommand", command: "status" });
+    await flush();
+    expect(transport.send).toHaveBeenCalledWith({
+      type: "status",
+      status: {
+        cli: "claude",
+        sessionId: "sess-0",
+        model: "default",
+        mode: "acceptEdits",
+        effort: "default",
+        contextTokens: 1234,
+      },
+    });
+  });
+
+  it("/resume refreshes sessions and gives a visible instruction", async () => {
+    const { fromUI, transport } = harness();
+
+    fromUI({ type: "slashCommand", command: "resume" });
+    await flush();
+    expect(transport.send).toHaveBeenCalledWith({ type: "sessions", list: [], activeId: undefined });
+    expect(transport.send).toHaveBeenCalledWith({ type: "notice", text: "Resume: open a session from History." });
   });
 });

--- a/packages/core/src/chat/session.ts
+++ b/packages/core/src/chat/session.ts
@@ -14,6 +14,8 @@
 import type { AgentRuntime, SessionHandle } from "../runtime/contract.js";
 import type { ApprovalChannel } from "../runtime/approval/channel.js";
 import type { SkillCard, MarketRequest } from "./marketMessages.js";
+import { access, writeFile } from "node:fs/promises";
+import { join } from "node:path";
 
 // The two-way pipe to ONE chat UI (one panel / one socket). Messages both ways are
 // flat {type, ...} JSON — the same shape the webview already speaks.
@@ -117,6 +119,33 @@ async function ownedSkillsMsg(env: ChatEnv): Promise<{ type: "ownedSkills"; name
   const mints = env.ownedSkillMints ? await env.ownedSkillMints().catch(() => ({})) : {};
   const disposedMints = env.disposedSkillMints ? await env.disposedSkillMints().catch(() => ({})) : {};
   return { type: "ownedSkills", names, mints, disposedMints };
+}
+
+async function exists(path: string): Promise<boolean> {
+  try {
+    await access(path);
+    return true;
+  } catch {
+    return false;
+  }
+}
+
+async function initInstructionsFile(cli: "claude" | "codex", cwd: string): Promise<{ file: string; created: boolean }> {
+  const file = cli === "codex" ? "AGENTS.md" : "CLAUDE.md";
+  const path = join(cwd, file);
+  if (await exists(path)) return { file, created: false };
+  const tool = cli === "codex" ? "Codex" : "Claude Code";
+  await writeFile(path, [
+    `# ${file}`,
+    "",
+    `Project instructions for ${tool}.`,
+    "",
+    "- Follow the existing repository conventions.",
+    "- Keep changes focused on the user's request.",
+    "- Run the relevant checks before handing off changes.",
+    "",
+  ].join("\n"), "utf8");
+  return { file, created: true };
 }
 
 // Wire one chat UI to the runtime. Returns a stop() that tears down both engine
@@ -335,6 +364,27 @@ export function createChatSession(
       case "slashCommand": {
         const command = typeof m.command === "string" ? m.command : "";
         const arg = typeof m.arg === "string" ? m.arg.trim() : "";
+        if (command === "permissions") {
+          const modes = cli === "claude"
+            ? "default, acceptEdits, plan, bypassPermissions"
+            : "readonly, auto, full";
+          transport.send({ type: "notice", text: `Current permission mode: ${slot().mode ?? "default"}\nAvailable modes: ${modes}\nUse /permissions <mode> or /mode <mode> to change it.` });
+          break;
+        }
+        if (command === "init") {
+          try {
+            const res = await initInstructionsFile(cli, env.cwd());
+            transport.send({ type: "notice", text: res.created ? `Created ${res.file}.` : `${res.file} already exists.` });
+          } catch (e) {
+            transport.send({ type: "notice", text: `Could not create instructions file: ${e instanceof Error ? e.message : String(e)}` });
+          }
+          break;
+        }
+        if (command === "skills") {
+          sendMarket(await ownedSkillsMsg(env));
+          transport.send({ type: "notice", text: "Skills refreshed." });
+          break;
+        }
         if (command === "compact") {
           const h = await ensureHandle();
           h.runSlashCommand?.("compact", arg || undefined);
@@ -345,7 +395,12 @@ export function createChatSession(
           h.runSlashCommand?.("diff");
           break;
         }
-        if (command === "status") {
+        if (command === "review" || command === "mcp") {
+          const h = await ensureHandle();
+          h.runSlashCommand?.(command, arg || undefined);
+          break;
+        }
+        if (command === "status" || command === "cost" || command === "usage") {
           const s = slot();
           transport.send({
             type: "status",

--- a/packages/core/src/chat/session.ts
+++ b/packages/core/src/chat/session.ts
@@ -135,7 +135,7 @@ export function createChatSession(
   // q.interrupt / codex child.kill). Instead we re-spawn lazily on the next send,
   // carrying the live session over, so the running turn finishes untouched and the new
   // setting applies from the next message.
-  type Slot = { handle: SessionHandle | null; pendingId?: string; model?: string; mode?: string; effort?: "low" | "medium" | "high" | "xhigh" | "max"; restage?: boolean };
+  type Slot = { handle: SessionHandle | null; pendingId?: string; model?: string; mode?: string; effort?: "low" | "medium" | "high" | "xhigh" | "max"; restage?: boolean; lastUsage?: number };
   const slots: Record<"claude" | "codex", Slot> = {
     claude: { handle: null, mode: "acceptEdits" },
     codex: { handle: null, mode: "auto" },
@@ -158,7 +158,10 @@ export function createChatSession(
     // persisted; only painted for the active tab.
     h.onSkill((name) => { if (cli === forCli) sendMarket({ type: "skillActive", name }); });
     // token usage: forward to the active surface so it can render a context meter.
-    h.onUsage((contextTokens) => { if (cli === forCli) transport.send({ type: "usage", contextTokens }); });
+    h.onUsage((contextTokens) => {
+      slots[forCli].lastUsage = contextTokens;
+      if (cli === forCli) transport.send({ type: "usage", contextTokens });
+    });
     h.onTurnEnd(async () => {
       if (cli === forCli) transport.send({ type: "turnEnd" }); // stop the typing dots
       await pushSessions();
@@ -259,6 +262,13 @@ export function createChatSession(
         })().catch(() => {});
         break;
       case "new":   await open(); await pushSessions(); break;
+      case "clear":
+        // Reset context, not only the transcript DOM. This intentionally opens a blank
+        // in-place chat for the active engine; `/new` remains the explicit fresh-session
+        // action users can pick from the UI.
+        await open();
+        await pushSessions();
+        break;
       // Opening a session resumes it in the CURRENT tab's cli (cross-CLI). The
       // session's own cli is ignored — that's the whole point of cross-CLI resume.
       // If the guard rejected it (open elsewhere), don't repaint the session list.
@@ -319,6 +329,41 @@ export function createChatSession(
         const imgs = Array.isArray(m.images) && m.images.length ? m.images : undefined;
         if (typeof m.text === "string" && (m.text.length > 0 || imgs)) {
           (await ensureHandle()).send(m.text, imgs);
+        }
+        break;
+      }
+      case "slashCommand": {
+        const command = typeof m.command === "string" ? m.command : "";
+        const arg = typeof m.arg === "string" ? m.arg.trim() : "";
+        if (command === "compact") {
+          const h = await ensureHandle();
+          h.runSlashCommand?.("compact", arg || undefined);
+          break;
+        }
+        if (command === "diff") {
+          const h = await ensureHandle();
+          h.runSlashCommand?.("diff");
+          break;
+        }
+        if (command === "status") {
+          const s = slot();
+          transport.send({
+            type: "status",
+            status: {
+              cli,
+              sessionId: s.handle?.sessionId ?? s.pendingId,
+              model: s.model ?? "default",
+              mode: s.mode,
+              effort: s.effort ?? "default",
+              contextTokens: s.lastUsage,
+            },
+          });
+          break;
+        }
+        if (command === "resume") {
+          await pushSessions();
+          transport.send({ type: "notice", text: "Resume: open a session from History." });
+          break;
         }
         break;
       }

--- a/packages/core/src/chat/ui/webview.ts
+++ b/packages/core/src/chat/ui/webview.ts
@@ -1675,6 +1675,12 @@ export function chatHtml(): string {
     { name: 'status', desc: 'show model, mode, tokens, session', insert: '/status' },
     { name: 'resume', desc: 'refresh resumable sessions', insert: '/resume' },
     { name: 'diff', desc: 'show working-tree changes', insert: '/diff' },
+    { name: 'permissions', desc: 'show or change permission mode', insert: '/permissions ' },
+    { name: 'init', desc: 'create engine instructions file', insert: '/init' },
+    { name: 'review', desc: 'review changes', insert: '/review' },
+    { name: 'mcp', desc: 'show MCP server status', insert: '/mcp' },
+    { name: 'skills', desc: 'refresh equipped skills', insert: '/skills' },
+    { name: 'cost', desc: 'show usage/status', insert: '/cost' },
     { name: 'copy', desc: 'copy last reply', insert: '/copy' },
     { name: 'engine', desc: 'switch engine (claude|codex)', insert: '/engine ' },
     { name: 'model', desc: 'change model', insert: '/model ' },
@@ -2858,6 +2864,20 @@ export function chatHtml(): string {
           vscode.postMessage({ type: 'slashCommand', command: 'diff' });
           showTyping();
           input.value = ''; return;
+        case 'permissions':
+          if (arg) { modeByCli[cli] = arg; fillModes(); vscode.postMessage({ type: 'mode', mode: arg }); }
+          else vscode.postMessage({ type: 'slashCommand', command: 'permissions' });
+          input.value = ''; return;
+        case 'init':
+        case 'skills':
+        case 'cost':
+          vscode.postMessage({ type: 'slashCommand', command: cmd });
+          input.value = ''; return;
+        case 'review':
+        case 'mcp':
+          vscode.postMessage({ type: 'slashCommand', command: cmd, arg });
+          showTyping();
+          input.value = ''; return;
         case 'copy': {
           const last = Array.from(log.querySelectorAll('.bubble.assistant')).pop();
           if (last && navigator.clipboard) navigator.clipboard.writeText(last.textContent || '').catch(() => {});
@@ -2882,6 +2902,12 @@ export function chatHtml(): string {
             '/status — show model, mode, tokens, and session',
             '/resume — refresh resumable sessions',
             '/diff — show working-tree changes',
+            '/permissions [mode] — show or change permission mode',
+            '/init — create AGENTS.md for Codex or CLAUDE.md for Claude',
+            '/review [focus] — review changes',
+            '/mcp — show MCP server status',
+            '/skills — refresh equipped skills',
+            '/cost — show usage/status',
             '/copy — copy last reply', '/engine claude|codex — switch engine',
             '/model <model> — change model', '/mode <mode> — change permission mode',
             '/effort low|medium|high|xhigh|max — set reasoning effort',

--- a/packages/core/src/chat/ui/webview.ts
+++ b/packages/core/src/chat/ui/webview.ts
@@ -1570,6 +1570,29 @@ export function chatHtml(): string {
   const loadingEl = document.getElementById('loading');
   // hide the IQ watermark once the chat has any content; show it on an empty log
   function syncWatermark() { mainEl.classList.toggle('hasMsgs', log.childElementCount > 0); }
+  function renderNotice(text) {
+    const notice = document.createElement('div');
+    notice.style.cssText = 'padding:4px 12px;font-size:0.82em;opacity:0.65;white-space:pre-wrap';
+    notice.textContent = text;
+    log.appendChild(notice); syncWatermark(); stickToBottom();
+  }
+  function renderStatus(status) {
+    const ctx = typeof status.contextTokens === 'number'
+      ? (status.contextTokens >= 1000 ? Math.round(status.contextTokens / 1000) + 'k' : String(status.contextTokens))
+      : 'unknown';
+    const text = [
+      'engine: ' + status.cli,
+      'session: ' + (status.sessionId || '(none)'),
+      'model: ' + (status.model || 'default'),
+      'mode: ' + (status.mode || 'default'),
+      'effort: ' + (status.effort || 'default'),
+      'context tokens: ' + ctx,
+    ].join('\\n');
+    const pre = document.createElement('pre');
+    pre.style.cssText = 'margin:8px 0;padding:8px 12px;background:var(--an-bg-1);border-radius:6px;font-size:0.82em;opacity:0.85;white-space:pre-wrap';
+    pre.textContent = text;
+    log.appendChild(pre); syncWatermark(); stickToBottom();
+  }
 
   // ---- stick-to-bottom + jump-to-latest (normal chat-app feel) ----
   // Follow the newest message ONLY while the user is already near the bottom (a generous
@@ -1647,7 +1670,11 @@ export function chatHtml(): string {
   // ---- slash command autocomplete ----
   const SLASH_CMDS = [
     { name: 'new', desc: 'start fresh session', insert: '/new' },
-    { name: 'clear', desc: 'clear on-screen log', insert: '/clear' },
+    { name: 'clear', desc: 'reset conversation context', insert: '/clear' },
+    { name: 'compact', desc: 'compact context, optionally with focus', insert: '/compact ' },
+    { name: 'status', desc: 'show model, mode, tokens, session', insert: '/status' },
+    { name: 'resume', desc: 'refresh resumable sessions', insert: '/resume' },
+    { name: 'diff', desc: 'show working-tree changes', insert: '/diff' },
     { name: 'copy', desc: 'copy last reply', insert: '/copy' },
     { name: 'engine', desc: 'switch engine (claude|codex)', insert: '/engine ' },
     { name: 'model', desc: 'change model', insert: '/model ' },
@@ -2815,8 +2842,21 @@ export function chatHtml(): string {
           vscode.postMessage({ type: 'new' });
           input.value = ''; return;
         case 'clear':
-          while (log.firstChild) log.removeChild(log.firstChild);
-          syncWatermark();
+          vscode.postMessage({ type: 'clear' });
+          input.value = ''; return;
+        case 'compact':
+          vscode.postMessage({ type: 'slashCommand', command: 'compact', arg });
+          showTyping();
+          input.value = ''; return;
+        case 'status':
+          vscode.postMessage({ type: 'slashCommand', command: 'status' });
+          input.value = ''; return;
+        case 'resume':
+          vscode.postMessage({ type: 'slashCommand', command: 'resume' });
+          input.value = ''; return;
+        case 'diff':
+          vscode.postMessage({ type: 'slashCommand', command: 'diff' });
+          showTyping();
           input.value = ''; return;
         case 'copy': {
           const last = Array.from(log.querySelectorAll('.bubble.assistant')).pop();
@@ -2837,7 +2877,11 @@ export function chatHtml(): string {
           input.value = ''; return;
         case 'help': {
           const helpText = [
-            '/new — start fresh session', '/clear — clear on-screen log',
+            '/new — start fresh session', '/clear — reset conversation context',
+            '/compact [focus] — compact conversation context',
+            '/status — show model, mode, tokens, and session',
+            '/resume — refresh resumable sessions',
+            '/diff — show working-tree changes',
             '/copy — copy last reply', '/engine claude|codex — switch engine',
             '/model <model> — change model', '/mode <mode> — change permission mode',
             '/effort low|medium|high|xhigh|max — set reasoning effort',
@@ -4237,6 +4281,8 @@ export function chatHtml(): string {
     const m = event.data;
     if (m.type === 'message') onMessage(m.msg);
     else if (m.type === 'sessions') { allSessions = m.list || []; activeId = m.activeId; renderSessions(); }
+    else if (m.type === 'notice') renderNotice(m.text || '');
+    else if (m.type === 'status') renderStatus(m.status || {});
     else if (m.type === 'loading') showLoading();
     else if (m.type === 'clear') { log.innerHTML = ''; approvalDock.innerHTML = ''; ctxMeter.style.display = 'none'; syncComposerLock(); streaming = null; openBash = null; tailTurn = null; headTurn = null; hideTyping(); hideActivity(); resetPaging(); syncWatermark(); hideLoading(); }
     else if (m.type === 'turnEnd') { hideTyping(); hideActivity(); }

--- a/packages/core/src/runtime/contract.ts
+++ b/packages/core/src/runtime/contract.ts
@@ -90,6 +90,7 @@ export interface SessionHandle {
   readonly sessionId: string; // from the CLI's system/init
   readonly cli: "claude" | "codex";
   send(userText: string, images?: ImageInput[]): void; // user input (+ attached images) → CLI
+  runSlashCommand?(command: string, arg?: string): void; // native CLI slash command, not a chat turn
   onMessage(cb: (msg: ChatMessage) => void): void; // CLI output (UI renders)
   onTurnEnd(cb: () => void): void; // turn finished (runtime auto-saves here)
   onSkill(cb: (name: string) => void): void; // a skill fired → UI "Casting <skill>" cue

--- a/packages/core/src/runtime/index.ts
+++ b/packages/core/src/runtime/index.ts
@@ -208,6 +208,9 @@ export function createRuntime(
           emit({ role: "user", text: userText, ts: Date.now(), imageCount: images?.length || undefined });
           cli.send(userText, images);
         },
+        runSlashCommand(command: string, arg?: string) {
+          cli.runSlashCommand?.(command, arg);
+        },
         onMessage(cb) {
           msgCbs.push(cb);
         },

--- a/packages/core/src/runtime/spawn.ts
+++ b/packages/core/src/runtime/spawn.ts
@@ -857,6 +857,38 @@ function codexEngine(opts: SpawnOpts): Engine {
         cb.emitTurn();
         return;
       }
+      if (command === "review") {
+        running = true;
+        await sendRequest("review/start", {
+          threadId: sessionId,
+          target: arg ? { type: "custom", instructions: arg } : { type: "uncommittedChanges" },
+          delivery: "inline",
+        });
+        return;
+      }
+      if (command === "mcp") {
+        const res = await sendRequest("mcpServerStatus/list", {
+          threadId: sessionId,
+          limit: 50,
+          detail: "toolsAndAuthOnly",
+        });
+        const servers = Array.isArray(res?.data) ? res.data : [];
+        const text = servers.length
+          ? servers.map((s: any) => {
+              const tools = s?.tools && typeof s.tools === "object" ? Object.keys(s.tools).length : 0;
+              const auth = typeof s?.authStatus === "string" ? s.authStatus : JSON.stringify(s?.authStatus ?? null);
+              return `${s?.name ?? "(unnamed)"}: ${auth}, ${tools} tools`;
+            }).join("\n")
+          : "No MCP servers configured.";
+        cb.emitMsg({
+          role: "tool",
+          text,
+          ts: Date.now(),
+          tool: { name: "MCP", command: "mcpServerStatus/list", output: text },
+        });
+        cb.emitTurn();
+        return;
+      }
       await runTurn("/" + command + (arg ? " " + arg : ""));
     } catch (e) {
       cb.emitErr(`[codex ${command}] ${e instanceof Error ? e.message : String(e)}`);

--- a/packages/core/src/runtime/spawn.ts
+++ b/packages/core/src/runtime/spawn.ts
@@ -82,6 +82,7 @@ export interface Engine {
   onSkill(cb: (name: string) => void): void;
   onUsage(cb: (contextTokens: number) => void): void; // real context occupancy per turn
   send(text: string, images?: ImageInput[]): void;
+  runSlashCommand?(command: string, arg?: string): void;
   interrupt(): void; // stop the current turn, keep the session alive
   stop(): void;
   updateMode?(mode: string): void;
@@ -399,6 +400,10 @@ function claudeEngine(opts: SpawnOpts): Engine {
     onSkill: (c) => cb.skill.push(c),
     onUsage: (c) => cb.use.push(c),
     send: (t, images) => push(t, images),
+    runSlashCommand: (command, arg) => {
+      const text = "/" + command + (arg ? " " + arg : "");
+      push(text);
+    },
     // interrupt the running turn WITHOUT closing the query — prompts() keeps waiting, so
     // the next send resumes the same session. (stop() also sets closed=true to end it.)
     interrupt: () => { void q.interrupt?.().catch(() => {}); },
@@ -827,6 +832,38 @@ function codexEngine(opts: SpawnOpts): Engine {
     }
   };
 
+  const runSlashCommand = async (command: string, arg?: string) => {
+    try {
+      await initPromise;
+      if (command === "compact") {
+        await sendRequest("thread/compact/start", { threadId: sessionId });
+        cb.emitMsg({
+          role: "summary",
+          text: arg ? `context compacted: ${arg}` : "context compacted",
+          ts: Date.now(),
+        });
+        cb.emitTurn();
+        return;
+      }
+      if (command === "diff") {
+        const res = await sendRequest("gitDiffToRemote", { cwd: opts.cwd });
+        const diff = typeof res?.diff === "string" ? res.diff : "";
+        cb.emitMsg({
+          role: "tool",
+          text: diff || "No working-tree changes.",
+          ts: Date.now(),
+          tool: { name: "Diff", command: "git diff", output: diff },
+        });
+        cb.emitTurn();
+        return;
+      }
+      await runTurn("/" + command + (arg ? " " + arg : ""));
+    } catch (e) {
+      cb.emitErr(`[codex ${command}] ${e instanceof Error ? e.message : String(e)}`);
+      cb.emitTurn();
+    }
+  };
+
   return {
     onMessage: (c) => cb.msg.push(c),
     onSessionId: (c) => cb.sid.push(c),
@@ -838,6 +875,9 @@ function codexEngine(opts: SpawnOpts): Engine {
     onUsage: (c) => cb.use.push(c),
     send: (t, images) => {
       void initPromise.then(() => runTurn(t, images));
+    },
+    runSlashCommand: (command, arg) => {
+      void runSlashCommand(command, arg);
     },
     // ask the server to abort the in-flight turn (keeps the thread alive). The resulting
     // turn/completed|failed unblocks the UI and clears running/turnId as usual.


### PR DESCRIPTION
## Summary
- expand webview slash command autocomplete and help for the issue command set
- route slash commands through the shared chat session instead of treating them as UI-only commands
- add engine-backed handlers for compaction, diff, review, MCP status, usage/status, skills, permissions, and init files
- add dispatcher coverage for the new command behavior

## Tests
- pnpm --filter @iqlabs-official/agent-sdk exec tsc --noEmit
- pnpm --filter @iqlabs-official/agent-sdk exec vitest run src/chat/session.spec.ts
- pnpm run build:vscode

Fixes #51