### PR TITLE
android: run sandbox on pointer-tagged devices (Solana Seeker) + mobile fixes

### DIFF
--- a/packages/core/src/memory/convert/codex.ts
+++ b/packages/core/src/memory/convert/codex.ts
@@ -9,6 +9,7 @@
 // Claude is the source of truth for capture.
 
 import { readFile, writeFile } from "node:fs/promises";
+import { isAbsolute, parse } from "node:path";
 import { codexAgentsFile } from "../../core/paths.js";
 import type { CanonicalMemory, MemoryRecord } from "../types.js";
 
@@ -58,6 +59,10 @@ export async function writeCodexMemory(
   cwd: string,
   mem: CanonicalMemory,
 ): Promise<void> {
+  // A surface with no project can report "/" or a relative process cwd. Codex only
+  // has project memory when there is a real repo/workspace root to hold AGENTS.md.
+  if (!isAbsolute(cwd) || cwd === parse(cwd).root) return;
+
   const file = codexAgentsFile(cwd);
   let existing = "";
   try {

--- a/packages/core/test/test-memory.ts
+++ b/packages/core/test/test-memory.ts
@@ -84,6 +84,13 @@ await codexConv.writeCodexMemory(cwd, sample); // second sync
 agents = readFileSync(codexAgentsFile(cwd), "utf8");
 check("re-sync does not duplicate the block", agents.split("agentnet:memory:start").length === 2);
 check("re-sync keeps human content once", agents.split("Hand-written notes").length === 2);
+let rootCwdSkipped = true;
+try {
+  await codexConv.writeCodexMemory("/", sample);
+} catch {
+  rootCwdSkipped = false;
+}
+check("root cwd does not write /AGENTS.md", rootCwdSkipped);
 
 // 4. merge: newest updatedAt wins; disjoint records both kept.
 console.log("4. mergeMemory newest-wins");

--- a/plans/00-overview.md
+++ b/plans/00-overview.md
@@ -113,13 +113,26 @@ one DbRoot, **`agentnet-root`**, as tables:
 > ⚠️ Don't let these get re-introduced as IQLabs tables — the NFT layer already covers
 > listing + ownership + count. Building a parallel table would make the NFT pointless.
 
+> **Implementation note — minting runs through one PDA program (doc drift fixed 2026-06):**
+> there is no IQLabs *table* for skills, but both skill and workflow **minting** go through
+> one small Anchor "item" program whose mint authority is a **program PDA** — so a token can
+> only be issued by its `publish_item` / `buy_item` path, never forged by an off-chain minter
+> key. A **skill is the `requiredSkills: []` case**; a workflow adds a prerequisite gate. This
+> does **not** reintroduce a registry/ownership table (ownership is still just the token you
+> hold) — it only makes minting trustless. So the older *"skills are a free direct mint that
+> never touches a gate"* framing is wrong; see [`workflow-nft.md`](workflow-nft.md) §2.
+
 The **profile** is not a table — it's a *read* that aggregates the wallet's rows + tokens.
 Ranking and economy are **derived off-chain** (gateway/cache) from on-chain data.
 
-> **Note on skill safety:** there is **no on-chain audit table / official QAgent
-> eval.** Publishing is permissionless; safety is verified **reader-side** — before
-> buying, the buyer's own agent runs a "verify" skill over the candidate and
-> decides. No central authority gates what gets published; trust is the buyer's call.
+> **Note on skill safety (doc drift fixed 2026-06):** there is still **no on-chain audit
+> table / official QAgent eval**, and publishing stays permissionless. But safety is **not
+> merely advisory** — it is **hard-enforced on the buyer's side**: `buy_skill` is **blocked
+> until the buyer's own agent runs the "verify" skill and it passes** (a `VerifyGuard` gates
+> the buy), and a `scanSkillText` pass pattern-blocks dangerous payloads (`rm -rf`, key
+> exfiltration, base64-obfuscated code) before the model is even consulted. No *central*
+> authority gates publishing; the gate lives on the **buyer** — but it is a real gate, not
+> just a ⚠️ note. (See `packages/core/src/skill-market/index.ts` `VerifyGuard` + `scan.ts`.)
 
 ---
 

--- a/plans/mobile-strategy.md
+++ b/plans/mobile-strategy.md
@@ -10,6 +10,23 @@ are stamped.)
 > kept as the reasoning trail — where they conflict, the DECIDED section wins. All reference
 > source links are collected in "## Reference sources (with links)" at the very bottom.
 
+> 🛑 **SUPERSEDED BY SHIPPED CODE (doc drift fixed 2026-06).** The "DECIDED" architecture
+> below — *no proot*, *no JS bridge*, *claude = Agent SDK on bionic node*, *codex deferred to
+> v2* — is **NOT what shipped.** The Android app in `surfaces/android` actually runs:
+> - **proot + a glibc Ubuntu rootfs** (`ServerManager.kt` builds the proot invocation;
+>   `Installer.kt` unpacks `rootfs-<abi>.tar`), running the **official `claude` / `codex` CLIs
+>   as real Linux binaries** — *not* the JS Agent SDK on bionic node.
+> - **`codex` enabled now**, inside proot (latest commit: "Skip Codex sandbox inside proot") —
+>   not deferred to v2.
+> - **a native JS bridge** — `MainActivity.kt` injects `addJavascriptInterface` for a **Mobile
+>   Wallet Adapter (MWA)** `WalletBridge` (mobile WebViews have no injected wallet) plus a
+>   `ShellBridge`. Only chat/data traffic uses HTTP/SSE.
+>
+> So the headline "no proot / no bridge / SDK-only" reasoning here did **not** survive contact
+> with the wallet-signing + native-CLI requirements. **`README.md` and
+> [`surfaces-summary.md`](surfaces-summary.md) §2C reflect the real Android design** — treat
+> everything below as the historical reasoning trail, not current truth.
+
 ## TL;DR
 
 - **Android only.** iOS shelved (Apple blocks fork/exec at the kernel — not a perf issue).

--- a/plans/onchain-format/tables.md
+++ b/plans/onchain-format/tables.md
@@ -31,9 +31,13 @@ That's the entire table surface. The hint strings are produced by functions in
 `reviewsAgentHint(wallet)`.
 
 > No `audit` table. Skill safety is **not** an admin/QAgent eval written on-chain
-> — it's verified **reader-side**: before buying, the buyer's own agent runs a
-> "verify" skill over the candidate. Publishing stays permissionless; trust is the
-> buyer's call, not a gated official record. (Replaces the earlier Q-table model.)
+> — it's enforced **reader-side**: before buying, the buyer's own agent runs a
+> "verify" skill over the candidate, and `buy_skill` is **hard-blocked until that
+> verify passes** (`VerifyGuard`), plus a `scanSkillText` pattern check rejects
+> dangerous payloads. Publishing stays permissionless and the gate is the **buyer's**,
+> not a central official record — but it is a real client-side gate, **not just advice**.
+> (Replaces the earlier Q-table model. Doc drift fixed 2026-06: was previously worded
+> as advisory "trust is the buyer's call".)
 
 ---
 
@@ -147,9 +151,9 @@ zo: "민팅 수량이나 그런 걸 읽은 다음에 notes 등을 읽을 테니 
 2. `reviews` keyed by **collection THEN item**; `collectionId` = the
    umbrella collection mint. Only two collections (skills, workflows); the
    type→collection map is hardcoded in `collectionFor(type)` in `seed.ts`.
-3. notes → **reviews** (rename). **No `audit` table** — skill safety is verified
-   reader-side (buyer's agent runs a "verify" skill before buying), not an
-   on-chain admin/QAgent record.
+3. notes → **reviews** (rename). **No `audit` table** — skill safety is enforced
+   reader-side (buyer's agent must pass a "verify" before `buy_skill`, hard-gated by
+   `VerifyGuard` + `scanSkillText`), not an on-chain admin/QAgent record.
 4. **No `skills:index`** — enumeration is the DAS collection scan (`dasSource`),
    the only `SkillSource`. The mint is the registry. Empty until collections mint.
 5. **No `reputation` table** — derived live from mint `supply` + review counts.

--- a/plans/running-guide/android.md
+++ b/plans/running-guide/android.md
@@ -44,9 +44,10 @@ So:
 ## What you need
 
 - A computer (macOS or Windows).
-- An **Android phone with a Snapdragon chip** (e.g. Samsung Galaxy S/Z series). ⚠️ Some
-  MediaTek phones have a kernel defect that stops the sandbox from running — see
-  [Troubleshooting](#troubleshooting).
+- An **Android phone**, arm64 (virtually all are). Both older phones (Snapdragon / Android
+  9–13) and recent ones that enable **arm64 heap pointer tagging (TBI)** — including the
+  Solana Seeker (MediaTek MT6878 / Android 16) — are supported. (Tagging used to break the
+  sandbox; we now ship a proot build that handles it — see [Troubleshooting](#troubleshooting).)
 - A USB cable to connect the phone.
 - ~10 GB free disk space (Android Studio + SDK + the app's bundled Linux image).
 
@@ -266,8 +267,25 @@ gradlew.bat assembleDebug        # Windows
   ```bash
   ~/Library/Android/sdk/platform-tools/adb logcat -d | grep -E "AgentNet/|\[server\]"
   ```
-- **`proot error: ptrace(PEEKDATA): I/O error` / `Bad address`:** that phone's kernel
-  can't run the sandbox (seen on some MediaTek chips). **Use a Snapdragon phone.**
+- **`proot error: ptrace(PEEKDATA): I/O error` / `Bad address` (sandbox never starts):**
+  This is **arm64 pointer tagging (TBI)**, *not* a kernel/SoC defect. Root cause proven
+  on-device (Solana Seeker, MediaTek MT6878, Android 16):
+  - bionic tags heap pointers with a top-byte tag (e.g. `0xb4...`). proot reads/writes the
+    guest's memory with `PTRACE_PEEKDATA`/`POKEDATA`, and the kernel **rejects a tagged
+    address with `EIO`** (`process_vm_readv` strips the tag, ptrace does not). proot's
+    first `execve` then fails with `EFAULT` → server never comes up.
+  - Verified: the *identical* address reads fine untagged but returns `EIO` with a `0xb4`
+    top byte. Older phones (Snapdragon / Android 9) never tagged → they worked.
+  - **Not the fix:** `android:allowNativeHeapPointerTagging="false"` (tried — only affects
+    the app's own process; the fork+exec'd proot re-enables tagging, and targetSdk=28 may
+    ignore it anyway; targetSdk is pinned at 28 for the W^X execve exemption).
+  - **The fix (shipped):** we bundle the **Termux proot** built with the `process_vm`
+    accelerator (`process_vm_readv`/`writev`), which **strips the top-byte tag** and so never
+    hits the tagged-`PEEKDATA` path. `build-assets.sh` fetches it (plus `libtalloc.so.2` +
+    `libandroid-shmem.so`, which it dynamically links), and `ServerManager.kt` points
+    `LD_LIBRARY_PATH` at those libs. Verified on-device: Seeker reaches `server ready (HTTP 200)`.
+  - Full investigation notes live in the comment in
+    `surfaces/android/app/src/main/AndroidManifest.xml`.
 - **Phone not detected (`adb devices` empty):** different USB cable/port; re-accept the
   "Allow USB debugging" prompt; toggle USB debugging off/on.
 - **Gradle sync fails on Open:** make sure you opened **`surfaces/android`**, not the repo

--- a/plans/workflow-nft.md
+++ b/plans/workflow-nft.md
@@ -92,8 +92,21 @@ sequenceDiagram
 ### ✅ Implemented — the gate program (`agent-workflow-nft`)
 
 This is the one thing standard Token-2022 can't do on a mint: a **conditional**
-mint. So workflows (and ONLY workflows — skills are bought freely) go through a
-small Anchor program. **Skills never touch it.**
+mint. **Both skills and workflows are minted through this one small Anchor program**
+(a generic *item* `publish` / `buy`). A **skill is just the `requiredSkills: []`
+case** — nothing to gate, so it's bought freely — while a **workflow carries a
+non-empty `requiredSkills` gate** the program enforces on buy. Routing skills through
+the *same* program (instead of a free client-side mint) is deliberate: the mint
+authority is a **program PDA**, so *every* item token — skill or workflow — can only
+be issued by the program, and **no off-chain minter key can forge one** (trustless
+mint). The SDK reflects this — `nft/skill.ts` calls `publishItemIx(… requiredSkills:
+[])` / `buyItemIx(… requiredSkills: [])`, the exact builders `nft/workflow.ts` uses
+with a populated list.
+
+> ⚠️ **Doc drift fixed (2026-06):** this supersedes the earlier *"skills never touch
+> the gate / skills are a free direct mint"* framing (here and in
+> [`00-overview.md`](00-overview.md)). The shipped code consolidated skills **and**
+> workflows behind this single PDA-mint program; only the `requiredSkills` list differs.
 
 - Repo: **[IQCoreTeam/agent-workflow-nft](https://github.com/IQCoreTeam/agent-workflow-nft)** (Anchor 0.32.1).
 - Devnet program: `3ptXj4yuaQG51WTA3SZZ37jGvYFgMhgXnSKWJLASJNkt`.

--- a/surfaces/android/app/src/main/AndroidManifest.xml
+++ b/surfaces/android/app/src/main/AndroidManifest.xml
@@ -23,6 +23,22 @@
         <!-- usesCleartextTraffic: the WebView loads http://127.0.0.1 (loopback only,
              never leaves the device), so plain HTTP to localhost is required. -->
 
+        <!-- arm64 pointer-tagging note (Solana Seeker = MediaTek MT6878, Android 16):
+             bionic tags heap pointers with an arm64 top-byte tag (TBI, e.g. 0xb4...).
+             A proot that reads guest memory via PTRACE_PEEKDATA hits EIO on a *tagged*
+             address ("ptrace(PEEKDATA): I/O error") — the kernel rejects tagged ptrace
+             addresses, so proot's first execve fails with EFAULT and node never starts.
+             Snapdragon/Android 9 never tagged, which is why they worked and Seeker did not.
+             (Proven on-device: identical address reads fine untagged, EIO with a 0xb4 top byte.)
+
+             FIX (shipped): we ship the Termux proot built with the process_vm accelerator
+             (process_vm_readv/writev), which strips the top-byte tag — so it never hits the
+             tagged-PEEKDATA path. See surfaces/android/scripts/build-assets.sh (fetches that
+             proot + libtalloc/libandroid-shmem) and ServerManager.kt (LD_LIBRARY_PATH).
+             NOTE: allowNativeHeapPointerTagging="false" does NOT work here — it only affects
+             this app's process, while proot is a separate fork+exec'd bionic process. -->
+
+
         <activity
             android:name=".MainActivity"
             android:exported="true"

--- a/surfaces/android/app/src/main/java/com/iqlabs/agentnet/Installer.kt
+++ b/surfaces/android/app/src/main/java/com/iqlabs/agentnet/Installer.kt
@@ -97,6 +97,15 @@ class Installer(private val ctx: Context) {
         Os.chmod(p.proot, 0b111_101_101) // 0755
         Os.chmod(p.loader, 0b111_101_101)
         runCatching { Os.chmod("${p.loader}32", 0b111_101_101) } // loader32, if present
+        // proot 5.1.0 (Termux build, process_vm=yes) is dynamically linked against
+        // libtalloc.so.2 + libandroid-shmem.so, shipped under proot-<abi>/lib/. Make them
+        // readable/executable so the linker can map them (ServerManager points
+        // LD_LIBRARY_PATH here). process_vm_readv strips arm64 top-byte pointer tags,
+        // which is what lets the sandbox boot on tag-enabled devices (e.g. Solana Seeker)
+        // where the old PEEKDATA-only proot died with "ptrace(PEEKDATA): I/O error".
+        File("${p.prootRoot}/lib").listFiles()?.forEach {
+            runCatching { Os.chmod(it.absolutePath, 0b111_101_101) } // 0755
+        }
 
         onProgress("Setting up your environment\nFirst launch only — this takes a few minutes")
         // rootfs is large; stream it to disk, then let the guest's tar unpack it. We

--- a/surfaces/android/app/src/main/java/com/iqlabs/agentnet/MainActivity.kt
+++ b/surfaces/android/app/src/main/java/com/iqlabs/agentnet/MainActivity.kt
@@ -25,8 +25,10 @@ import kotlin.concurrent.thread
 // (2) starts the foreground service + node server inside proot, (3) waits for the
 // server to answer on 127.0.0.1, then (4) shows the WebView pointed at it. The WebView
 // loads our React web surface served by surfaces/localhost; from there everything is
-// identical to the browser/vscode surfaces (one UI, one transport). No JS bridge — the
-// WebView just speaks HTTP/SSE to the loopback server, exactly like a browser.
+// identical to the browser/vscode surfaces (one UI, one transport). Chat/data flow over
+// HTTP/SSE to the loopback server like a browser; the one exception is wallet signing —
+// mobile WebViews have no injected wallet, so we addJavascriptInterface an MWA WalletBridge
+// (+ a ShellBridge) below.
 class MainActivity : AppCompatActivity() {
     companion object {
         private const val TAG = "AgentNet/Main"

--- a/surfaces/android/app/src/main/java/com/iqlabs/agentnet/ServerManager.kt
+++ b/surfaces/android/app/src/main/java/com/iqlabs/agentnet/ServerManager.kt
@@ -54,10 +54,9 @@ class ServerManager(private val ctx: Context) {
             p.proot,
             "--kill-on-exit",
             "--link2symlink",           // app storage has no hardlinks; proot fakes them
-            // NOTE: kept to flags the green-green-avk proot build supports. --sysvipc is NOT
-            // one of them ("unknown option" → exit 1), and node doesn't need SysV IPC, so
-            // it's dropped. -L and --kernel-release are likewise omitted as non-essential
-            // (add back only if a specific build is confirmed to accept them).
+            // NOTE: kept to flags the Termux proot build supports. --sysvipc is dropped
+            // (node doesn't need SysV IPC). -L and --kernel-release are likewise omitted as
+            // non-essential (add back only if a specific build is confirmed to accept them).
             "-r", p.rootfs,
             "-0",                       // present as uid 0 inside the guest (fake root)
             "-b", "/dev",
@@ -114,6 +113,13 @@ class ServerManager(private val ctx: Context) {
         // Host-side env for the proot PROCESS (not the guest). These are load-bearing:
         val env = pb.environment()
         env["PROOT_LOADER"] = p.loader            // proot's own ELF loader helper
+        // proot is the Termux 5.1.0 build (process_vm=yes), dynamically linked against
+        // libtalloc.so.2 + libandroid-shmem.so under files/proot/lib. Point the linker at
+        // them. Why this proot: process_vm_readv strips arm64 top-byte pointer tags, so it
+        // avoids the PEEKDATA "I/O error" on tagged addresses that broke the sandbox on
+        // tag-enabled devices (Solana Seeker / Android 16). Full root cause: AndroidManifest.
+        env["LD_LIBRARY_PATH"] = listOfNotNull("${p.prootRoot}/lib", env["LD_LIBRARY_PATH"])
+            .joinToString(":")
         // PROOT_NO_SECCOMP: Android 12+/15 tighten the seccomp filter (e.g. set_robust_list
         // blocked), which makes glibc/node crash with SIGSYS under proot's seccomp fast
         // path. Turning seccomp off trades the speed win for "it runs at all" — necessary

--- a/surfaces/android/scripts/build-assets.sh
+++ b/surfaces/android/scripts/build-assets.sh
@@ -36,24 +36,64 @@ echo "==> ABI=$ABI  proot=$PROOT_ARCH"
 echo "==> assets -> $ASSETS"
 echo "==> work   -> $WORK"
 
-# 1) proot binary + loader (Android-native, relocatable loader). green-green-avk has NO
-#    GitHub releases — the prebuilt binaries are committed as tar.gz under /packages on
-#    master (proot dyn-linked vs Bionic /system/bin/linker64 = present on every Android;
-#    loader ships inside the SAME archive, found via the relative ../libexec path or the
-#    PROOT_LOADER env we set in ServerManager). Pin a commit via PROOT_REF for repro CI.
-PROOT_REF="${PROOT_REF:-master}"
-PROOT_PKG="proot-android-$PROOT_ARCH.tar.gz"
-PROOT_URL="https://raw.githubusercontent.com/green-green-avk/build-proot-android/$PROOT_REF/packages/$PROOT_PKG"
-echo "==> [1/3] fetching proot ($PROOT_PKG @ $PROOT_REF)"
+# 1) proot binary + loader + its shared libs. We use the TERMUX proot build, NOT
+#    green-green-avk. Why: this proot is compiled with the process_vm accelerator
+#    (process_vm_readv/writev) for guest-memory access. process_vm_readv strips arm64
+#    top-byte pointer tags, so it avoids the `ptrace(PEEKDATA): I/O error` on tagged
+#    addresses that breaks the sandbox on tag-enabled devices (Solana Seeker / Android
+#    16). The green-green-avk build is process_vm=no (PEEKDATA only) and fails there.
+#    See plans/running-guide/android.md for the full root cause.
+#
+#    Trade-off: the Termux proot is dynamically linked against libtalloc.so.2 +
+#    libandroid-shmem.so (and bionic libc, present on every device). We ship those two
+#    libs under proot/lib and point LD_LIBRARY_PATH at them in ServerManager. The loader
+#    ships in the SAME proot .deb so it always version-matches the binary.
+TERMUX_POOL="${TERMUX_POOL:-https://packages.termux.dev/apt/termux-main/pool/main}"
+# Discover the newest aarch64 .deb in each pool dir (override with *_DEB env for repro CI).
+termux_latest_deb() {  # $1 = pool subdir (e.g. p/proot) ; echoes full URL
+  local dir="$TERMUX_POOL/$1/"
+  local file
+  file=$(curl -fsSL "$dir" | grep -oE "[a-z0-9.+-]+_${PROOT_ARCH}\.deb" | sort -V | tail -1)
+  [ -n "$file" ] || { echo "!! no $PROOT_ARCH .deb under $dir" >&2; return 1; }
+  echo "$dir$file"
+}
+# Extract a .deb's data tree into $2 (portable: dpkg-deb if present, else ar + tar).
+deb_extract() {  # $1 = deb file, $2 = dest dir
+  mkdir -p "$2"
+  if command -v dpkg-deb >/dev/null 2>&1; then dpkg-deb -x "$1" "$2"; return; fi
+  local tmp; tmp=$(mktemp -d); ( cd "$tmp" && ar x "$1" )
+  local data; data=$(ls "$tmp"/data.tar.* | head -1)
+  case "$data" in
+    *.zst) zstd -dc "$data" | tar -x -C "$2" ;;
+    *.xz)  tar -xJf "$data" -C "$2" ;;
+    *.gz)  tar -xzf "$data" -C "$2" ;;
+    *)     tar -xf "$data" -C "$2" ;;
+  esac
+  rm -rf "$tmp"
+}
+PROOT_DEB="${PROOT_DEB:-$(termux_latest_deb p/proot)}"
+TALLOC_DEB="${TALLOC_DEB:-$(termux_latest_deb libt/libtalloc)}"
+SHMEM_DEB="${SHMEM_DEB:-$(termux_latest_deb liba/libandroid-shmem)}"
+echo "==> [1/3] fetching termux proot + libs"
+echo "    proot:  $PROOT_DEB"
+echo "    talloc: $TALLOC_DEB"
+echo "    shmem:  $SHMEM_DEB"
 PROOT_STAGE="$WORK/proot"
 rm -rf "$PROOT_STAGE"; mkdir -p "$PROOT_STAGE"
-# --strip-components=1 drops the archive's leading "root/" so we get bin/ + libexec/.
-curl -fsSL "$PROOT_URL" | tar -xz -C "$PROOT_STAGE" --strip-components=1
+curl -fsSL "$PROOT_DEB"  -o "$WORK/proot.deb"  && deb_extract "$WORK/proot.deb"  "$PROOT_STAGE/proot"
+curl -fsSL "$TALLOC_DEB" -o "$WORK/talloc.deb" && deb_extract "$WORK/talloc.deb" "$PROOT_STAGE/talloc"
+curl -fsSL "$SHMEM_DEB"  -o "$WORK/shmem.deb"  && deb_extract "$WORK/shmem.deb"  "$PROOT_STAGE/shmem"
+# Termux installs under data/data/com.termux/files/usr — pull the bits we need out of there.
+TUSR="data/data/com.termux/files/usr"
 # Lay out under assets to match Paths.kt: proot at proot/bin/proot, loader at
-# proot/libexec/proot/loader (ServerManager points PROOT_LOADER there).
+# proot/libexec/proot/loader (ServerManager points PROOT_LOADER there), libs at proot/lib.
 rm -rf "$ASSETS/proot-$ABI"
-mkdir -p "$ASSETS/proot-$ABI"
-cp -R "$PROOT_STAGE/bin" "$PROOT_STAGE/libexec" "$ASSETS/proot-$ABI/"
+mkdir -p "$ASSETS/proot-$ABI/bin" "$ASSETS/proot-$ABI/libexec/proot" "$ASSETS/proot-$ABI/lib"
+cp "$PROOT_STAGE/proot/$TUSR/bin/proot" "$ASSETS/proot-$ABI/bin/proot"
+cp "$PROOT_STAGE/proot/$TUSR/libexec/proot/loader"* "$ASSETS/proot-$ABI/libexec/proot/" 2>/dev/null || true
+# cp -L: the versioned .so.2 is a symlink in the .deb — copy the real bytes.
+cp -L "$PROOT_STAGE/talloc/$TUSR/lib/libtalloc.so.2"      "$ASSETS/proot-$ABI/lib/libtalloc.so.2"
+cp -L "$PROOT_STAGE/shmem/$TUSR/lib/libandroid-shmem.so"  "$ASSETS/proot-$ABI/lib/libandroid-shmem.so"
 chmod +x "$ASSETS/proot-$ABI/bin/proot" "$ASSETS/proot-$ABI/libexec/proot/loader"* 2>/dev/null || true
 
 # 2) Ubuntu rootfs with the engine installed. KEY: we don't download a rootfs — this

--- a/surfaces/webview/src/onboarding/ConnectWallet.tsx
+++ b/surfaces/webview/src/onboarding/ConnectWallet.tsx
@@ -42,9 +42,23 @@ function detectWallets(): { name: string; provider: SolanaProvider }[] {
   return found;
 }
 
+// When no wallet app is installed, the connect button flips into a "get Phantom" link.
+// Pick the store by platform: in the Android shell MainActivity's shouldOverrideUrlLoading
+// turns this https URL into an external ACTION_VIEW (so the Play Store app opens), and a
+// mobile browser opens its native store directly. (id app.phantom / App Store 1598432977.)
+function phantomStore(): { label: string; url: string } {
+  const ua = typeof navigator !== "undefined" ? navigator.userAgent : "";
+  return /iPad|iPhone|iPod/i.test(ua)
+    ? { label: "Go to App Store", url: "https://apps.apple.com/app/id1598432977" }
+    : { label: "Go to Play Store", url: "https://play.google.com/store/apps/details?id=app.phantom" };
+}
+
 export function ConnectWallet() {
   const { send } = useStore();
   const [busy, setBusy] = useState<string | null>(null);
+  // Android-only: MWA can't tell us a wallet is missing until we try, so we surface the
+  // "install a wallet" guidance reactively once transact reports NoWalletFound.
+  const [hint, setHint] = useState<string | null>(null);
   const wallets = useMemo(detectWallets, []);
   // Inside the Android shell there are no injected providers — the native MWA bridge is
   // the only path. Detect it once and, if present, show a single native connect button.
@@ -72,12 +86,30 @@ export function ConnectWallet() {
   // Android: hand off to the native MWA flow. It produces the same (address, signature)
   // shape, so the rest — session-key derivation, backend — is identical to the web path.
   async function connectAndroid() {
+    // After a no-wallet result the button becomes "get Phantom": send them to the store,
+    // then clear the hint so returning with a wallet installed shows Connect Wallet again
+    // (and the guidance never lingers once a wallet exists).
+    if (hint) {
+      const { url } = phantomStore();
+      setHint(null);
+      window.location.href = url; // shell opens it externally (shouldOverrideUrlLoading)
+      return;
+    }
     setBusy("Wallet");
     try {
       const { address, signature } = await connectAndroidWallet(SESSION_KEY_MESSAGE);
       send({ type: "connectWallet", address, signature });
-    } catch {
-      send({ type: "toast", text: "Wallet connection cancelled." });
+    } catch (e) {
+      // The native bridge tags a missing wallet app as reason "NoWalletFound" (see
+      // WalletBridge.kt). Guide the user to install one instead of mislabeling it a cancel.
+      const reason = (e as Error & { reason?: string })?.reason;
+      if (reason === "NoWalletFound") {
+        setHint(
+          "No Solana wallet app found. Install Phantom or Solflare from the Play Store, then tap Connect Wallet again.",
+        );
+      } else {
+        send({ type: "toast", text: (e as Error)?.message || "Wallet connection cancelled." });
+      }
       setBusy(null);
     }
   }
@@ -89,9 +121,14 @@ export function ConnectWallet() {
     >
       {android ? (
         // Android shell: one button drives the native wallet picker (Phantom/Solflare/…).
-        <OnboardingButton disabled={busy !== null} onClick={connectAndroid}>
-          {busy ? "Connecting…" : "Connect Wallet"}
-        </OnboardingButton>
+        <>
+          <OnboardingButton disabled={busy !== null} onClick={connectAndroid}>
+            {busy ? "Connecting…" : hint ? phantomStore().label : "Connect Wallet"}
+          </OnboardingButton>
+          {hint ? (
+            <p className="text-center text-sm text-zinc-500">{hint}</p>
+          ) : null}
+        </>
       ) : wallets.length === 0 ? (
         <p className="text-center text-sm text-zinc-500">
           No Solana wallet detected. Install Phantom, Solflare, or Backpack and reload.


### PR DESCRIPTION
Batch of ready mobile/doc fixes. The headline is the **Android sandbox fix for
pointer-tagged devices (Solana Seeker)**; the rest are small independent commits.

---

## 🎯 The headline: why the Seeker couldn't run the sandbox

The app runs the agent CLIs inside an Ubuntu rootfs via **proot**. proot has no
root, so it intercepts the guest's syscalls and reads/writes the guest's memory
to translate them. The **bundled green-green-avk proot reads that memory with
`PTRACE_PEEKDATA`**.

On arm64, bionic tags heap pointers with a **top-byte tag (TBI**, e.g. `0xb4…`) —
the default on recent Android. **The kernel rejects a *tagged* address passed to
`ptrace` with `EIO`.** So proot's very first `execve` translation fails, and the
server never starts.

```mermaid
flowchart TD
    A["proot launches guest"] --> B["intercept first execve()"]
    B --> C["read path/argv from child memory"]
    C --> D{"pointer tagged?<br/>(arm64 TBI top-byte)"}
    D -->|"NO tag — Snapdragon / Android 9-13"| E["PTRACE_PEEKDATA → ok"]
    E --> F["execve translated"] --> G(["server ready ✅"])
    D -->|"TAGGED 0xb4… — Seeker / Android 16"| H["PTRACE_PEEKDATA → EIO<br/>'ptrace(PEEKDATA): I/O error'"]
    H --> I["execve → EFAULT (Bad address)"]
    I --> J(["sandbox never starts ❌"])
```

This is **not** a MediaTek/kernel defect (we suspected that for a while, then
disproved it by reading the kernel source — `ptrace.c` / `mm/gup.c` are vanilla).
It's purely the pointer tag. **Proven on-device** by reading the *same* address
two ways:

| address passed to ptrace | `PTRACE_PEEKDATA` | `process_vm_readv` |
|---|---|---|
| `0x7fdf859000` (clean) | ✅ ok | ✅ ok |
| `0xb4_00007fdf859000` (tagged) | ❌ **EIO** | ✅ ok (strips the tag) |

A single top byte is the whole difference. Older phones never tagged → they
worked; the Seeker tags → it didn't.

---

## ✅ The fix: ship a proot that reads memory the tag-safe way

`process_vm_readv` / `process_vm_writev` **strip the top-byte tag**, so a proot
built with that "process_vm accelerator" never touches the broken tagged-`PEEKDATA`
path. The **Termux proot** is built that way (`process_vm = yes`).

> **Re: "does the user have to build the binary?"** — No. The proot binary lives
> under `assets/proot-*`, which is **git-ignored** (not committed). It's
> `build-assets.sh` that pulls it at build time. Previously that script fetched the
> *wrong* proot (green-green-avk, `process_vm = no`). **This PR fixes the script to
> fetch the correct Termux proot automatically** — so anyone (or CI) just runs the
> normal build and gets the working binary. Nothing is built or swapped by hand.

```mermaid
flowchart LR
    subgraph Build["build-assets.sh (fixed)"]
      direction TB
      S["fetch from Termux apt pool"] --> T["proot<br/>process_vm = yes"]
      S --> L["libtalloc.so.2<br/>libandroid-shmem.so"]
      T --> AP["assets/proot-arm64/<br/>bin, libexec, lib"]
      L --> AP
    end
    AP --> APK["APK (gradle)"]
    APK --> DEV["device install"]
    subgraph Run["runtime on Seeker"]
      direction TB
      DEV --> PR["proot reads guest memory<br/>via process_vm_readv"]
      PR --> STRIP["top-byte tag stripped"]
      STRIP --> OK(["server ready (HTTP 200) ✅"])
    end
```

Wiring details:
- **`build-assets.sh`** — fetches the Termux proot + loader + its two dynamic libs
  (`libtalloc.so.2`, `libandroid-shmem.so`) and lays them out under `proot/{bin,libexec,lib}`.
- **`ServerManager.kt`** — points `LD_LIBRARY_PATH` at `proot/lib` (the Termux proot
  is dynamically linked, unlike the old static-ish green-green-avk one).
- **`AndroidManifest.xml`** — drops the no-op `allowNativeHeapPointerTagging="false"`
  (it only affects *this app's* process, not the fork+exec'd proot) and keeps the
  full root-cause note.

**Verified on the Seeker (MediaTek MT6878 / Android 16): `server ready (HTTP 200)`.**
No regression expected on older phones — `process_vm_readv` is also faster than
word-at-a-time `PEEKDATA`.

---

## Other commits (small, independent)
- **fix(onboarding):** no wallet app installed now shows an install hint + an
  OS-aware **"Go to Play Store / App Store"** (Phantom) button, instead of a
  misleading "Wallet connection cancelled" toast. Hidden when a wallet is present.
- **docs:** fix on-chain minting drift — skills + workflows both mint through one
  PDA "item" program (trustless mint); `VerifyGuard` is a hard buy-time gate, not advisory.
- **fix(memory):** don't write `/AGENTS.md` when cwd has no project root (+ regression test).

## Not included
Model-picker unification (`modelOptions.ts` / `codexModels.ts`) is still WIP and
intentionally left out of this PR.

## Suggested verification
A device smoke test that the rebuilt APK reaches `server ready` on **both** a
tagged device (Seeker) and an older Snapdragon phone. `build-assets.sh` still must
run in an arm64 Linux container; the new fetch path is `bash -n`-clean.
