### PR TITLE
fix(onboarding): stop bouncing connected users back to ConnectWallet

### DIFF
--- a/surfaces/localhost/src/index.ts
+++ b/surfaces/localhost/src/index.ts
@@ -53,6 +53,7 @@ import {
   saveGoogleCreds,
   hasGoogleCreds,
   isCloudConnected,
+  isInitialized,
   marketplaceEnv,
   saveHeliusKey,
   maskedHeliusKey,
@@ -227,7 +228,6 @@ async function connectWallet(address: string, signature: Uint8Array): Promise<vo
   // First-time users go through onboarding (storage picker) before runtime is needed;
   // building it here with no-cloud config and then rebuilding after Drive OAuth caused
   // the chat SSE to attach to a stale local runtime while the user was in Chrome.
-  const { isInitialized } = await import("@iqlabs-official/agent-sdk");
   if (await isInitialized()) {
     runtime = await connect(wallet, (s) => { lastCloudStatus = s; onCloudStatus?.(); });
   }
@@ -672,6 +672,16 @@ const http = createServer(async (req, res) => {
     res.write(`event: client\ndata: ${JSON.stringify({ client: id })}\n\n`);
     res.on("close", () => { clearInterval(ka); scheduleTeardown(id, c); });
     if (runtime) attachChat(id, c, runtime);
+    // Wallet is connected this session and storage is configured, but the runtime is null
+    // — e.g. a reconnect/reopen raced the deferred runtime build (connectWallet only builds
+    // it once storage exists). Rebuild it and bind CHAT, rather than falling back to the
+    // onboarding handler (which would re-send `init` and silently drop chat messages). Only
+    // when isInitialized() (storage set up): a mid-onboarding client with no storage yet
+    // must still finish the picker, and a true process restart (wallet lost) re-onboards.
+    else if (wallet && (await isInitialized())) {
+      runtime = await connect(wallet, (s) => { lastCloudStatus = s; onCloudStatus?.(); });
+      attachChat(id, c, runtime);
+    }
     else attachOnboarding(c);
     return;
   }

--- a/surfaces/webview/src/state/store.tsx
+++ b/surfaces/webview/src/state/store.tsx
@@ -228,7 +228,15 @@ function reducer(state: State, ev: Action): State {
       return { ...state, cli: ev.cli, phase: "chat" };
     }
     case "init":
-      // Onboarding handshake: no runtime yet → show ConnectWallet.
+      // Onboarding handshake: no runtime yet → show ConnectWallet. BUT only when this
+      // client hasn't already connected a wallet. A first-time user's runtime isn't built
+      // until storage is configured (server connectWallet defers it), so any SSE reconnect
+      // or WebView reload mid-onboarding (frequent on mobile) routes to the server's
+      // onboarding handler and re-sends `init`. Without this guard that stray `init` throws
+      // the user — who already passed the wallet step (walletAddress set) and may be in
+      // storageSelect/engineSelect/chat — all the way back to ConnectWallet. Once a wallet
+      // is connected, a re-`init` is a no-op: keep the phase we're already in.
+      if (state.walletAddress) return state;
       return { ...state, phase: "onboarding" };
     case "walletConnected":
       // Wallet is in. If storage was already configured on this device (returning user),


### PR DESCRIPTION
## Problem

A user who completed **Connect Wallet then Storage then engine select** kept getting bounced back to the **Connect your wallet** screen, repeatedly, especially on mobile.

## Root cause (deterministic, not a race)

```mermaid
flowchart TD
    CW["connectWallet() server"] --> Chk{"isInitialized()? storage configured?"}
    Chk -->|"first-time user = NO"| RN["walletAddress set, runtime stays null"]
    RN --> SSE["mobile WebView SSE reconnect / reload"]
    SSE --> Route{"fresh connect: runtime exists?"}
    Route -->|"null"| AO["attachOnboarding sends init"]
    AO --> Reset["reducer case init: phase = onboarding (even with walletAddress set)"]
    Reset --> Bounce["back to ConnectWallet"]
```

Two faults compound:
1. **Server:** `connectWallet` defers building the runtime until storage is configured, so a first-time user has `runtime === null`. A fresh SSE connect then routes to the onboarding handler and re-sends `init`.
2. **Client:** the `init` reducer reset `phase` to `onboarding` **unconditionally**, even when a wallet was already connected.

## Fix

- **client** (`store.tsx`): once a wallet is connected (`walletAddress` set), a stray `init` is a no-op, keep the current phase.
- **server** (`localhost/index.ts`): on a fresh connect, if a wallet is connected and storage is `isInitialized()` but the runtime is null, **rebuild the runtime and attach chat** instead of falling back to onboarding (which would also silently drop chat messages).

## Verified
Deployed to the Solana Seeker (server bundle re-extracted, HTTP 200) and walked the full onboarding, no more bounce; chat sends work.
