### PR TITLE
Fix mobile market owned skills payload crash

### DIFF
--- a/surfaces/localhost/src/index.ts
+++ b/surfaces/localhost/src/index.ts
@@ -467,8 +467,12 @@ function attachChat(id: string, c: Client, rt: AgentRuntime) {
       }
       case "ownedSkills": {
         try {
-          const r = await mkt.ownedSkills();
-          c.send({ type: "ownedSkills", ...r });
+          const names = mkt.ownedNftSkills ? await mkt.ownedNftSkills() : await mkt.ownedSkills();
+          const [mints, disposedMints] = await Promise.all([
+            mkt.ownedSkillMints ? mkt.ownedSkillMints().catch(() => ({})) : Promise.resolve({}),
+            mkt.disposedSkillMints ? mkt.disposedSkillMints().catch(() => ({})) : Promise.resolve({}),
+          ]);
+          c.send({ type: "ownedSkills", names, mints, disposedMints });
         } catch (e) {
           c.send({ type: "toast", text: "Failed to load owned skills: " + (e as Error).message });
         }

--- a/surfaces/webview/src/state/store.tsx
+++ b/surfaces/webview/src/state/store.tsx
@@ -359,7 +359,7 @@ function reducer(state: State, ev: Action): State {
         buyCelebrate: ev.ok ? true : state.buyCelebrate,
       };
     case "ownedSkills":
-      return { ...state, marketOwned: ev.names };
+      return { ...state, marketOwned: Array.isArray(ev.names) ? ev.names : [] };
     case "balance":
       return { ...state, marketBalance: ev.lamports };
     case "rpcStatus":


### PR DESCRIPTION
## Summary
- send the localhost/mobile ownedSkills event with the expected names array instead of spreading an array into an object
- include owned and disposed mint maps so the payload matches the shared market contract
- guard the React reducer against malformed ownedSkills events so marketOwned never becomes undefined

## Verification
- pnpm --filter agentnet-localhost build
- pnpm --filter agentnet-webview build

This targets the mobile market black-screen crash path when entering the market.