### PR TITLE
fix(skills): enrich Claude awareness signal with name+description per skill (#58)

### DIFF
--- a/packages/core/src/memory/skillsSection.spec.ts
+++ b/packages/core/src/memory/skillsSection.spec.ts
@@ -2,7 +2,8 @@ import { describe, it, expect, vi, beforeEach } from "vitest";
 
 // Mock the filesystem + paths so the test is pure (no real skills dir, no real
 // memory files). We assert the splice behaviour: the managed block is created,
-// replaced in place, and never disturbs content outside the markers.
+// includes each skill's trigger description, replaced in place, and never disturbs
+// content outside the markers.
 const files = new Map<string, string>();
 let skillDirs: string[] = [];
 
@@ -28,13 +29,32 @@ const MEMORY = "/mem/MEMORY.md";
 describe("memory/skillsSection", () => {
   beforeEach(() => { files.clear(); skillDirs = []; });
 
-  it("writes a one-line block naming installed skills (claude MEMORY.md)", async () => {
+  it("writes a block naming installed skills with descriptions (claude MEMORY.md)", async () => {
     skillDirs = ["code-review", "changelog-generator"];
-    await updateSkillsSection("claude", "/proj");
+    files.set("/skills/code-review/SKILL.md", "---\nname: code-review\ndescription: Review code for bugs and missing tests.\n---\n");
+    files.set("/skills/changelog-generator/SKILL.md", "---\nname: changelog-generator\ndescription: \"Draft release notes from git history.\"\n---\n");
+    const skills = await updateSkillsSection("claude", "/proj");
     const out = files.get(MEMORY)!;
     expect(out).toContain("<!-- agentnet:skills:start -->");
     expect(out).toContain("<!-- agentnet:skills:end -->");
-    expect(out).toContain("changelog-generator, code-review"); // sorted, comma-joined
+    expect(out).toContain("- changelog-generator: Draft release notes from git history.");
+    expect(out).toContain("- code-review: Review code for bugs and missing tests.");
+    expect(skills.map((s) => s.name)).toEqual(["changelog-generator", "code-review"]);
+  });
+
+  it("parses YAML block scalar descriptions (>- and |-)", async () => {
+    skillDirs = ["skill-shopping"];
+    files.set("/skills/skill-shopping/SKILL.md", "---\nname: skill-shopping\ndescription: >-\n  Find and acquire a skill from the marketplace.\n---\n");
+    await updateSkillsSection("claude", "/proj");
+    const out = files.get(MEMORY)!;
+    expect(out).toContain("- skill-shopping: Find and acquire a skill from the marketplace.");
+    expect(out).not.toContain(">-");
+  });
+
+  it("falls back to the directory name when a skill file cannot be read", async () => {
+    skillDirs = ["local-skill"];
+    await updateSkillsSection("claude", "/proj");
+    expect(files.get(MEMORY)!).toContain("- local-skill");
   });
 
   it("says none when no skills are installed", async () => {

--- a/packages/core/src/memory/skillsSection.ts
+++ b/packages/core/src/memory/skillsSection.ts
@@ -1,4 +1,4 @@
-// "Your skills" memory section — a managed, auto-updated one-liner that tells the
+// "Your skills" memory section — a managed, auto-updated block that tells the
 // agent which skills are installed, without the user ever typing a prompt and
 // without bloating the system prompt (we keep claude's system prompt vanilla).
 //
@@ -9,8 +9,8 @@
 //     sees this passively — no need to remember to scan the skills dir itself.
 //
 // It's a SETTER over a marker-delimited block: read the local skills dir (NO RPC —
-// just the filesystem, the same readdir the "owned skills" panel uses), render one
-// line of skill titles, and splice it into:
+// just the filesystem, the same readdir the "owned skills" panel uses), render
+// skill names plus one-line descriptions, and splice them into:
 //   - claude: the project memory index (MEMORY.md)
 //   - codex:  the repo AGENTS.md
 // Both already get our other managed blocks; we own ONLY between the markers and
@@ -24,26 +24,72 @@ import { spliceMarkedBlock } from "./convert/codex.js";
 const START = "<!-- agentnet:skills:start -->";
 const END = "<!-- agentnet:skills:end -->";
 
-/** Read installed skill titles from the local skills dir (one subdir per skill).
+export interface InstalledSkillSummary {
+  name: string;
+  description?: string;
+}
+
+function parseFrontmatterScalar(skillMd: string, key: "name" | "description"): string | undefined {
+  const lines = skillMd.replace(/^﻿/, "").split("\n");
+  if (!lines[0]?.trim().startsWith("---")) return undefined;
+  const closeIdx = lines.findIndex((line, i) => i > 0 && line.trim() === "---");
+  if (closeIdx === -1) return undefined;
+
+  for (let i = 1; i < closeIdx; i++) {
+    const m = lines[i].match(/^([A-Za-z0-9_.-]+):[ \t]*(.*)$/);
+    if (!m || m[1] !== key) continue;
+    const raw = m[2].trim();
+    if (!raw) return undefined;
+    if (/^[|>][+-]?$/.test(raw)) {
+      const block: string[] = [];
+      for (let j = i + 1; j < closeIdx; j++) {
+        if (/^\s+\S/.test(lines[j])) block.push(lines[j].trim());
+        else break;
+      }
+      return block.join(" ").replace(/\s+/g, " ").trim() || undefined;
+    }
+    return raw.replace(/^['"]|['"]$/g, "").replace(/\s+/g, " ").trim() || undefined;
+  }
+  return undefined;
+}
+
+async function readSkillSummary(dirName: string): Promise<InstalledSkillSummary> {
+  try {
+    const body = await readFile(join(claudeSkillsDir(), dirName, "SKILL.md"), "utf8");
+    return {
+      name: parseFrontmatterScalar(body, "name") ?? dirName,
+      description: parseFrontmatterScalar(body, "description"),
+    };
+  } catch {
+    return { name: dirName };
+  }
+}
+
+/** Read installed skill metadata from the local skills dir (one subdir per skill).
  *  Pure filesystem, no RPC. Both runtimes install the same SKILL.md, so claude's
  *  dir is the single read. Returns [] when nothing is installed (or the dir is
  *  missing) — the caller then writes an empty/cleared block. */
-async function installedSkillNames(): Promise<string[]> {
+export async function installedSkillSummaries(): Promise<InstalledSkillSummary[]> {
   try {
     const entries = await readdir(claudeSkillsDir(), { withFileTypes: true });
-    return entries.filter((e) => e.isDirectory()).map((e) => e.name).sort();
+    const dirs = entries.filter((e) => e.isDirectory()).map((e) => e.name).sort();
+    const summaries = await Promise.all(dirs.map(readSkillSummary));
+    return summaries.sort((a, b) => a.name.localeCompare(b.name));
   } catch {
     return [];
   }
 }
 
-/** The managed block: a single human-readable line naming the installed skills, so
- *  the agent knows they exist and can reach for them. The full SKILL.md body stays
- *  in the skills dir (read on demand) — we only list titles here. Empty list →
- *  a block that says so (keeps the markers present and idempotent). */
-function renderBlock(names: string[]): string {
-  const line = names.length
-    ? `The following skills are installed and ready — use one when it fits the task: ${names.join(", ")}.`
+/** The managed block names installed skills and includes their trigger descriptions, so
+ *  the agent knows what each skill does and when to reach for it. The full SKILL.md body
+ *  stays in the skills dir (read on demand). Empty list → a block that says so (keeps
+ *  the markers present and idempotent). */
+function renderBlock(skills: InstalledSkillSummary[]): string {
+  const line = skills.length
+    ? [
+        "The following skills are installed and ready. Use one when it fits the task:",
+        ...skills.map((s) => s.description ? `- ${s.name}: ${s.description}` : `- ${s.name}`),
+      ].join("\n")
     : "No skills are installed yet.";
   return `${START}\n${line}\n${END}`;
 }
@@ -71,12 +117,15 @@ async function spliceIntoFile(file: string, block: string): Promise<void> {
  * installed. Best-effort: a filesystem error is swallowed — a missing skills line
  * must never block a session or a purchase.
  */
-export async function updateSkillsSection(cli: "claude" | "codex", cwd: string): Promise<void> {
+export async function updateSkillsSection(cli: "claude" | "codex", cwd: string): Promise<InstalledSkillSummary[]> {
   try {
-    const block = renderBlock(await installedSkillNames());
+    const skills = await installedSkillSummaries();
+    const block = renderBlock(skills);
     const file = cli === "claude" ? join(claudeMemoryDir(cwd), "MEMORY.md") : codexAgentsFile(cwd);
     await spliceIntoFile(file, block);
+    return skills;
   } catch {
     /* never throw from skill-section sync */
+    return [];
   }
 }

--- a/packages/core/src/runtime/index.ts
+++ b/packages/core/src/runtime/index.ts
@@ -100,12 +100,14 @@ export function createRuntime(
       // Inject the project's shared memory into this CLI's native files (Claude's
       // memory dir / Codex's AGENTS.md) BEFORE it starts so it loads this run. Best
       // effort — a memory/storage hiccup must not block starting the session.
+      let enabledSkills: string[] | undefined;
       try {
         await memory.injectAtStart(opts.cli, opts.cwd);
         // After memory is written, refresh the managed "your skills" line so the agent
         // passively knows which skills are installed (no system-prompt nudge, no RPC).
         // Must run AFTER injectAtStart, which regenerates MEMORY.md / AGENTS.md.
-        await updateSkillsSection(opts.cli, opts.cwd);
+        const skills = await updateSkillsSection(opts.cli, opts.cwd);
+        if (opts.cli === "claude" && skills.length) enabledSkills = skills.map((s) => s.name);
       } catch (e) {
         console.warn("[memory] inject failed:", e);
       }
@@ -122,7 +124,7 @@ export function createRuntime(
       // per-session approval channel (each panel passes its own) wins; fall back to
       // the runtime-level default channel.
       const apiKey = opts.apiKey || (opts.cli === "codex" ? (await getCodexApiKey().catch(() => undefined)) ?? undefined : undefined);
-      const cli = spawnCli({ ...opts, sessionId: nativeId, approval: opts.approval ?? approval, apiKey, ...passive });
+      const cli = spawnCli({ ...opts, sessionId: nativeId, approval: opts.approval ?? approval, apiKey, enabledSkills, ...passive });
 
       // Storage key stays the CANONICAL id while resuming; the cli's emitted (native)
       // id must NOT overwrite it, or appended turns land in the wrong log.

--- a/packages/core/src/runtime/spawn.ts
+++ b/packages/core/src/runtime/spawn.ts
@@ -103,6 +103,7 @@ export interface SpawnOpts {
   // system-prompt append — so there's no appendSystemPrompt option anymore.)
   mcpServers?: Record<string, unknown>;
   allowedTools?: string[];
+  enabledSkills?: string[];
   // Codex MCP (Phase 1): codex app-server loads MCP servers from config, not an
   // in-process object — so it's spawned as a child process. We inject it via `-c
   // mcp_servers.<name>...` overrides on the app-server command (process-scoped; the
@@ -324,6 +325,7 @@ function claudeEngine(opts: SpawnOpts): Engine {
       // NOT injected here anymore — it's a managed memory section (skillsSection.ts).
       ...(opts.mcpServers ? { mcpServers: opts.mcpServers as never } : {}),
       ...(opts.allowedTools ? { allowedTools: opts.allowedTools } : {}),
+      ...(opts.enabledSkills?.length ? { skills: opts.enabledSkills } : {}),
       // NOTE: settingSources is deliberately omitted — the SDK then loads ALL sources
       // (user/project/local), which is what lets skills in the user dir (~/.claude/skills,
       // where owned NFTs + the passive workflow are installed) be discovered. Passing


### PR DESCRIPTION
## Summary

Fixes #58 — Claude engine was ignoring equipped skills because the awareness signal listed titles only; Codex surfaces name+description on every turn via its native `## Skills` list, giving it a stronger trigger.

- **`skillsSection.ts`**: renders `- name: description` per skill (bullet list) instead of a comma-joined title string. Parses YAML block scalar descriptions (`>-`, `|-`, `>+`, `|+`) so skills like `skill-shopping` with folded frontmatter get their full description extracted.
- **`runtime/index.ts`**: consumes the new `InstalledSkillSummary[]` return value from `updateSkillsSection`, extracts skill names, passes them as `enabledSkills` to `spawnCli`.
- **`spawn.ts`**: forwards `enabledSkills` as `skills: []` to `query()` so the SDK surfaces equipped skills as first-class `Skill` tools. `settingSources` deliberately omitted — default loads all sources including `~/.claude/skills` (user dir where bought skills live); passing `settingSources:['project']` would drop it.

## Verification

- 6/6 unit tests pass (`skillsSection.spec.ts`)
- Installed VSIX, started session → Output panel showed `[agentnet:skills] ['graphify', 'llm-council', 'ml-engineer', 'patch-repos', 'react-doctor', 'skill-shopping', 'ui-ux-pro-max']`
- MEMORY.md confirmed updated with name+description format

## Test plan

- [x] Install VSIX, open AgentNet, start chat
- [x] Check Output panel for `[agentnet:skills]` log (debug line removed before merge — verify via MEMORY.md instead)
- [x] Ask Claude something that fits an equipped skill — confirm it reaches for it instead of ignoring it
- [x] Confirm MEMORY.md block shows `- name: description` format

🤖 Generated with [Claude Code](https://claude.com/claude-code)