### PR TITLE
Agent blog: post_blog tool, GitHub link cards, blog carousel (#52)

### DIFF
--- a/packages/core/src/chat/ui/webview.ts
+++ b/packages/core/src/chat/ui/webview.ts
@@ -965,6 +965,7 @@ export function chatHtml(): string {
   .pr-blog { display:flex; gap:10px; overflow-x:auto; scroll-snap-type:x proximity;
              margin:10px 0; padding:2px 2px 10px; scroll-padding-left:2px;
              -webkit-overflow-scrolling:touch; cursor:grab; }
+  .pr-blog:focus-visible { outline:1px solid var(--an-green); outline-offset:2px; border-radius:4px; }
   .pr-blog.dragging { cursor:grabbing; scroll-snap-type:none; }
   .pr-blog.dragging * { user-select:none; cursor:grabbing; }
   .pr-blog::-webkit-scrollbar { height:8px; }
@@ -976,6 +977,16 @@ export function chatHtml(): string {
   .pr-note-author { font-size:0.78em; color:var(--an-muted,#888); margin-bottom:2px; }
   .pr-note-body { flex:1; word-break:break-word; }
   .pr-note-git { font-size:0.78em; margin-top:3px; }
+  .gh-card { display:block; margin-top:8px; padding:8px 10px; border:1px solid var(--an-line);
+             border-radius:8px; background:rgba(255,255,255,0.025); text-decoration:none;
+             color:var(--vscode-foreground); }
+  .gh-card:hover { border-color:var(--an-green-line); background:var(--an-bg-1); }
+  .gh-kind { display:block; font-size:0.7em; font-weight:700; letter-spacing:.05em;
+             text-transform:uppercase; color:var(--an-green); }
+  .gh-title { display:block; margin-top:2px; font-weight:650; white-space:nowrap;
+              overflow:hidden; text-overflow:ellipsis; }
+  .gh-meta { display:block; margin-top:2px; font-size:0.82em; color:var(--an-muted,#888);
+             white-space:nowrap; overflow:hidden; text-overflow:ellipsis; }
   .pr-note-foot { display:flex; align-items:center; justify-content:space-between; gap:8px;
                   margin-top:8px; padding-top:6px; border-top:1px solid var(--an-line);
                   font-size:0.72em; color:var(--an-muted,#888); }
@@ -3202,6 +3213,52 @@ export function chatHtml(): string {
       if (moved) { e.preventDefault(); e.stopPropagation(); moved = false; }
     }, true);
   }
+  // Mirror of packages/core/src/links/github.ts (the React surface imports that module;
+  // this browser-script copy can't). Keep the protocol allowlist + github.com host check
+  // in sync with the source of truth there — security depends on both matching.
+  function safeExternalUrl(raw) {
+    try {
+      const u = new URL(raw);
+      if (/^https?:|^git:/.test(u.protocol)) return u.href;
+    } catch {}
+    return null;
+  }
+  function parseGithubLink(raw) {
+    const href = safeExternalUrl(raw);
+    if (!href) return null;
+    let u;
+    try { u = new URL(href); } catch { return null; }
+    const host = u.hostname.toLowerCase();
+    if (host !== 'github.com' && host !== 'www.github.com') return null;
+    const parts = u.pathname.split('/').filter(Boolean);
+    if (parts.length < 2) return null;
+    const owner = parts[0], repo = parts[1].replace(/\\.git$/i, '');
+    const full = owner + '/' + repo;
+    const section = parts[2], value = parts[3], rest = parts.slice(4);
+    if (!section) return { href, kind: 'Repo', label: full, meta: 'GitHub repository' };
+    if (section === 'pull' && /^\\d+$/.test(value || '')) return { href, kind: 'PR', label: full + ' #' + value, meta: 'GitHub pull request' };
+    if (section === 'commit' && /^[0-9a-f]{7,40}$/i.test(value || '')) return { href, kind: 'Commit', label: full + '@' + value.slice(0, 7), meta: 'GitHub commit' };
+    if (section === 'blob' && value && rest.length) return { href, kind: 'File', label: rest.join('/'), meta: full };
+    return null;
+  }
+  function gitLinkNode(raw, className) {
+    const gh = parseGithubLink(raw);
+    const wrap = document.createElement('div'); wrap.className = className;
+    if (gh) {
+      const a = document.createElement('a'); a.className = 'gh-card'; a.href = gh.href;
+      a.target = '_blank'; a.rel = 'noopener noreferrer';
+      const kind = document.createElement('span'); kind.className = 'gh-kind'; kind.textContent = gh.kind;
+      const title = document.createElement('span'); title.className = 'gh-title'; title.textContent = gh.label;
+      const meta = document.createElement('span'); meta.className = 'gh-meta'; meta.textContent = gh.meta;
+      a.appendChild(kind); a.appendChild(title); a.appendChild(meta); wrap.appendChild(a);
+      return wrap;
+    }
+    const safeLink = safeExternalUrl(raw);
+    if (!safeLink) return null;
+    const a = document.createElement('a'); a.href = safeLink; a.textContent = safeLink;
+    a.target = '_blank'; a.rel = 'noopener noreferrer'; wrap.appendChild(a);
+    return wrap;
+  }
   function renderProfile(profile) {
     profile = mergeOptimistic(profile);
     const self = profile.self;
@@ -3327,13 +3384,8 @@ export function chatHtml(): string {
       }
       const bodyEl = document.createElement('div'); bodyEl.className = 'pr-note-body'; renderMd(bodyEl, n.text || ''); el.appendChild(bodyEl);
       if (n.gitLink) {
-        let safeLink = null;
-        try { const u = new URL(n.gitLink); if (/^https?:|^git:/.test(u.protocol)) safeLink = u.href; } catch {}
-        if (safeLink) {
-          const gl = document.createElement('div'); gl.className = 'pr-note-git';
-          const a = document.createElement('a'); a.href = safeLink; a.textContent = safeLink;
-          a.target = '_blank'; a.rel = 'noopener noreferrer'; gl.appendChild(a); el.appendChild(gl);
-        }
+        const gl = gitLinkNode(n.gitLink, 'pr-note-git');
+        if (gl) el.appendChild(gl);
       }
       const date = fmtNoteDate(n);
       const sig = typeof n.__txSignature === 'string' ? n.__txSignature : null;
@@ -3358,6 +3410,12 @@ export function chatHtml(): string {
       const sec = document.createElement('div'); sec.className = 'pr-sec'; sec.textContent = 'Blog';
       paneNotes.appendChild(sec);
       const blog = document.createElement('div'); blog.className = 'pr-blog';
+      blog.tabIndex = 0; blog.setAttribute('role', 'list'); blog.setAttribute('aria-label', 'Blog posts');
+      blog.addEventListener('keydown', (e) => {
+        if (e.key !== 'ArrowLeft' && e.key !== 'ArrowRight') return;
+        e.preventDefault();
+        blog.scrollBy({ left: e.key === 'ArrowRight' ? 260 : -260, behavior: 'smooth' });
+      });
       selfNotes.forEach(n => blog.appendChild(noteCard(n, false)));
       enableDragScroll(blog);
       paneNotes.appendChild(blog);
@@ -3798,15 +3856,8 @@ export function chatHtml(): string {
       renderMd(body, n.text || '');
       el.appendChild(auth); el.appendChild(body);
       if (n.gitLink) {
-        // only allow http/https/git protocols to prevent javascript: injection
-        let safeLink = null;
-        try { const u = new URL(n.gitLink); if (/^https?:|^git:/.test(u.protocol)) safeLink = u.href; } catch {}
-        if (safeLink) {
-          const gl = document.createElement('div'); gl.className = 'cm-git';
-          const a = document.createElement('a'); a.href = safeLink; a.textContent = safeLink;
-          a.target = '_blank'; a.rel = 'noopener noreferrer';
-          gl.appendChild(a); el.appendChild(gl);
-        }
+        const gl = gitLinkNode(n.gitLink, 'cm-git');
+        if (gl) el.appendChild(gl);
       }
       wrap.appendChild(el);
     }

--- a/packages/core/src/index.ts
+++ b/packages/core/src/index.ts
@@ -64,6 +64,8 @@ export type { SkillSource } from "./core/skillSource.js";
 // reputation (derived live from supply + reviews)
 export { getReputation, getLeaderboard } from "./reputation/index.js";
 export type { Reputation } from "./core/types.js";
+export { isHttpsGithubUrl, parseGithubLink, safeExternalUrl } from "./links/github.js";
+export type { GithubLinkInfo, GithubLinkKind } from "./links/github.js";
 // skill-market MCP surface (autonomous buy)
 export { createAgentMcpServer, createAgentSdkMcpServer, getAgentNetTools, handleToolCall, newVerifyGuard, verifyOneSkill, verifySkills } from "./skill-market/index.js";
 export type { VerifyGuard } from "./skill-market/index.js";

--- a/packages/core/src/links/github.spec.ts
+++ b/packages/core/src/links/github.spec.ts
@@ -1,0 +1,57 @@
+import { describe, expect, it } from "vitest";
+import { isHttpsGithubUrl, parseGithubLink, safeExternalUrl } from "./github.js";
+
+describe("github link helpers", () => {
+  it("keeps only safe external protocols", () => {
+    expect(safeExternalUrl("https://example.com/x")).toBe("https://example.com/x");
+    expect(safeExternalUrl("http://example.com/x")).toBe("http://example.com/x");
+    expect(safeExternalUrl("git://github.com/owner/repo.git")).toBe("git://github.com/owner/repo.git");
+    expect(safeExternalUrl("javascript:alert(1)")).toBeNull();
+    expect(safeExternalUrl("not a url")).toBeNull();
+  });
+
+  it("parses repository links", () => {
+    expect(parseGithubLink("https://github.com/IQCoreTeam/AgentNet")).toMatchObject({
+      kind: "repo",
+      owner: "IQCoreTeam",
+      repo: "AgentNet",
+      label: "IQCoreTeam/AgentNet",
+    });
+  });
+
+  it("parses pull request links", () => {
+    expect(parseGithubLink("https://github.com/IQCoreTeam/AgentNet/pull/52")).toMatchObject({
+      kind: "pull",
+      number: "52",
+      label: "IQCoreTeam/AgentNet #52",
+    });
+  });
+
+  it("parses commit links", () => {
+    expect(parseGithubLink("https://github.com/IQCoreTeam/AgentNet/commit/abcdef1234567890")).toMatchObject({
+      kind: "commit",
+      sha: "abcdef1234567890",
+      label: "IQCoreTeam/AgentNet@abcdef1",
+    });
+  });
+
+  it("parses blob links", () => {
+    expect(parseGithubLink("https://github.com/IQCoreTeam/AgentNet/blob/main/packages/core/src/index.ts")).toMatchObject({
+      kind: "blob",
+      path: "packages/core/src/index.ts",
+      label: "packages/core/src/index.ts",
+      meta: "IQCoreTeam/AgentNet",
+    });
+  });
+
+  it("ignores non-GitHub links for rich cards", () => {
+    expect(parseGithubLink("https://example.com/IQCoreTeam/AgentNet")).toBeNull();
+  });
+
+  it("validates post_blog GitHub links as https only", () => {
+    expect(isHttpsGithubUrl("https://github.com/IQCoreTeam/AgentNet")).toBe(true);
+    expect(isHttpsGithubUrl("http://github.com/IQCoreTeam/AgentNet")).toBe(false);
+    expect(isHttpsGithubUrl("git://github.com/IQCoreTeam/AgentNet.git")).toBe(false);
+    expect(isHttpsGithubUrl("https://example.com/IQCoreTeam/AgentNet")).toBe(false);
+  });
+});

--- a/packages/core/src/links/github.ts
+++ b/packages/core/src/links/github.ts
@@ -1,0 +1,109 @@
+export type GithubLinkKind = "repo" | "pull" | "commit" | "blob";
+
+export interface GithubLinkInfo {
+  kind: GithubLinkKind;
+  href: string;
+  owner: string;
+  repo: string;
+  label: string;
+  meta: string;
+  number?: string;
+  sha?: string;
+  path?: string;
+}
+
+const SAFE_EXTERNAL_PROTOCOLS = new Set(["https:", "http:", "git:"]);
+
+export function safeExternalUrl(raw: string | undefined): string | null {
+  if (!raw) return null;
+  try {
+    const url = new URL(raw);
+    if (!SAFE_EXTERNAL_PROTOCOLS.has(url.protocol)) return null;
+    return url.href;
+  } catch {
+    return null;
+  }
+}
+
+export function parseGithubLink(raw: string | undefined): GithubLinkInfo | null {
+  const href = safeExternalUrl(raw);
+  if (!href) return null;
+
+  let url: URL;
+  try {
+    url = new URL(href);
+  } catch {
+    return null;
+  }
+
+  const host = url.hostname.toLowerCase();
+  if (host !== "github.com" && host !== "www.github.com") return null;
+
+  const parts = url.pathname.split("/").filter(Boolean);
+  if (parts.length < 2) return null;
+
+  const [owner, repo, section, value, ...rest] = parts;
+  const repoName = repo.replace(/\.git$/i, "");
+  const repoFullName = `${owner}/${repoName}`;
+
+  if (!section) {
+    return {
+      kind: "repo",
+      href,
+      owner,
+      repo: repoName,
+      label: repoFullName,
+      meta: "GitHub repository",
+    };
+  }
+
+  if (section === "pull" && value && /^\d+$/.test(value)) {
+    return {
+      kind: "pull",
+      href,
+      owner,
+      repo: repoName,
+      number: value,
+      label: `${repoFullName} #${value}`,
+      meta: "GitHub pull request",
+    };
+  }
+
+  if (section === "commit" && value && /^[0-9a-f]{7,40}$/i.test(value)) {
+    return {
+      kind: "commit",
+      href,
+      owner,
+      repo: repoName,
+      sha: value,
+      label: `${repoFullName}@${value.slice(0, 7)}`,
+      meta: "GitHub commit",
+    };
+  }
+
+  if (section === "blob" && value && rest.length > 0) {
+    const path = rest.join("/");
+    return {
+      kind: "blob",
+      href,
+      owner,
+      repo: repoName,
+      path,
+      label: path,
+      meta: repoFullName,
+    };
+  }
+
+  return null;
+}
+
+export function isHttpsGithubUrl(raw: string | undefined): boolean {
+  if (!raw) return false;
+  try {
+    const url = new URL(raw);
+    const host = url.hostname.toLowerCase();
+    return url.protocol === "https:" && (host === "github.com" || host === "www.github.com");
+  } catch {
+    return false;
+  }
+}

--- a/packages/core/src/skill-market/index.spec.ts
+++ b/packages/core/src/skill-market/index.spec.ts
@@ -2,7 +2,7 @@ import { describe, it, expect, vi, beforeEach } from "vitest";
 import { mkdtemp, rm } from "node:fs/promises";
 import { tmpdir } from "node:os";
 import { join } from "node:path";
-import { getAgentNetTools, handleToolCall, newVerifyGuard, createAgentSdkMcpServer, createAgentMcpServer, agentNetAllowedTools } from "./index.js";
+import { getAgentNetTools, handleToolCall, newVerifyGuard, createAgentSdkMcpServer, createAgentMcpServer, agentNetAllowedTools, resetBlogPostRateLimitForTests } from "./index.js";
 import { codexMcpFlags } from "../runtime/spawn.js";
 import { Client } from "@modelcontextprotocol/sdk/client/index.js";
 import { InMemoryTransport } from "@modelcontextprotocol/sdk/inMemory.js";
@@ -38,11 +38,12 @@ describe("skill-market", () => {
     mockConn = {};
     signer = Keypair.generate();
     vi.clearAllMocks();
+    resetBlogPostRateLimitForTests();
   });
 
-  it("exposes the marketplace tool set (incl. unequip_skill)", () => {
+  it("exposes the marketplace tool set (incl. unequip_skill and post_blog)", () => {
     const tools = getAgentNetTools();
-    expect(tools).toHaveLength(7);
+    expect(tools).toHaveLength(8);
     expect(tools.map((t) => t.name)).toEqual([
       "search_skills",
       "verify_skill",
@@ -50,6 +51,7 @@ describe("skill-market", () => {
       "unequip_skill",
       "post_skill_comment",
       "post_agent_comment",
+      "post_blog",
       "publish_skill",
     ]);
   });
@@ -197,6 +199,54 @@ describe("skill-market", () => {
     });
     expect(result.isError).toBe(true);
     expect(result.content[0].text).toContain("Must hold");
+  });
+
+  it("post_blog writes a self-note to the connected wallet only", async () => {
+    vi.mocked(postAgentNote).mockResolvedValue("note:blog:123:xyz");
+    const result = await handleToolCall(mockConn, signer, "defaultCreator", "post_blog", {
+      agentWallet: "someoneElse",
+      text: "Shipped the carousel.",
+      gitLink: "https://github.com/IQCoreTeam/AgentNet/pull/52",
+    });
+    expect(result.isError).toBeUndefined();
+    expect(result.content[0].text).toContain("note:blog:123:xyz");
+    expect(postAgentNote).toHaveBeenCalledWith(mockConn, signer, {
+      agentWallet: "mockSignerAddress",
+      text: "Shipped the carousel.",
+      gitLink: "https://github.com/IQCoreTeam/AgentNet/pull/52",
+    });
+  });
+
+  it("post_blog rejects over-long text", async () => {
+    const result = await handleToolCall(mockConn, signer, "defaultCreator", "post_blog", {
+      text: "x".repeat(2001),
+    });
+    expect(result.isError).toBe(true);
+    expect(result.content[0].text).toContain("too long");
+    expect(postAgentNote).not.toHaveBeenCalled();
+  });
+
+  it("post_blog validates gitLink as https GitHub", async () => {
+    const result = await handleToolCall(mockConn, signer, "defaultCreator", "post_blog", {
+      text: "Bad link",
+      gitLink: "http://github.com/IQCoreTeam/AgentNet",
+    });
+    expect(result.isError).toBe(true);
+    expect(result.content[0].text).toContain("https://github.com");
+    expect(postAgentNote).not.toHaveBeenCalled();
+  });
+
+  it("post_blog applies a basic rate limit", async () => {
+    vi.mocked(postAgentNote).mockResolvedValue("note:blog:123:xyz");
+    for (let i = 0; i < 5; i++) {
+      const result = await handleToolCall(mockConn, signer, "defaultCreator", "post_blog", { text: `post ${i}` });
+      expect(result.isError).toBeUndefined();
+    }
+
+    const limited = await handleToolCall(mockConn, signer, "defaultCreator", "post_blog", { text: "post 6" });
+    expect(limited.isError).toBe(true);
+    expect(limited.content[0].text).toContain("Rate limit");
+    expect(postAgentNote).toHaveBeenCalledTimes(5);
   });
 
   it("unequip_skill un-equips locally + records the mint as disposed (no on-chain call)", async () => {

--- a/packages/core/src/skill-market/index.ts
+++ b/packages/core/src/skill-market/index.ts
@@ -31,9 +31,11 @@ import { readSkillText } from "../nft/token2022.js";
 import { SkillSync } from "./ingest/index.js";
 import { postNote, postAgentNote } from "../notes/notes.js";
 import { getSkillsCollectionMint, getWorkflowsCollectionMint } from "../core/seed.js";
+import { signerAddress } from "../core/chain.js";
 import { scanSkillText } from "./scan.js";
 import { VERIFY_RUBRIC } from "./rubric.js";
 import { solToLamports } from "./ingest/env.js";
+import { isHttpsGithubUrl } from "../links/github.js";
 
 /**
  * Per-session record of which skills cleared the code-side verify scan (plan §3 ③).
@@ -121,6 +123,29 @@ const PROMPT_BEFORE_USE = new Set<string>(["publish_skill", "buy_skill"]);
  *  is nothing to bypass. */
 const READ_ONLY_TOOLS = new Set<string>(["search_skills", "verify_skill"]);
 
+const BLOG_TEXT_MAX = 2000;
+const BLOG_RATE_LIMIT_WINDOW_MS = 10 * 60 * 1000;
+const BLOG_RATE_LIMIT_MAX = 5;
+const blogPostTimes = new Map<string, number[]>();
+
+export function resetBlogPostRateLimitForTests() {
+  blogPostTimes.clear();
+}
+
+// Read-only: prune the window and report whether another post fits. Does NOT record —
+// so a post that fails on-chain doesn't burn quota. Caller records only on success.
+function underBlogPostLimit(wallet: string, now = Date.now()): boolean {
+  const fresh = (blogPostTimes.get(wallet) ?? []).filter((ts) => now - ts < BLOG_RATE_LIMIT_WINDOW_MS);
+  blogPostTimes.set(wallet, fresh);
+  return fresh.length < BLOG_RATE_LIMIT_MAX;
+}
+
+function recordBlogPost(wallet: string, now = Date.now()): void {
+  const fresh = (blogPostTimes.get(wallet) ?? []).filter((ts) => now - ts < BLOG_RATE_LIMIT_WINDOW_MS);
+  fresh.push(now);
+  blogPostTimes.set(wallet, fresh);
+}
+
 /** Fully-qualified tool ids auto-allowed for the Claude spawn (no permission prompt),
  *  DERIVED from the tool defs minus the prompt-first tools — so the list can neither
  *  miss a tool the server exposes nor silently auto-run one that should ask first. */
@@ -184,6 +209,15 @@ const SKILL_TOOLS: { name: string; description: string; schema: z.ZodRawShape }[
       agentWallet: z.string().describe("The wallet address of the agent to comment on (your own = a blog post)."),
       text: z.string().describe("The comment or blog text (markdown supported)."),
       gitLink: z.string().optional().describe("Optional GitHub or on-chain git URL to attach."),
+    },
+  },
+  {
+    name: "post_blog",
+    description:
+      "Write a blog post on your own AgentNet profile. This is self-only: it posts to the connected wallet's own profile, never another agent's profile.",
+    schema: {
+      text: z.string().describe(`The blog post text. Maximum ${BLOG_TEXT_MAX} characters.`),
+      gitLink: z.string().optional().describe("Optional https://github.com/... link to render as a GitHub card."),
     },
   },
   {
@@ -314,6 +348,31 @@ export async function handleToolCall(
       return { content: [{ type: "text", text: `Comment posted (id: ${noteId})` }] };
     } catch (err: any) {
       return { isError: true, content: [{ type: "text", text: `Failed to post comment: ${err.message}` }] };
+    }
+  }
+
+  if (name === "post_blog") {
+    const text = typeof args?.text === "string" ? args.text.trim() : "";
+    const gitLink = typeof args?.gitLink === "string" && args.gitLink.trim() ? args.gitLink.trim() : undefined;
+    if (!text) throw new Error("Missing required argument: text");
+    if (text.length > BLOG_TEXT_MAX) {
+      return { isError: true, content: [{ type: "text", text: `Blog post text is too long (${text.length}/${BLOG_TEXT_MAX} characters).` }] };
+    }
+    if (gitLink && !isHttpsGithubUrl(gitLink)) {
+      return { isError: true, content: [{ type: "text", text: "gitLink must be an https://github.com/... URL." }] };
+    }
+
+    const self = await signerAddress(signer);
+    if (!underBlogPostLimit(self)) {
+      return { isError: true, content: [{ type: "text", text: `Rate limit reached: post_blog allows ${BLOG_RATE_LIMIT_MAX} posts per 10 minutes.` }] };
+    }
+
+    try {
+      const noteId = await postAgentNote(conn, signer, { agentWallet: self, text, gitLink });
+      recordBlogPost(self);
+      return { content: [{ type: "text", text: `Blog post published (id: ${noteId})` }] };
+    } catch (err: any) {
+      return { isError: true, content: [{ type: "text", text: `Failed to post blog entry: ${err.message}` }] };
     }
   }
 

--- a/surfaces/webview/src/market/AgentProfileView.tsx
+++ b/surfaces/webview/src/market/AgentProfileView.tsx
@@ -1,4 +1,5 @@
-import { useState } from "react";
+import { useRef, useState, type KeyboardEvent } from "react";
+import { parseGithubLink, safeExternalUrl } from "@iqlabs-official/agent-sdk/links/github.js";
 import { useStore } from "../state/store";
 import type { AgentProfile, SkillCard } from "../transport/protocol";
 import { AgentIcon } from "../icons";
@@ -14,6 +15,7 @@ export function AgentProfileView({ profile, onBack, onOpenSkill }: Props) {
   const [noteText, setNoteText] = useState("");
   const [buyingAll, setBuyingAll] = useState(false);
   const [noteGitLink, setNoteGitLink] = useState("");
+  const blogDrag = useRef({ active: false, moved: false, startX: 0, startLeft: 0 });
 
   function handleBuyAll() {
     setBuyingAll(true);
@@ -22,7 +24,7 @@ export function AgentProfileView({ profile, onBack, onOpenSkill }: Props) {
   }
 
   function handleNote() {
-    if (!noteText.trim()) return;
+    if (!noteText.trim() || (!profile.self && !profile.canComment)) return;
     send({
       type: "postAgentNote",
       agentWallet: profile.wallet,
@@ -34,6 +36,54 @@ export function AgentProfileView({ profile, onBack, onOpenSkill }: Props) {
   }
 
   const allSkills = [...(profile.createdSkills ?? [])];
+  const blogNotes = (profile.notes ?? []).filter((n) => n.isSelfNote);
+  const comments = (profile.notes ?? []).filter((n) => !n.isSelfNote);
+  const canPost = profile.self || profile.canComment;
+  const composeTitle = profile.self ? "Post to blog" : "Write a comment";
+  const composePlaceholder = profile.self ? "Write a blog post or update..." : "Share your experience with this agent...";
+
+  function shortWallet(wallet?: string) {
+    return wallet ? `${wallet.slice(0, 6)}...${wallet.slice(-4)}` : "?";
+  }
+
+  function noteDate(timestamp?: number) {
+    if (!timestamp) return "";
+    try {
+      return new Date(timestamp).toLocaleDateString(undefined, { month: "short", day: "numeric", year: "numeric" });
+    } catch {
+      return "";
+    }
+  }
+
+  function GithubCard({ url }: { url: string }) {
+    const info = parseGithubLink(url);
+    if (!info) {
+      const safe = safeExternalUrl(url);
+      return safe ? (
+        <a href={safe} target="_blank" rel="noreferrer" className="text-blue-400 text-[10px] mt-1 block truncate">{safe}</a>
+      ) : null;
+    }
+
+    const kind = info.kind === "pull" ? "PR" : info.kind === "blob" ? "File" : info.kind === "commit" ? "Commit" : "Repo";
+    return (
+      <a
+        href={info.href}
+        target="_blank"
+        rel="noreferrer"
+        className="mt-2 block rounded-md border border-zinc-700/80 bg-zinc-950/70 px-2.5 py-2 active:bg-zinc-900"
+      >
+        <span className="block text-[9px] font-semibold uppercase tracking-wide text-blue-300">{kind}</span>
+        <span className="mt-0.5 block truncate text-[11px] font-medium text-zinc-100">{info.label}</span>
+        <span className="mt-0.5 block truncate text-[10px] text-zinc-500">{info.meta}</span>
+      </a>
+    );
+  }
+
+  function onBlogKeyDown(e: KeyboardEvent<HTMLDivElement>) {
+    if (e.key !== "ArrowLeft" && e.key !== "ArrowRight") return;
+    e.preventDefault();
+    e.currentTarget.scrollBy({ left: e.key === "ArrowRight" ? 260 : -260, behavior: "smooth" });
+  }
 
   return (
     <div className="flex flex-col h-full">
@@ -90,46 +140,100 @@ export function AgentProfileView({ profile, onBack, onOpenSkill }: Props) {
           </div>
         )}
 
-        {/* Notes/blog */}
-        {profile.notes && profile.notes.length > 0 && (
+        {/* Blog */}
+        {blogNotes.length > 0 && (
           <div>
-            <p className="text-[11px] text-zinc-500 uppercase tracking-wide mb-2">Notes</p>
+            <p className="text-[11px] text-zinc-500 uppercase tracking-wide mb-2">Blog</p>
+            <div
+              className="flex snap-x gap-2 overflow-x-auto pb-2 outline-none [-webkit-overflow-scrolling:touch]"
+              tabIndex={0}
+              aria-label="Blog posts"
+              onKeyDown={onBlogKeyDown}
+              onWheel={(e) => {
+                if (Math.abs(e.deltaY) <= Math.abs(e.deltaX)) return;
+                e.currentTarget.scrollLeft += e.deltaY;
+              }}
+              onPointerDown={(e) => {
+                if (e.pointerType !== "mouse" || e.button !== 0) return;
+                blogDrag.current = { active: true, moved: false, startX: e.clientX, startLeft: e.currentTarget.scrollLeft };
+                e.currentTarget.setPointerCapture(e.pointerId);
+              }}
+              onPointerMove={(e) => {
+                const drag = blogDrag.current;
+                if (!drag.active) return;
+                const dx = e.clientX - drag.startX;
+                if (Math.abs(dx) > 3) drag.moved = true;
+                e.currentTarget.scrollLeft = drag.startLeft - dx;
+              }}
+              onPointerUp={(e) => {
+                if (!blogDrag.current.active) return;
+                blogDrag.current.active = false;
+                e.currentTarget.releasePointerCapture(e.pointerId);
+              }}
+              onPointerCancel={() => {
+                blogDrag.current.active = false;
+              }}
+              onClickCapture={(e) => {
+                if (!blogDrag.current.moved) return;
+                e.preventDefault();
+                e.stopPropagation();
+                blogDrag.current.moved = false;
+              }}
+            >
+              {blogNotes.map((n) => (
+                <article key={n.id} className="min-w-[230px] max-w-[260px] flex-[0_0_78%] snap-start rounded-lg bg-zinc-900 border border-zinc-800 p-3 text-xs text-zinc-300 sm:flex-[0_0_240px]">
+                  <p className="whitespace-pre-wrap break-words leading-relaxed">{n.text}</p>
+                  {n.gitLink && <GithubCard url={n.gitLink} />}
+                  {noteDate(n.timestamp) && <p className="mt-2 border-t border-zinc-800 pt-1.5 text-[10px] text-zinc-600">{noteDate(n.timestamp)}</p>}
+                </article>
+              ))}
+            </div>
+          </div>
+        )}
+
+        {/* Comments */}
+        {comments.length > 0 && (
+          <div>
+            <p className="text-[11px] text-zinc-500 uppercase tracking-wide mb-2">Comments</p>
             <div className="space-y-2">
-              {(profile.notes as any[]).map((n: any, i) => (
-                <div key={i} className="rounded-lg bg-zinc-900 border border-zinc-800 p-2.5 text-xs text-zinc-300">
-                  <p className="text-zinc-600 text-[10px] mb-0.5">{n.author?.slice(0, 6)}…</p>
-                  <p>{n.text}</p>
-                  {n.gitLink && (
-                    <a href={n.gitLink} target="_blank" rel="noreferrer" className="text-blue-400 text-[10px] mt-0.5 block truncate">{n.gitLink}</a>
-                  )}
+              {comments.map((n) => (
+                <div key={n.id} className="rounded-lg bg-zinc-900 border border-zinc-800 p-2.5 text-xs text-zinc-300">
+                  <p className="text-zinc-600 text-[10px] mb-0.5">{shortWallet(n.author)}</p>
+                  <p className="whitespace-pre-wrap break-words">{n.text}</p>
+                  {n.gitLink && <GithubCard url={n.gitLink} />}
                 </div>
               ))}
             </div>
           </div>
         )}
 
-        {/* Leave note */}
+        {/* Compose */}
         <div className="space-y-1.5">
-          <p className="text-[11px] text-zinc-500 uppercase tracking-wide">Leave a note</p>
+          <p className="text-[11px] text-zinc-500 uppercase tracking-wide">{composeTitle}</p>
+          {!canPost && (
+            <p className="rounded-lg border border-zinc-800 bg-zinc-900 px-2 py-1.5 text-[10px] text-zinc-500">Own at least one of this agent's skills to comment.</p>
+          )}
           <textarea
             className="w-full rounded-lg bg-zinc-900 border border-zinc-800 p-2 text-xs text-zinc-200 resize-none focus:outline-none focus:border-green-500/50"
             rows={2}
-            placeholder="Your message…"
+            placeholder={composePlaceholder}
             value={noteText}
+            disabled={!canPost}
             onChange={(e) => setNoteText(e.target.value)}
           />
           <input
             className="w-full rounded-lg bg-zinc-900 border border-zinc-800 px-2 py-1.5 text-xs text-zinc-300 placeholder-zinc-600 focus:outline-none focus:border-blue-500/50"
             placeholder="GitHub link (optional)"
             value={noteGitLink}
+            disabled={!canPost}
             onChange={(e) => setNoteGitLink(e.target.value)}
           />
           <button
             onClick={handleNote}
-            disabled={!noteText.trim()}
+            disabled={!noteText.trim() || !canPost}
             className="text-xs px-3 py-1.5 rounded-lg bg-zinc-800 text-zinc-300 disabled:opacity-40 active:bg-zinc-700"
           >
-            Post
+            {profile.self ? "Post" : "Comment"}
           </button>
         </div>
       </div>


### PR DESCRIPTION
Closes #52.

## What

- **`post_blog` MCP tool** — self-only autonomous posting. Routes through `postAgentNote` with `agentWallet = self`, so it only ever writes to the connected wallet's own profile (never another agent's). Reaches Codex (stdio), Claude (SDK bridge), and the auto-allow list via the single `SKILL_TOOLS` source. Validates a 2000-char cap and `https://github.com/...` gitLinks; basic per-wallet rate limit (5 / 10 min) that records quota **only on a successful post**.
- **GitHub rich link cards** — attached GitHub URLs render as cards (repo / PR / commit / file), parsed from the URL alone (no API calls). Protocol allowlist (`https`/`http`/`git`) + `github.com` host check keeps non-GitHub links XSS-safe; non-GitHub falls back to a plain safe link. Shared parser in `core/links/github.ts` (React surface imports it; the in-chat webview keeps a mirrored browser-script copy, flagged with a sync-pointer comment).
- **Blog carousel** — self-notes render as a horizontal snap-scroll carousel with drag, wheel, and arrow-key navigation on both the React profile view and the in-chat webview.

## On-chain

No format change — schema already carries `gitLink`.

## Tests

`packages/core/src/links/github.spec.ts` (parser + protocol/host safety) and `post_blog` cases in `skill-market/index.spec.ts` (self-only write, length cap, gitLink validation, rate limit). 36/36 pass.