### PR TITLE
feat(android): gate background runtime to active turns (#53)

### DIFF
--- a/packages/core/src/chat/ui/webview.ts
+++ b/packages/core/src/chat/ui/webview.ts
@@ -965,6 +965,7 @@ export function chatHtml(): string {
   .pr-blog { display:flex; gap:10px; overflow-x:auto; scroll-snap-type:x proximity;
              margin:10px 0; padding:2px 2px 10px; scroll-padding-left:2px;
              -webkit-overflow-scrolling:touch; cursor:grab; }
+  .pr-blog:focus-visible { outline:1px solid var(--an-green); outline-offset:2px; border-radius:4px; }
   .pr-blog.dragging { cursor:grabbing; scroll-snap-type:none; }
   .pr-blog.dragging * { user-select:none; cursor:grabbing; }
   .pr-blog::-webkit-scrollbar { height:8px; }
@@ -976,6 +977,16 @@ export function chatHtml(): string {
   .pr-note-author { font-size:0.78em; color:var(--an-muted,#888); margin-bottom:2px; }
   .pr-note-body { flex:1; word-break:break-word; }
   .pr-note-git { font-size:0.78em; margin-top:3px; }
+  .gh-card { display:block; margin-top:8px; padding:8px 10px; border:1px solid var(--an-line);
+             border-radius:8px; background:rgba(255,255,255,0.025); text-decoration:none;
+             color:var(--vscode-foreground); }
+  .gh-card:hover { border-color:var(--an-green-line); background:var(--an-bg-1); }
+  .gh-kind { display:block; font-size:0.7em; font-weight:700; letter-spacing:.05em;
+             text-transform:uppercase; color:var(--an-green); }
+  .gh-title { display:block; margin-top:2px; font-weight:650; white-space:nowrap;
+              overflow:hidden; text-overflow:ellipsis; }
+  .gh-meta { display:block; margin-top:2px; font-size:0.82em; color:var(--an-muted,#888);
+             white-space:nowrap; overflow:hidden; text-overflow:ellipsis; }
   .pr-note-foot { display:flex; align-items:center; justify-content:space-between; gap:8px;
                   margin-top:8px; padding-top:6px; border-top:1px solid var(--an-line);
                   font-size:0.72em; color:var(--an-muted,#888); }
@@ -3202,6 +3213,52 @@ export function chatHtml(): string {
       if (moved) { e.preventDefault(); e.stopPropagation(); moved = false; }
     }, true);
   }
+  // Mirror of packages/core/src/links/github.ts (the React surface imports that module;
+  // this browser-script copy can't). Keep the protocol allowlist + github.com host check
+  // in sync with the source of truth there — security depends on both matching.
+  function safeExternalUrl(raw) {
+    try {
+      const u = new URL(raw);
+      if (/^https?:|^git:/.test(u.protocol)) return u.href;
+    } catch {}
+    return null;
+  }
+  function parseGithubLink(raw) {
+    const href = safeExternalUrl(raw);
+    if (!href) return null;
+    let u;
+    try { u = new URL(href); } catch { return null; }
+    const host = u.hostname.toLowerCase();
+    if (host !== 'github.com' && host !== 'www.github.com') return null;
+    const parts = u.pathname.split('/').filter(Boolean);
+    if (parts.length < 2) return null;
+    const owner = parts[0], repo = parts[1].replace(/\\.git$/i, '');
+    const full = owner + '/' + repo;
+    const section = parts[2], value = parts[3], rest = parts.slice(4);
+    if (!section) return { href, kind: 'Repo', label: full, meta: 'GitHub repository' };
+    if (section === 'pull' && /^\\d+$/.test(value || '')) return { href, kind: 'PR', label: full + ' #' + value, meta: 'GitHub pull request' };
+    if (section === 'commit' && /^[0-9a-f]{7,40}$/i.test(value || '')) return { href, kind: 'Commit', label: full + '@' + value.slice(0, 7), meta: 'GitHub commit' };
+    if (section === 'blob' && value && rest.length) return { href, kind: 'File', label: rest.join('/'), meta: full };
+    return null;
+  }
+  function gitLinkNode(raw, className) {
+    const gh = parseGithubLink(raw);
+    const wrap = document.createElement('div'); wrap.className = className;
+    if (gh) {
+      const a = document.createElement('a'); a.className = 'gh-card'; a.href = gh.href;
+      a.target = '_blank'; a.rel = 'noopener noreferrer';
+      const kind = document.createElement('span'); kind.className = 'gh-kind'; kind.textContent = gh.kind;
+      const title = document.createElement('span'); title.className = 'gh-title'; title.textContent = gh.label;
+      const meta = document.createElement('span'); meta.className = 'gh-meta'; meta.textContent = gh.meta;
+      a.appendChild(kind); a.appendChild(title); a.appendChild(meta); wrap.appendChild(a);
+      return wrap;
+    }
+    const safeLink = safeExternalUrl(raw);
+    if (!safeLink) return null;
+    const a = document.createElement('a'); a.href = safeLink; a.textContent = safeLink;
+    a.target = '_blank'; a.rel = 'noopener noreferrer'; wrap.appendChild(a);
+    return wrap;
+  }
   function renderProfile(profile) {
     profile = mergeOptimistic(profile);
     const self = profile.self;
@@ -3327,13 +3384,8 @@ export function chatHtml(): string {
       }
       const bodyEl = document.createElement('div'); bodyEl.className = 'pr-note-body'; renderMd(bodyEl, n.text || ''); el.appendChild(bodyEl);
       if (n.gitLink) {
-        let safeLink = null;
-        try { const u = new URL(n.gitLink); if (/^https?:|^git:/.test(u.protocol)) safeLink = u.href; } catch {}
-        if (safeLink) {
-          const gl = document.createElement('div'); gl.className = 'pr-note-git';
-          const a = document.createElement('a'); a.href = safeLink; a.textContent = safeLink;
-          a.target = '_blank'; a.rel = 'noopener noreferrer'; gl.appendChild(a); el.appendChild(gl);
-        }
+        const gl = gitLinkNode(n.gitLink, 'pr-note-git');
+        if (gl) el.appendChild(gl);
       }
       const date = fmtNoteDate(n);
       const sig = typeof n.__txSignature === 'string' ? n.__txSignature : null;
@@ -3358,6 +3410,12 @@ export function chatHtml(): string {
       const sec = document.createElement('div'); sec.className = 'pr-sec'; sec.textContent = 'Blog';
       paneNotes.appendChild(sec);
       const blog = document.createElement('div'); blog.className = 'pr-blog';
+      blog.tabIndex = 0; blog.setAttribute('role', 'list'); blog.setAttribute('aria-label', 'Blog posts');
+      blog.addEventListener('keydown', (e) => {
+        if (e.key !== 'ArrowLeft' && e.key !== 'ArrowRight') return;
+        e.preventDefault();
+        blog.scrollBy({ left: e.key === 'ArrowRight' ? 260 : -260, behavior: 'smooth' });
+      });
       selfNotes.forEach(n => blog.appendChild(noteCard(n, false)));
       enableDragScroll(blog);
       paneNotes.appendChild(blog);
@@ -3798,15 +3856,8 @@ export function chatHtml(): string {
       renderMd(body, n.text || '');
       el.appendChild(auth); el.appendChild(body);
       if (n.gitLink) {
-        // only allow http/https/git protocols to prevent javascript: injection
-        let safeLink = null;
-        try { const u = new URL(n.gitLink); if (/^https?:|^git:/.test(u.protocol)) safeLink = u.href; } catch {}
-        if (safeLink) {
-          const gl = document.createElement('div'); gl.className = 'cm-git';
-          const a = document.createElement('a'); a.href = safeLink; a.textContent = safeLink;
-          a.target = '_blank'; a.rel = 'noopener noreferrer';
-          gl.appendChild(a); el.appendChild(gl);
-        }
+        const gl = gitLinkNode(n.gitLink, 'cm-git');
+        if (gl) el.appendChild(gl);
       }
       wrap.appendChild(el);
     }

--- a/packages/core/src/index.ts
+++ b/packages/core/src/index.ts
@@ -153,7 +153,7 @@ import { createRuntime } from "./runtime/index.js";
 import { login } from "./account/login.js";
 
 export type { ApprovalChannel, ApprovalRequest, ApprovalDecision } from "./runtime/approval/channel.js";
-export { autoApprove } from "./runtime/approval/channel.js";
+export { autoApprove, withTimeout } from "./runtime/approval/channel.js";
 
 // the transport-neutral chat dispatcher + its button-approval channel, shared by
 // every surface (vscode, server, android). A surface supplies a ChatTransport and a

--- a/packages/core/src/index.ts
+++ b/packages/core/src/index.ts
@@ -64,6 +64,8 @@ export type { SkillSource } from "./core/skillSource.js";
 // reputation (derived live from supply + reviews)
 export { getReputation, getLeaderboard } from "./reputation/index.js";
 export type { Reputation } from "./core/types.js";
+export { isHttpsGithubUrl, parseGithubLink, safeExternalUrl } from "./links/github.js";
+export type { GithubLinkInfo, GithubLinkKind } from "./links/github.js";
 // skill-market MCP surface (autonomous buy)
 export { createAgentMcpServer, createAgentSdkMcpServer, getAgentNetTools, handleToolCall, newVerifyGuard, verifyOneSkill, verifySkills } from "./skill-market/index.js";
 export type { VerifyGuard } from "./skill-market/index.js";

--- a/packages/core/src/links/github.spec.ts
+++ b/packages/core/src/links/github.spec.ts
@@ -1,0 +1,57 @@
+import { describe, expect, it } from "vitest";
+import { isHttpsGithubUrl, parseGithubLink, safeExternalUrl } from "./github.js";
+
+describe("github link helpers", () => {
+  it("keeps only safe external protocols", () => {
+    expect(safeExternalUrl("https://example.com/x")).toBe("https://example.com/x");
+    expect(safeExternalUrl("http://example.com/x")).toBe("http://example.com/x");
+    expect(safeExternalUrl("git://github.com/owner/repo.git")).toBe("git://github.com/owner/repo.git");
+    expect(safeExternalUrl("javascript:alert(1)")).toBeNull();
+    expect(safeExternalUrl("not a url")).toBeNull();
+  });
+
+  it("parses repository links", () => {
+    expect(parseGithubLink("https://github.com/IQCoreTeam/AgentNet")).toMatchObject({
+      kind: "repo",
+      owner: "IQCoreTeam",
+      repo: "AgentNet",
+      label: "IQCoreTeam/AgentNet",
+    });
+  });
+
+  it("parses pull request links", () => {
+    expect(parseGithubLink("https://github.com/IQCoreTeam/AgentNet/pull/52")).toMatchObject({
+      kind: "pull",
+      number: "52",
+      label: "IQCoreTeam/AgentNet #52",
+    });
+  });
+
+  it("parses commit links", () => {
+    expect(parseGithubLink("https://github.com/IQCoreTeam/AgentNet/commit/abcdef1234567890")).toMatchObject({
+      kind: "commit",
+      sha: "abcdef1234567890",
+      label: "IQCoreTeam/AgentNet@abcdef1",
+    });
+  });
+
+  it("parses blob links", () => {
+    expect(parseGithubLink("https://github.com/IQCoreTeam/AgentNet/blob/main/packages/core/src/index.ts")).toMatchObject({
+      kind: "blob",
+      path: "packages/core/src/index.ts",
+      label: "packages/core/src/index.ts",
+      meta: "IQCoreTeam/AgentNet",
+    });
+  });
+
+  it("ignores non-GitHub links for rich cards", () => {
+    expect(parseGithubLink("https://example.com/IQCoreTeam/AgentNet")).toBeNull();
+  });
+
+  it("validates post_blog GitHub links as https only", () => {
+    expect(isHttpsGithubUrl("https://github.com/IQCoreTeam/AgentNet")).toBe(true);
+    expect(isHttpsGithubUrl("http://github.com/IQCoreTeam/AgentNet")).toBe(false);
+    expect(isHttpsGithubUrl("git://github.com/IQCoreTeam/AgentNet.git")).toBe(false);
+    expect(isHttpsGithubUrl("https://example.com/IQCoreTeam/AgentNet")).toBe(false);
+  });
+});

--- a/packages/core/src/links/github.ts
+++ b/packages/core/src/links/github.ts
@@ -1,0 +1,109 @@
+export type GithubLinkKind = "repo" | "pull" | "commit" | "blob";
+
+export interface GithubLinkInfo {
+  kind: GithubLinkKind;
+  href: string;
+  owner: string;
+  repo: string;
+  label: string;
+  meta: string;
+  number?: string;
+  sha?: string;
+  path?: string;
+}
+
+const SAFE_EXTERNAL_PROTOCOLS = new Set(["https:", "http:", "git:"]);
+
+export function safeExternalUrl(raw: string | undefined): string | null {
+  if (!raw) return null;
+  try {
+    const url = new URL(raw);
+    if (!SAFE_EXTERNAL_PROTOCOLS.has(url.protocol)) return null;
+    return url.href;
+  } catch {
+    return null;
+  }
+}
+
+export function parseGithubLink(raw: string | undefined): GithubLinkInfo | null {
+  const href = safeExternalUrl(raw);
+  if (!href) return null;
+
+  let url: URL;
+  try {
+    url = new URL(href);
+  } catch {
+    return null;
+  }
+
+  const host = url.hostname.toLowerCase();
+  if (host !== "github.com" && host !== "www.github.com") return null;
+
+  const parts = url.pathname.split("/").filter(Boolean);
+  if (parts.length < 2) return null;
+
+  const [owner, repo, section, value, ...rest] = parts;
+  const repoName = repo.replace(/\.git$/i, "");
+  const repoFullName = `${owner}/${repoName}`;
+
+  if (!section) {
+    return {
+      kind: "repo",
+      href,
+      owner,
+      repo: repoName,
+      label: repoFullName,
+      meta: "GitHub repository",
+    };
+  }
+
+  if (section === "pull" && value && /^\d+$/.test(value)) {
+    return {
+      kind: "pull",
+      href,
+      owner,
+      repo: repoName,
+      number: value,
+      label: `${repoFullName} #${value}`,
+      meta: "GitHub pull request",
+    };
+  }
+
+  if (section === "commit" && value && /^[0-9a-f]{7,40}$/i.test(value)) {
+    return {
+      kind: "commit",
+      href,
+      owner,
+      repo: repoName,
+      sha: value,
+      label: `${repoFullName}@${value.slice(0, 7)}`,
+      meta: "GitHub commit",
+    };
+  }
+
+  if (section === "blob" && value && rest.length > 0) {
+    const path = rest.join("/");
+    return {
+      kind: "blob",
+      href,
+      owner,
+      repo: repoName,
+      path,
+      label: path,
+      meta: repoFullName,
+    };
+  }
+
+  return null;
+}
+
+export function isHttpsGithubUrl(raw: string | undefined): boolean {
+  if (!raw) return false;
+  try {
+    const url = new URL(raw);
+    const host = url.hostname.toLowerCase();
+    return url.protocol === "https:" && (host === "github.com" || host === "www.github.com");
+  } catch {
+    return false;
+  }
+}

--- a/packages/core/src/runtime/approval/channel.ts
+++ b/packages/core/src/runtime/approval/channel.ts
@@ -74,3 +74,26 @@ export interface ApprovalChannel {
 export function autoApprove(outcome: ApprovalDecision["outcome"] = "once"): ApprovalChannel {
   return { request: async () => ({ outcome }) };
 }
+
+// Wrap any channel so requests that go unanswered for `ms` milliseconds auto-deny.
+// Prevents the engine from hanging forever when the user dismisses a notification, closes
+// the tab, or the app is killed mid-turn. Default: 10 minutes.
+export function withTimeout(
+  channel: ApprovalChannel,
+  ms = 10 * 60 * 1000,
+  reason = "Approval timed out — no response received.",
+): ApprovalChannel {
+  return {
+    async request(req) {
+      let timer: ReturnType<typeof setTimeout>;
+      const timeout = new Promise<ApprovalDecision>((resolve) => {
+        timer = setTimeout(() => resolve({ outcome: "deny", reason }), ms);
+      });
+      try {
+        return await Promise.race([channel.request(req), timeout]);
+      } finally {
+        clearTimeout(timer!);
+      }
+    },
+  };
+}

--- a/packages/core/src/skill-market/index.spec.ts
+++ b/packages/core/src/skill-market/index.spec.ts
@@ -2,7 +2,7 @@ import { describe, it, expect, vi, beforeEach } from "vitest";
 import { mkdtemp, rm } from "node:fs/promises";
 import { tmpdir } from "node:os";
 import { join } from "node:path";
-import { getAgentNetTools, handleToolCall, newVerifyGuard, createAgentSdkMcpServer, createAgentMcpServer, agentNetAllowedTools } from "./index.js";
+import { getAgentNetTools, handleToolCall, newVerifyGuard, createAgentSdkMcpServer, createAgentMcpServer, agentNetAllowedTools, resetBlogPostRateLimitForTests } from "./index.js";
 import { codexMcpFlags } from "../runtime/spawn.js";
 import { Client } from "@modelcontextprotocol/sdk/client/index.js";
 import { InMemoryTransport } from "@modelcontextprotocol/sdk/inMemory.js";
@@ -38,11 +38,12 @@ describe("skill-market", () => {
     mockConn = {};
     signer = Keypair.generate();
     vi.clearAllMocks();
+    resetBlogPostRateLimitForTests();
   });
 
-  it("exposes the marketplace tool set (incl. unequip_skill)", () => {
+  it("exposes the marketplace tool set (incl. unequip_skill and post_blog)", () => {
     const tools = getAgentNetTools();
-    expect(tools).toHaveLength(7);
+    expect(tools).toHaveLength(8);
     expect(tools.map((t) => t.name)).toEqual([
       "search_skills",
       "verify_skill",
@@ -50,6 +51,7 @@ describe("skill-market", () => {
       "unequip_skill",
       "post_skill_comment",
       "post_agent_comment",
+      "post_blog",
       "publish_skill",
     ]);
   });
@@ -197,6 +199,54 @@ describe("skill-market", () => {
     });
     expect(result.isError).toBe(true);
     expect(result.content[0].text).toContain("Must hold");
+  });
+
+  it("post_blog writes a self-note to the connected wallet only", async () => {
+    vi.mocked(postAgentNote).mockResolvedValue("note:blog:123:xyz");
+    const result = await handleToolCall(mockConn, signer, "defaultCreator", "post_blog", {
+      agentWallet: "someoneElse",
+      text: "Shipped the carousel.",
+      gitLink: "https://github.com/IQCoreTeam/AgentNet/pull/52",
+    });
+    expect(result.isError).toBeUndefined();
+    expect(result.content[0].text).toContain("note:blog:123:xyz");
+    expect(postAgentNote).toHaveBeenCalledWith(mockConn, signer, {
+      agentWallet: "mockSignerAddress",
+      text: "Shipped the carousel.",
+      gitLink: "https://github.com/IQCoreTeam/AgentNet/pull/52",
+    });
+  });
+
+  it("post_blog rejects over-long text", async () => {
+    const result = await handleToolCall(mockConn, signer, "defaultCreator", "post_blog", {
+      text: "x".repeat(2001),
+    });
+    expect(result.isError).toBe(true);
+    expect(result.content[0].text).toContain("too long");
+    expect(postAgentNote).not.toHaveBeenCalled();
+  });
+
+  it("post_blog validates gitLink as https GitHub", async () => {
+    const result = await handleToolCall(mockConn, signer, "defaultCreator", "post_blog", {
+      text: "Bad link",
+      gitLink: "http://github.com/IQCoreTeam/AgentNet",
+    });
+    expect(result.isError).toBe(true);
+    expect(result.content[0].text).toContain("https://github.com");
+    expect(postAgentNote).not.toHaveBeenCalled();
+  });
+
+  it("post_blog applies a basic rate limit", async () => {
+    vi.mocked(postAgentNote).mockResolvedValue("note:blog:123:xyz");
+    for (let i = 0; i < 5; i++) {
+      const result = await handleToolCall(mockConn, signer, "defaultCreator", "post_blog", { text: `post ${i}` });
+      expect(result.isError).toBeUndefined();
+    }
+
+    const limited = await handleToolCall(mockConn, signer, "defaultCreator", "post_blog", { text: "post 6" });
+    expect(limited.isError).toBe(true);
+    expect(limited.content[0].text).toContain("Rate limit");
+    expect(postAgentNote).toHaveBeenCalledTimes(5);
   });
 
   it("unequip_skill un-equips locally + records the mint as disposed (no on-chain call)", async () => {

--- a/packages/core/src/skill-market/index.ts
+++ b/packages/core/src/skill-market/index.ts
@@ -31,9 +31,11 @@ import { readSkillText } from "../nft/token2022.js";
 import { SkillSync } from "./ingest/index.js";
 import { postNote, postAgentNote } from "../notes/notes.js";
 import { getSkillsCollectionMint, getWorkflowsCollectionMint } from "../core/seed.js";
+import { signerAddress } from "../core/chain.js";
 import { scanSkillText } from "./scan.js";
 import { VERIFY_RUBRIC } from "./rubric.js";
 import { solToLamports } from "./ingest/env.js";
+import { isHttpsGithubUrl } from "../links/github.js";
 
 /**
  * Per-session record of which skills cleared the code-side verify scan (plan §3 ③).
@@ -121,6 +123,29 @@ const PROMPT_BEFORE_USE = new Set<string>(["publish_skill", "buy_skill"]);
  *  is nothing to bypass. */
 const READ_ONLY_TOOLS = new Set<string>(["search_skills", "verify_skill"]);
 
+const BLOG_TEXT_MAX = 2000;
+const BLOG_RATE_LIMIT_WINDOW_MS = 10 * 60 * 1000;
+const BLOG_RATE_LIMIT_MAX = 5;
+const blogPostTimes = new Map<string, number[]>();
+
+export function resetBlogPostRateLimitForTests() {
+  blogPostTimes.clear();
+}
+
+// Read-only: prune the window and report whether another post fits. Does NOT record —
+// so a post that fails on-chain doesn't burn quota. Caller records only on success.
+function underBlogPostLimit(wallet: string, now = Date.now()): boolean {
+  const fresh = (blogPostTimes.get(wallet) ?? []).filter((ts) => now - ts < BLOG_RATE_LIMIT_WINDOW_MS);
+  blogPostTimes.set(wallet, fresh);
+  return fresh.length < BLOG_RATE_LIMIT_MAX;
+}
+
+function recordBlogPost(wallet: string, now = Date.now()): void {
+  const fresh = (blogPostTimes.get(wallet) ?? []).filter((ts) => now - ts < BLOG_RATE_LIMIT_WINDOW_MS);
+  fresh.push(now);
+  blogPostTimes.set(wallet, fresh);
+}
+
 /** Fully-qualified tool ids auto-allowed for the Claude spawn (no permission prompt),
  *  DERIVED from the tool defs minus the prompt-first tools — so the list can neither
  *  miss a tool the server exposes nor silently auto-run one that should ask first. */
@@ -184,6 +209,15 @@ const SKILL_TOOLS: { name: string; description: string; schema: z.ZodRawShape }[
       agentWallet: z.string().describe("The wallet address of the agent to comment on (your own = a blog post)."),
       text: z.string().describe("The comment or blog text (markdown supported)."),
       gitLink: z.string().optional().describe("Optional GitHub or on-chain git URL to attach."),
+    },
+  },
+  {
+    name: "post_blog",
+    description:
+      "Write a blog post on your own AgentNet profile. This is self-only: it posts to the connected wallet's own profile, never another agent's profile.",
+    schema: {
+      text: z.string().describe(`The blog post text. Maximum ${BLOG_TEXT_MAX} characters.`),
+      gitLink: z.string().optional().describe("Optional https://github.com/... link to render as a GitHub card."),
     },
   },
   {
@@ -314,6 +348,31 @@ export async function handleToolCall(
       return { content: [{ type: "text", text: `Comment posted (id: ${noteId})` }] };
     } catch (err: any) {
       return { isError: true, content: [{ type: "text", text: `Failed to post comment: ${err.message}` }] };
+    }
+  }
+
+  if (name === "post_blog") {
+    const text = typeof args?.text === "string" ? args.text.trim() : "";
+    const gitLink = typeof args?.gitLink === "string" && args.gitLink.trim() ? args.gitLink.trim() : undefined;
+    if (!text) throw new Error("Missing required argument: text");
+    if (text.length > BLOG_TEXT_MAX) {
+      return { isError: true, content: [{ type: "text", text: `Blog post text is too long (${text.length}/${BLOG_TEXT_MAX} characters).` }] };
+    }
+    if (gitLink && !isHttpsGithubUrl(gitLink)) {
+      return { isError: true, content: [{ type: "text", text: "gitLink must be an https://github.com/... URL." }] };
+    }
+
+    const self = await signerAddress(signer);
+    if (!underBlogPostLimit(self)) {
+      return { isError: true, content: [{ type: "text", text: `Rate limit reached: post_blog allows ${BLOG_RATE_LIMIT_MAX} posts per 10 minutes.` }] };
+    }
+
+    try {
+      const noteId = await postAgentNote(conn, signer, { agentWallet: self, text, gitLink });
+      recordBlogPost(self);
+      return { content: [{ type: "text", text: `Blog post published (id: ${noteId})` }] };
+    } catch (err: any) {
+      return { isError: true, content: [{ type: "text", text: `Failed to post blog entry: ${err.message}` }] };
     }
   }
 

--- a/plans/background-server-android.md
+++ b/plans/background-server-android.md
@@ -1,0 +1,76 @@
+# Android background server — gated lifecycle (issue #53)
+
+## Before (broken)
+
+```mermaid
+flowchart TD
+    A["MainActivity.onCreate"] --> B["startForegroundService(ServerService)"]
+    B --> C["ServerService — START_STICKY\nongoing notification always on"]
+    A --> D["bg thread: install → start node → wait → showWebView"]
+
+    style B fill:#7a2020
+    style C fill:#7a2020
+```
+
+Problem: foreground service (and its persistent notification) starts on every app launch,
+regardless of whether any agent work is happening. `START_STICKY` resurrects it even after
+Android kills it. Node/proot runtime stays alive in background permanently.
+
+## After (fix)
+
+```mermaid
+flowchart TD
+    subgraph Launch
+        A["MainActivity.onCreate"] --> D["bg thread: install → start node → wait → showWebView"]
+        A --> P["requestPermissions POST_NOTIFICATIONS (Android 13+)"]
+    end
+
+    subgraph "Turn lifecycle (web drives, Android responds)"
+        W1["state.typing = true\nOR approvals.length > 0"] -->|"syncAgentService(true)"| S1["AgentNetShell.setAgentActive(true)"]
+        S1 --> SVC["startForegroundService(ServerService)\nnotif: 'An agent task is running'"]
+
+        W2["typing = false AND approvals empty"] -->|"syncAgentService(false)"| S2["AgentNetShell.setAgentActive(false)"]
+        S2 --> STOP["stopService(ServerService)\nAndroid reclaims idle process"]
+    end
+
+    subgraph "Approval while backgrounded"
+        W3["approvals[0] changes"] -->|"notifyApproval(id, title)"| S3["AgentNetShell.requestApproval(id, title)"]
+        S3 --> FG{"inForeground?"}
+        FG -->|yes| NOP["WebView shows it — no notification"]
+        FG -->|no| NOTIF["NotificationManager.notify()\n'Approval needed · {title}'\ntap → reopen app"]
+        NOTIF --> RESUME["onResume → cancel notification\nWebView now shows approval"]
+    end
+
+    subgraph "Background exec setting (drawer toggle)"
+        TOG["Sessions.tsx toggle"] -->|"setBackgroundExecEnabled(on)"| LS["localStorage key"]
+        LS -->|"off, immediately"| S2
+        LS -->|"on, next turn"| W1
+    end
+```
+
+## Key invariants
+
+| Condition | Service state |
+|---|---|
+| App foreground, no turn | No service (idle process, normal reclaim) |
+| App foreground, turn active | No service needed (Activity keeps process alive) |
+| App backgrounded, bg exec OFF | No service (process dies, turn dies) |
+| App backgrounded, bg exec ON, turn active | Foreground service running |
+| App backgrounded, turn ends | `stopService` — service torn down |
+
+## Files changed
+
+| File | Change |
+|---|---|
+| `surfaces/android/.../MainActivity.kt` | Remove launch-time service start; add `onResume`/`onPause` foreground tracking; add `setAgentActive()` + `requestApproval()`; request POST_NOTIFICATIONS |
+| `surfaces/android/.../ServerService.kt` | `START_NOT_STICKY`; updated notification text |
+| `surfaces/android/.../ShellBridge.kt` | Expose `setAgentActive` + `requestApproval` to web |
+| `surfaces/android/.../AndroidManifest.xml` | Add `POST_NOTIFICATIONS` permission |
+| `surfaces/webview/src/platform/agentService.ts` | New: bridge helper + `backgroundExec` localStorage setting |
+| `surfaces/webview/src/App.tsx` | `useEffect` drives `syncAgentService` from `typing\|\|approvals`; fires `notifyApproval` on top approval |
+| `surfaces/webview/src/chat/Sessions.tsx` | Android-only toggle row in Configure section |
+
+## Deferred (not in this change)
+
+- **Native approve/deny buttons in the notification** — needs a native→`/rpc` callback round-trip. Add when tap-to-open proves insufficient.
+- **Approval timeout** — unblocking the runtime after deny/timeout lives in `ApprovalChannel` (core), not Android shell.

--- a/surfaces/android/app/src/main/AndroidManifest.xml
+++ b/surfaces/android/app/src/main/AndroidManifest.xml
@@ -10,6 +10,8 @@
     <uses-permission android:name="android.permission.FOREGROUND_SERVICE_DATA_SYNC" />
     <uses-permission android:name="android.permission.WAKE_LOCK" />
     <uses-permission android:name="android.permission.REQUEST_IGNORE_BATTERY_OPTIMIZATIONS" />
+    <!-- POST_NOTIFICATIONS (Android 13+): the backgrounded-approval alert (#53). -->
+    <uses-permission android:name="android.permission.POST_NOTIFICATIONS" />
 
     <application
         android:allowBackup="false"
@@ -53,6 +55,11 @@
             android:name=".ServerService"
             android:exported="false"
             android:foregroundServiceType="dataSync" />
+
+        <!-- Notification action buttons (#53): Stop / Approve / Reject. Internal only. -->
+        <receiver
+            android:name=".NotifActionReceiver"
+            android:exported="false" />
 
     </application>
 </manifest>

--- a/surfaces/android/app/src/main/java/com/iqlabs/agentnet/MainActivity.kt
+++ b/surfaces/android/app/src/main/java/com/iqlabs/agentnet/MainActivity.kt
@@ -1,7 +1,13 @@
 package com.iqlabs.agentnet
 
+import android.Manifest
 import android.annotation.SuppressLint
+import android.app.Notification
+import android.app.NotificationChannel
+import android.app.NotificationManager
+import android.app.PendingIntent
 import android.content.Intent
+import android.content.pm.PackageManager
 import android.net.Uri
 import android.os.Build
 import android.os.Bundle
@@ -38,7 +44,14 @@ class MainActivity : AppCompatActivity() {
         private const val IDENTITY_NAME = "AgentNet"
         private const val IDENTITY_URI = "https://agentnet.iqlabs.com"
         private const val IDENTITY_ICON = "favicon.ico" // relative to IDENTITY_URI
+        private const val APPROVAL_CHANNEL = "agentnet_approval"
+        private const val APPROVAL_NOTIF_ID = 2
+        private const val REQ_POST_NOTIFICATIONS = 101
     }
+
+    // Whether the Activity is currently in the foreground. An approval that arrives while
+    // foreground is handled in the WebView; only a backgrounded one raises a notification.
+    @Volatile private var inForeground = false
 
     private lateinit var webView: WebView
     private lateinit var status: TextView
@@ -117,8 +130,111 @@ class MainActivity : AppCompatActivity() {
         googleDriveAuth = GoogleDriveAuth(this, googleDriveLauncher)
         googleTokenServer = GoogleDriveTokenServer(googleDriveAuth)
         googleTokenServer.start()
+
+        // Android 13+ needs runtime consent to post notifications. We need it for the
+        // backgrounded-approval alert (#53); best-effort, the app works without it.
+        if (Build.VERSION.SDK_INT >= Build.VERSION_CODES.TIRAMISU &&
+            checkSelfPermission(Manifest.permission.POST_NOTIFICATIONS) != PackageManager.PERMISSION_GRANTED) {
+            requestPermissions(arrayOf(Manifest.permission.POST_NOTIFICATIONS), REQ_POST_NOTIFICATIONS)
+        }
+
         startServerFlow()
     }
+
+    override fun onResume() {
+        super.onResume()
+        inForeground = true
+        // Returning to the app clears any pending approval alert — the WebView shows it now.
+        getSystemService(NotificationManager::class.java)?.cancel(APPROVAL_NOTIF_ID)
+    }
+
+    override fun onPause() {
+        inForeground = false
+        super.onPause()
+    }
+
+    // ── ShellBridge entry points (#53) ──────────────────────────────────────────────
+
+    // Promote/demote the foreground service that keeps this process (and the node runtime)
+    // alive while backgrounded. The web UI calls this with `active && backgroundExecEnabled`.
+    // `clientId` rides along so the notification's Stop action can reach /rpc.
+    fun setAgentActive(active: Boolean, clientId: String) {
+        val svc = Intent(this, ServerService::class.java).putExtra(ServerService.EXTRA_CLIENT, clientId)
+        if (active) {
+            if (Build.VERSION.SDK_INT >= Build.VERSION_CODES.O) startForegroundService(svc)
+            else startService(svc)
+        } else {
+            stopService(svc)
+        }
+    }
+
+    // First time the user enables background execution: ask to exempt us from battery
+    // optimization so Android doesn't reap a long-running background task. Guarded so we
+    // only ever prompt once (and skip if already exempt).
+    @SuppressLint("BatteryLife")
+    fun onBackgroundEnabled() {
+        val prefs = getSharedPreferences("agentnet", MODE_PRIVATE)
+        if (prefs.getBoolean("batteryPrompted", false)) return
+        val pm = getSystemService(android.os.PowerManager::class.java)
+        if (pm?.isIgnoringBatteryOptimizations(packageName) == true) return
+        prefs.edit().putBoolean("batteryPrompted", true).apply()
+        runCatching {
+            startActivity(
+                Intent(android.provider.Settings.ACTION_REQUEST_IGNORE_BATTERY_OPTIMIZATIONS)
+                    .setData(Uri.parse("package:$packageName")),
+            )
+        }
+    }
+
+    // A turn needs approval. If the app is foreground the WebView already shows it, so we
+    // only raise a notification when backgrounded. Tapping reopens the chat; the Approve /
+    // Reject actions POST an approvalDecision to /rpc (same as the in-app buttons).
+    fun requestApproval(id: String, title: String, clientId: String) {
+        if (inForeground) return
+        val mgr = getSystemService(NotificationManager::class.java) ?: return
+        if (Build.VERSION.SDK_INT >= Build.VERSION_CODES.O) {
+            mgr.createNotificationChannel(
+                NotificationChannel(APPROVAL_CHANNEL, "AgentNet approvals", NotificationManager.IMPORTANCE_HIGH)
+            )
+        }
+        val tap = PendingIntent.getActivity(
+            this, 0,
+            Intent(this, MainActivity::class.java).addFlags(Intent.FLAG_ACTIVITY_REORDER_TO_FRONT),
+            PendingIntent.FLAG_UPDATE_CURRENT or PendingIntent.FLAG_IMMUTABLE,
+        )
+        val builder = if (Build.VERSION.SDK_INT >= Build.VERSION_CODES.O) {
+            Notification.Builder(this, APPROVAL_CHANNEL)
+        } else {
+            @Suppress("DEPRECATION") Notification.Builder(this)
+        }
+        mgr.notify(
+            APPROVAL_NOTIF_ID,
+            builder
+                .setContentTitle("Approval needed")
+                .setContentText(title)
+                .setSmallIcon(android.R.drawable.stat_sys_warning)
+                .setContentIntent(tap)
+                .setAutoCancel(true)
+                .addAction(android.R.drawable.ic_menu_revert, "Reject", approvalAction("reject", id, clientId, 2))
+                .addAction(android.R.drawable.ic_menu_send, "Approve", approvalAction("approve", id, clientId, 3))
+                .build(),
+        )
+    }
+
+    // PendingIntent → NotifActionReceiver for an approve/reject button. `reqCode` keeps the
+    // two PendingIntents distinct (same Intent action would otherwise collide).
+    private fun approvalAction(kind: String, id: String, clientId: String, reqCode: Int): PendingIntent =
+        PendingIntent.getBroadcast(
+            this, reqCode,
+            Intent(this, NotifActionReceiver::class.java).apply {
+                action = NotifActionReceiver.ACTION
+                putExtra(NotifActionReceiver.EXTRA_KIND, kind)
+                putExtra(NotifActionReceiver.EXTRA_CLIENT, clientId)
+                putExtra(NotifActionReceiver.EXTRA_APPROVAL_ID, id)
+                putExtra(NotifActionReceiver.EXTRA_NOTIF_ID, APPROVAL_NOTIF_ID)
+            },
+            PendingIntent.FLAG_UPDATE_CURRENT or PendingIntent.FLAG_IMMUTABLE,
+        )
 
     // A status may carry a muted second line after a newline ("main\nsubtitle"); split it
     // so the splash shows a bright primary line over a dimmer detail line.
@@ -143,12 +259,11 @@ class MainActivity : AppCompatActivity() {
 
     // Everything heavy runs off the UI thread; the UI shows progress until the server
     // is ready. Errors surface in the status view instead of a blank WebView.
+    // NOTE (#53): we do NOT start ServerService here anymore. The node server runs as a
+    // child of this process and lives as long as the Activity is foreground. The
+    // foreground service is promoted only while a turn is active AND the user enabled
+    // background exec — driven from the web UI via ShellBridge.setAgentActive().
     private fun startServerFlow() {
-        // Keep the server alive across backgrounding before we start it.
-        val svc = Intent(this, ServerService::class.java)
-        if (Build.VERSION.SDK_INT >= Build.VERSION_CODES.O) startForegroundService(svc)
-        else startService(svc)
-
         thread {
             try {
                 val installer = Installer(this)
@@ -168,6 +283,7 @@ class MainActivity : AppCompatActivity() {
 
     override fun onDestroy() {
         if (::googleTokenServer.isInitialized) googleTokenServer.stop()
+        stopService(Intent(this, ServerService::class.java)) // no orphaned foreground notif
         server.stop()
         super.onDestroy()
     }

--- a/surfaces/android/app/src/main/java/com/iqlabs/agentnet/NotifActionReceiver.kt
+++ b/surfaces/android/app/src/main/java/com/iqlabs/agentnet/NotifActionReceiver.kt
@@ -1,0 +1,59 @@
+package com.iqlabs.agentnet
+
+import android.app.NotificationManager
+import android.content.BroadcastReceiver
+import android.content.Context
+import android.content.Intent
+
+// Handles the notification action buttons (#53): Stop a running turn, or Approve/Reject a
+// pending tool approval. Each maps to one /rpc message — the same message the in-app button
+// sends — so the engine is driven through the unchanged dispatcher/approval path.
+//
+// A BroadcastReceiver's onReceive runs on the main thread and can't block on network, so we
+// goAsync() and do the POST on a worker thread, then finish().
+class NotifActionReceiver : BroadcastReceiver() {
+    companion object {
+        const val ACTION = "com.iqlabs.agentnet.NOTIF_ACTION"
+        const val EXTRA_KIND = "kind"         // "stop" | "approve" | "reject"
+        const val EXTRA_CLIENT = "client"     // SSE client id to route the POST
+        const val EXTRA_APPROVAL_ID = "approvalId" // for approve/reject
+        const val EXTRA_NOTIF_ID = "notifId"  // notification to dismiss after acting
+    }
+
+    override fun onReceive(context: Context, intent: Intent) {
+        if (intent.action != ACTION) return
+        val kind = intent.getStringExtra(EXTRA_KIND) ?: return
+        val client = intent.getStringExtra(EXTRA_CLIENT) ?: ""
+        val approvalId = intent.getStringExtra(EXTRA_APPROVAL_ID)
+        val notifId = intent.getIntExtra(EXTRA_NOTIF_ID, -1)
+
+        // Dismiss the notification immediately so the tap feels responsive.
+        if (notifId >= 0) {
+            context.getSystemService(NotificationManager::class.java)?.cancel(notifId)
+        }
+
+        val body = when (kind) {
+            "stop" -> """{"type":"interrupt"}"""
+            "approve" -> """{"type":"approvalDecision","id":${jsonStr(approvalId)},"outcome":"once"}"""
+            "reject" -> """{"type":"approvalDecision","id":${jsonStr(approvalId)},"outcome":"deny","reason":"Rejected from notification"}"""
+            else -> return
+        }
+
+        val pending = goAsync()
+        Thread {
+            try {
+                RpcClient.post(client, body)
+                // Stop also demotes the foreground service (no more active work to hold it).
+                if (kind == "stop") context.stopService(Intent(context, ServerService::class.java))
+            } finally {
+                pending.finish()
+            }
+        }.start()
+    }
+
+    // Minimal JSON string escaping for the approval id (ids are engine-generated, but be safe).
+    private fun jsonStr(s: String?): String {
+        val v = s ?: ""
+        return "\"" + v.replace("\\", "\\\\").replace("\"", "\\\"") + "\""
+    }
+}

--- a/surfaces/android/app/src/main/java/com/iqlabs/agentnet/RpcClient.kt
+++ b/surfaces/android/app/src/main/java/com/iqlabs/agentnet/RpcClient.kt
@@ -1,0 +1,39 @@
+package com.iqlabs.agentnet
+
+import android.util.Log
+import java.net.HttpURLConnection
+import java.net.URL
+
+// Posts a single UI→server command to the loopback node server's /rpc, exactly as the
+// WebView does (POST /rpc?client=<id>, JSON body). Used by notification actions (#53) —
+// Stop / Approve / Reject — so they drive the engine through the SAME path as the in-app
+// buttons (no protocol fork, no weakening of the approval gate). The server acks 204 and
+// streams the real effect back over the client's SSE.
+object RpcClient {
+    private const val TAG = "AgentNet/Rpc"
+
+    // `jsonBody` is a ready-made JSON object string, e.g. {"type":"interrupt"} or
+    // {"type":"approvalDecision","id":"…","outcome":"deny"}. Runs on the caller's thread;
+    // callers (a BroadcastReceiver via goAsync) are already off the main thread.
+    fun post(clientId: String, jsonBody: String): Boolean {
+        if (clientId.isBlank()) { Log.w(TAG, "no client id; dropping $jsonBody"); return false }
+        return try {
+            val url = URL("http://127.0.0.1:${Paths.PORT}/rpc?client=" + java.net.URLEncoder.encode(clientId, "UTF-8"))
+            (url.openConnection() as HttpURLConnection).run {
+                requestMethod = "POST"
+                connectTimeout = 3000
+                readTimeout = 3000
+                doOutput = true
+                setRequestProperty("content-type", "application/json")
+                outputStream.use { it.write(jsonBody.toByteArray()) }
+                val code = responseCode
+                disconnect()
+                Log.i(TAG, "rpc $jsonBody → HTTP $code")
+                code in 200..399
+            }
+        } catch (e: Exception) {
+            Log.e(TAG, "rpc post failed: $jsonBody", e)
+            false
+        }
+    }
+}

--- a/surfaces/android/app/src/main/java/com/iqlabs/agentnet/ServerService.kt
+++ b/surfaces/android/app/src/main/java/com/iqlabs/agentnet/ServerService.kt
@@ -3,48 +3,79 @@ package com.iqlabs.agentnet
 import android.app.Notification
 import android.app.NotificationChannel
 import android.app.NotificationManager
+import android.app.PendingIntent
 import android.app.Service
 import android.content.Intent
 import android.os.Build
 import android.os.IBinder
 
-// Foreground service that keeps the node server (and any running agent turn) alive when
-// the app is backgrounded. Android aggressively kills background processes; a foreground
-// service with an ongoing notification is the supported way to say "I'm doing work the
-// user asked for, don't kill me". START_STICKY asks Android to restart us if it does.
-// (Generic Android pattern, same shape as AnyClaw's foreground service.)
+// Foreground service that keeps the node server (and the running agent turn) alive when the
+// app is backgrounded. Android aggressively kills background processes; a foreground service
+// with an ongoing notification is the supported way to say "I'm doing work the user asked
+// for, don't kill me". (Generic Android pattern, same shape as AnyClaw's foreground service.)
+//
+// #53: the notification tells the user what's running, taps back into the chat, and offers a
+// Stop action that cancels the turn (posts {type:"interrupt"} to /rpc via NotifActionReceiver).
 class ServerService : Service() {
     companion object {
         private const val CHANNEL = "agentnet_server"
         private const val NOTIF_ID = 1
+        const val EXTRA_CLIENT = "client" // SSE client id, so Stop can reach /rpc
     }
 
     override fun onCreate() {
         super.onCreate()
         if (Build.VERSION.SDK_INT >= Build.VERSION_CODES.O) {
-            val mgr = getSystemService(NotificationManager::class.java)
-            mgr.createNotificationChannel(
+            getSystemService(NotificationManager::class.java).createNotificationChannel(
                 NotificationChannel(CHANNEL, "AgentNet", NotificationManager.IMPORTANCE_LOW)
             )
         }
-        startForeground(NOTIF_ID, notification())
+        startForeground(NOTIF_ID, notification(""))
     }
 
-    override fun onStartCommand(intent: Intent?, flags: Int, startId: Int): Int = START_STICKY
+    // Each start carries the latest client id; rebuild the notification so Stop targets the
+    // live SSE client. NOT sticky (#53): runs only while a turn is active — if Android kills
+    // it we don't want it auto-resurrected with no work to do; the next turn restarts it.
+    override fun onStartCommand(intent: Intent?, flags: Int, startId: Int): Int {
+        val client = intent?.getStringExtra(EXTRA_CLIENT) ?: ""
+        startForeground(NOTIF_ID, notification(client))
+        return START_NOT_STICKY
+    }
 
     override fun onBind(intent: Intent?): IBinder? = null
 
-    private fun notification(): Notification {
+    private fun notification(client: String): Notification {
         val builder = if (Build.VERSION.SDK_INT >= Build.VERSION_CODES.O) {
             Notification.Builder(this, CHANNEL)
         } else {
             @Suppress("DEPRECATION") Notification.Builder(this)
         }
+
+        // Tap → bring the chat to the front.
+        val open = PendingIntent.getActivity(
+            this, 0,
+            Intent(this, MainActivity::class.java).addFlags(Intent.FLAG_ACTIVITY_REORDER_TO_FRONT),
+            PendingIntent.FLAG_UPDATE_CURRENT or PendingIntent.FLAG_IMMUTABLE,
+        )
+        // Stop → interrupt the turn + demote the service (handled in NotifActionReceiver).
+        val stop = PendingIntent.getBroadcast(
+            this, 1,
+            Intent(this, NotifActionReceiver::class.java).apply {
+                action = NotifActionReceiver.ACTION
+                putExtra(NotifActionReceiver.EXTRA_KIND, "stop")
+                putExtra(NotifActionReceiver.EXTRA_CLIENT, client)
+                putExtra(NotifActionReceiver.EXTRA_NOTIF_ID, NOTIF_ID)
+            },
+            PendingIntent.FLAG_UPDATE_CURRENT or PendingIntent.FLAG_IMMUTABLE,
+        )
+
         return builder
-            .setContentTitle("AgentNet is running")
-            .setContentText("Local agent server active")
+            .setContentTitle("AgentNet is working")
+            .setContentText("An agent task is running in the background")
             .setSmallIcon(android.R.drawable.stat_notify_sync)
             .setOngoing(true)
+            .setContentIntent(open)
+            .addAction(android.R.drawable.ic_menu_close_clear_cancel, "Stop", stop)
             .build()
     }
 }

--- a/surfaces/android/app/src/main/java/com/iqlabs/agentnet/ShellBridge.kt
+++ b/surfaces/android/app/src/main/java/com/iqlabs/agentnet/ShellBridge.kt
@@ -3,9 +3,10 @@ package com.iqlabs.agentnet
 import android.content.Intent
 import android.net.Uri
 import android.webkit.JavascriptInterface
-import androidx.appcompat.app.AppCompatActivity
 
-class ShellBridge(private val activity: AppCompatActivity) {
+// Web→native bridge injected as `window.AgentNetShell`. Methods are best-effort and hop to
+// the UI thread where they touch Activity/service state.
+class ShellBridge(private val activity: MainActivity) {
     @JavascriptInterface
     fun openUrl(url: String) {
         val uri = runCatching { Uri.parse(url) }.getOrNull() ?: return
@@ -14,5 +15,23 @@ class ShellBridge(private val activity: AppCompatActivity) {
         activity.runOnUiThread {
             runCatching { activity.startActivity(Intent(Intent.ACTION_VIEW, uri)) }
         }
+    }
+
+    // #53: turn started/ended → promote/demote the background foreground service.
+    @JavascriptInterface
+    fun setAgentActive(active: Boolean, clientId: String) {
+        activity.runOnUiThread { runCatching { activity.setAgentActive(active, clientId) } }
+    }
+
+    // #53: a turn is waiting on approval → raise a notification if the app is backgrounded.
+    @JavascriptInterface
+    fun requestApproval(id: String, title: String, clientId: String) {
+        activity.runOnUiThread { runCatching { activity.requestApproval(id, title, clientId) } }
+    }
+
+    // #53: user just enabled background execution → prompt for battery-opt exemption (once).
+    @JavascriptInterface
+    fun onBackgroundEnabled() {
+        activity.runOnUiThread { runCatching { activity.onBackgroundEnabled() } }
     }
 }

--- a/surfaces/localhost/src/index.ts
+++ b/surfaces/localhost/src/index.ts
@@ -30,6 +30,7 @@ import {
   connect,
   createChatSession,
   TransportApprovalChannel,
+  withTimeout,
   webWallet,
   getStorageInfo,
   STORAGE_OPTIONS,
@@ -628,7 +629,7 @@ function attachChat(id: string, c: Client, rt: AgentRuntime) {
     // handler on the same transport. POST fans out to all of them.
     onRecv: (cb: (m: any) => void) => { c.recvs.push(cb); },
   };
-  const approval = new TransportApprovalChannel(transport);
+  const approval = withTimeout(new TransportApprovalChannel(transport));
   const chat = createChatSession(rt, transport, {
     cwd: () => process.cwd(),
     approval,

--- a/surfaces/vscode/src/extension.ts
+++ b/surfaces/vscode/src/extension.ts
@@ -26,6 +26,7 @@ import {
   maskedHeliusKey,
   getNetwork,
   TransportApprovalChannel,
+  withTimeout,
   chatHtml,
   onboardingHtml,
   listCodexModelOptions,
@@ -182,7 +183,7 @@ async function openChat(context: vscode.ExtensionContext, column = vscode.ViewCo
   // This panel's OWN approval channel — tool approvals from sessions started here
   // dock in THIS panel (it shares this panel's transport). Drained on dispose so a
   // request to a closed panel auto-denies instead of hanging the engine.
-  const approval = new TransportApprovalChannel(transport);
+  const approval = withTimeout(new TransportApprovalChannel(transport));
   panel.onDidDispose(() => approval.drain());
 
   // Multi-tab guard: VSCode can open the same session in two panels (two tabs writing

--- a/surfaces/webview/src/App.tsx
+++ b/surfaces/webview/src/App.tsx
@@ -8,6 +8,8 @@ import { ChatScreen } from "./chat/ChatScreen";
 import { MarketScreen } from "./market/MarketScreen";
 import { Toast } from "./Toast";
 import { useVisualViewportVars } from "./layoutEffects";
+import { useEffect } from "react";
+import { syncAgentService, notifyApproval } from "./platform/agentService";
 
 // Phase router:
 //   connecting   → opening SSE stream / sent `ready`, waiting for init|sessions
@@ -18,8 +20,21 @@ import { useVisualViewportVars } from "./layoutEffects";
 //   codexAuth    → codex chosen, not logged in → device-auth (open URL, enter code)
 //   chat         → runtime ready → the chat shell
 export function App() {
-  const { state } = useStore();
+  const { state, getClientId } = useStore();
   useVisualViewportVars();
+
+  // Issue #53: a turn streaming OR a pending approval = active agent work. Keep the
+  // Android foreground service (proot runtime) alive only while that's true and the user
+  // enabled background exec; demote otherwise. No-op off the Android shell.
+  const agentActive = state.typing || state.approvals.length > 0;
+  useEffect(() => { syncAgentService(agentActive, getClientId()); }, [agentActive, getClientId]);
+
+  // Backgrounded approval → ask the shell to raise a notification. Fires per new top
+  // approval; the shell ignores it when the app is foreground.
+  const topApproval = state.approvals[0];
+  useEffect(() => {
+    if (topApproval) notifyApproval(topApproval.id, topApproval.title, getClientId());
+  }, [topApproval?.id, topApproval?.title, getClientId]);
 
   return (
     <>

--- a/surfaces/webview/src/chat/ChatScreen.tsx
+++ b/surfaces/webview/src/chat/ChatScreen.tsx
@@ -54,6 +54,7 @@ export function ChatScreen() {
           )}
         </div>
         <div className="flex items-center gap-1 shrink-0">
+          <StatusBadge waitingApproval={state.approvals.length > 0} working={state.typing} />
           {state.firingSkill && (
             <span className="inline-flex items-center gap-1 text-xs animate-pulse skill-firing-badge" style={{ color: "var(--an-green)" }}>
               <SkillIcon className="h-3.5 w-3.5" /> {state.firingSkill}
@@ -86,4 +87,27 @@ export function ChatScreen() {
       {drawer && <Sessions onClose={() => setDrawer(false)} />}
     </div>
   );
+}
+
+// Lifecycle indicator (#53): so the user can always see what the agent is doing. Approval
+// wins over working (it's the blocking state). Idle = no badge — an empty header reads as
+// "nothing running" more clearly than a muted "idle" chip. Foreground-vs-background isn't
+// shown here: a backgrounded WebView can't paint, so that distinction lives on the Android
+// notification, which IS the visible surface when backgrounded.
+function StatusBadge({ waitingApproval, working }: { waitingApproval: boolean; working: boolean }) {
+  if (waitingApproval) {
+    return (
+      <span className="inline-flex items-center gap-1 text-xs font-medium" style={{ color: "var(--an-amber)" }}>
+        <span className="h-1.5 w-1.5 rounded-full" style={{ background: "var(--an-amber)" }} /> Waiting for approval
+      </span>
+    );
+  }
+  if (working) {
+    return (
+      <span className="inline-flex items-center gap-1 text-xs font-medium animate-pulse" style={{ color: "var(--an-green)" }}>
+        <span className="h-1.5 w-1.5 rounded-full" style={{ background: "var(--an-green)" }} /> Working
+      </span>
+    );
+  }
+  return null;
 }

--- a/surfaces/webview/src/chat/Sessions.tsx
+++ b/surfaces/webview/src/chat/Sessions.tsx
@@ -4,6 +4,7 @@ import { openExternalUrl } from "../platform/openExternalUrl";
 import { useAutoOpenExternalUrl } from "../platform/useAutoOpenExternalUrl";
 import { HeliusKeyForm } from "../settings/HeliusKeyForm";
 import { ConnectGithub } from "../onboarding/ConnectGithub";
+import { hasAgentService, backgroundExecEnabled, setBackgroundExecEnabled } from "../platform/agentService";
 
 // Chat list drawer — the mobile answer to vscode's multi-panel "new tab": instead of
 // splitting the screen, the ☰ menu slides this in and you pick ONE chat to show. Telegram
@@ -35,7 +36,7 @@ function MenuRow({ icon, label, subtitle, onClick, accent = false }: {
 }
 
 export function Sessions({ onClose }: { onClose: () => void }) {
-  const { state, send, openMarket, openMarketAgents } = useStore();
+  const { state, send, openMarket, openMarketAgents, getClientId, notify } = useStore();
   const { storage, cloudSync, googleLoginUrl, googleLoginError } = state;
 
   const [settingsMode, setSettingsMode] = useState<"list" | "connect" | "gdrive" | "custom" | "helius" | "github">("list");
@@ -44,6 +45,7 @@ export function Sessions({ onClose }: { onClose: () => void }) {
   const [code, setCode] = useState("");
   const [copied, setCopied] = useState(false);
   const [busy, setBusy] = useState(false);
+  const [bgExec, setBgExec] = useState(backgroundExecEnabled());
   const [showManualCode, setShowManualCode] = useState(false);
 
   const info = storage?.info as { kind?: string; connected?: boolean; account?: string; location?: string } | null;
@@ -163,6 +165,40 @@ export function Sessions({ onClose }: { onClose: () => void }) {
                   onClick={() => { send({ type: "getGithubStatus" }); setSettingsMode("github"); }}
                   icon={<svg width="22" height="22" viewBox="0 0 22 22" fill="none" stroke="currentColor" strokeWidth="1.55" strokeLinecap="round" strokeLinejoin="round"><path d="M8.5 16.5c-3 .9-3-1.5-4.2-1.8M15 19v-3.1c0-.8-.3-1.4-.8-1.8 2.6-.3 5.3-1.3 5.3-5.7 0-1.3-.4-2.3-1.2-3.2.1-.3.5-1.6-.1-3.1 0 0-1-.3-3.3 1.2a11.5 11.5 0 0 0-6 0C6.6 1.8 5.6 2.1 5.6 2.1c-.6 1.5-.2 2.8-.1 3.1-.8.9-1.2 2-1.2 3.2 0 4.4 2.7 5.4 5.3 5.7-.4.4-.7.9-.8 1.6V19" /></svg>}
                 />
+                {/* Android shell only: keep the agent running (and notify on approvals)
+                    while the app is backgrounded — but ONLY while a task is active. Off =
+                    idle process is reclaimed. Turning OFF mid-turn is foreground-only: the
+                    current turn keeps running while the app is open, it just won't survive
+                    backgrounding. (#53) */}
+                {hasAgentService() && (
+                  <>
+                    <button
+                      onClick={() => {
+                        const v = !bgExec;
+                        setBgExec(v);
+                        setBackgroundExecEnabled(v, getClientId());
+                        if (!v && state.typing) notify("Background off — task keeps running while the app is open.");
+                      }}
+                      className="flex w-full items-center gap-3.5 rounded-2xl px-2.5 py-3 text-left transition active:bg-[color:var(--an-bg-2)]"
+                    >
+                      <span className="flex h-7 w-7 shrink-0 items-center justify-center" style={{ color: bgExec ? "var(--an-green)" : "var(--an-fg-dim)" }}>
+                        <svg width="22" height="22" viewBox="0 0 22 22" fill="none" stroke="currentColor" strokeWidth="1.55" strokeLinecap="round" strokeLinejoin="round"><circle cx="11" cy="11" r="7" /><path d="M11 7v4l2.5 2" /></svg>
+                      </span>
+                      <span className="min-w-0 flex-1">
+                        <span className="block text-[1.12rem] font-semibold leading-tight" style={{ color: "var(--an-fg)" }}>Background execution</span>
+                        <span className="block text-[0.72rem] leading-tight" style={{ color: "var(--an-fg-mute)" }}>{bgExec ? "Runs in the background only while a task is active" : "Agent stops when you leave the app"}</span>
+                      </span>
+                      <span className="relative h-[1.35rem] w-[2.4rem] shrink-0 rounded-full transition" style={{ background: bgExec ? "var(--an-green)" : "var(--an-bg-2)" }}>
+                        <span className="absolute top-[0.15rem] h-[1.05rem] w-[1.05rem] rounded-full bg-white transition-all" style={{ left: bgExec ? "1.2rem" : "0.15rem" }} />
+                      </span>
+                    </button>
+                    {bgExec && (
+                      <p className="px-2.5 pb-1 text-[0.68rem] leading-snug" style={{ color: "var(--an-fg-mute)" }}>
+                        Uses more battery while a task runs in the background. No task = nothing runs.
+                      </p>
+                    )}
+                  </>
+                )}
               </div>
             </div>
 

--- a/surfaces/webview/src/market/AgentProfileView.tsx
+++ b/surfaces/webview/src/market/AgentProfileView.tsx
@@ -1,4 +1,5 @@
-import { useState } from "react";
+import { useRef, useState, type KeyboardEvent } from "react";
+import { parseGithubLink, safeExternalUrl } from "@iqlabs-official/agent-sdk/links/github.js";
 import { useStore } from "../state/store";
 import type { AgentProfile, SkillCard } from "../transport/protocol";
 import { AgentIcon } from "../icons";
@@ -14,6 +15,7 @@ export function AgentProfileView({ profile, onBack, onOpenSkill }: Props) {
   const [noteText, setNoteText] = useState("");
   const [buyingAll, setBuyingAll] = useState(false);
   const [noteGitLink, setNoteGitLink] = useState("");
+  const blogDrag = useRef({ active: false, moved: false, startX: 0, startLeft: 0 });
 
   function handleBuyAll() {
     setBuyingAll(true);
@@ -22,7 +24,7 @@ export function AgentProfileView({ profile, onBack, onOpenSkill }: Props) {
   }
 
   function handleNote() {
-    if (!noteText.trim()) return;
+    if (!noteText.trim() || (!profile.self && !profile.canComment)) return;
     send({
       type: "postAgentNote",
       agentWallet: profile.wallet,
@@ -34,6 +36,54 @@ export function AgentProfileView({ profile, onBack, onOpenSkill }: Props) {
   }
 
   const allSkills = [...(profile.createdSkills ?? [])];
+  const blogNotes = (profile.notes ?? []).filter((n) => n.isSelfNote);
+  const comments = (profile.notes ?? []).filter((n) => !n.isSelfNote);
+  const canPost = profile.self || profile.canComment;
+  const composeTitle = profile.self ? "Post to blog" : "Write a comment";
+  const composePlaceholder = profile.self ? "Write a blog post or update..." : "Share your experience with this agent...";
+
+  function shortWallet(wallet?: string) {
+    return wallet ? `${wallet.slice(0, 6)}...${wallet.slice(-4)}` : "?";
+  }
+
+  function noteDate(timestamp?: number) {
+    if (!timestamp) return "";
+    try {
+      return new Date(timestamp).toLocaleDateString(undefined, { month: "short", day: "numeric", year: "numeric" });
+    } catch {
+      return "";
+    }
+  }
+
+  function GithubCard({ url }: { url: string }) {
+    const info = parseGithubLink(url);
+    if (!info) {
+      const safe = safeExternalUrl(url);
+      return safe ? (
+        <a href={safe} target="_blank" rel="noreferrer" className="text-blue-400 text-[10px] mt-1 block truncate">{safe}</a>
+      ) : null;
+    }
+
+    const kind = info.kind === "pull" ? "PR" : info.kind === "blob" ? "File" : info.kind === "commit" ? "Commit" : "Repo";
+    return (
+      <a
+        href={info.href}
+        target="_blank"
+        rel="noreferrer"
+        className="mt-2 block rounded-md border border-zinc-700/80 bg-zinc-950/70 px-2.5 py-2 active:bg-zinc-900"
+      >
+        <span className="block text-[9px] font-semibold uppercase tracking-wide text-blue-300">{kind}</span>
+        <span className="mt-0.5 block truncate text-[11px] font-medium text-zinc-100">{info.label}</span>
+        <span className="mt-0.5 block truncate text-[10px] text-zinc-500">{info.meta}</span>
+      </a>
+    );
+  }
+
+  function onBlogKeyDown(e: KeyboardEvent<HTMLDivElement>) {
+    if (e.key !== "ArrowLeft" && e.key !== "ArrowRight") return;
+    e.preventDefault();
+    e.currentTarget.scrollBy({ left: e.key === "ArrowRight" ? 260 : -260, behavior: "smooth" });
+  }
 
   return (
     <div className="flex flex-col h-full">
@@ -90,46 +140,100 @@ export function AgentProfileView({ profile, onBack, onOpenSkill }: Props) {
           </div>
         )}
 
-        {/* Notes/blog */}
-        {profile.notes && profile.notes.length > 0 && (
+        {/* Blog */}
+        {blogNotes.length > 0 && (
           <div>
-            <p className="text-[11px] text-zinc-500 uppercase tracking-wide mb-2">Notes</p>
+            <p className="text-[11px] text-zinc-500 uppercase tracking-wide mb-2">Blog</p>
+            <div
+              className="flex snap-x gap-2 overflow-x-auto pb-2 outline-none [-webkit-overflow-scrolling:touch]"
+              tabIndex={0}
+              aria-label="Blog posts"
+              onKeyDown={onBlogKeyDown}
+              onWheel={(e) => {
+                if (Math.abs(e.deltaY) <= Math.abs(e.deltaX)) return;
+                e.currentTarget.scrollLeft += e.deltaY;
+              }}
+              onPointerDown={(e) => {
+                if (e.pointerType !== "mouse" || e.button !== 0) return;
+                blogDrag.current = { active: true, moved: false, startX: e.clientX, startLeft: e.currentTarget.scrollLeft };
+                e.currentTarget.setPointerCapture(e.pointerId);
+              }}
+              onPointerMove={(e) => {
+                const drag = blogDrag.current;
+                if (!drag.active) return;
+                const dx = e.clientX - drag.startX;
+                if (Math.abs(dx) > 3) drag.moved = true;
+                e.currentTarget.scrollLeft = drag.startLeft - dx;
+              }}
+              onPointerUp={(e) => {
+                if (!blogDrag.current.active) return;
+                blogDrag.current.active = false;
+                e.currentTarget.releasePointerCapture(e.pointerId);
+              }}
+              onPointerCancel={() => {
+                blogDrag.current.active = false;
+              }}
+              onClickCapture={(e) => {
+                if (!blogDrag.current.moved) return;
+                e.preventDefault();
+                e.stopPropagation();
+                blogDrag.current.moved = false;
+              }}
+            >
+              {blogNotes.map((n) => (
+                <article key={n.id} className="min-w-[230px] max-w-[260px] flex-[0_0_78%] snap-start rounded-lg bg-zinc-900 border border-zinc-800 p-3 text-xs text-zinc-300 sm:flex-[0_0_240px]">
+                  <p className="whitespace-pre-wrap break-words leading-relaxed">{n.text}</p>
+                  {n.gitLink && <GithubCard url={n.gitLink} />}
+                  {noteDate(n.timestamp) && <p className="mt-2 border-t border-zinc-800 pt-1.5 text-[10px] text-zinc-600">{noteDate(n.timestamp)}</p>}
+                </article>
+              ))}
+            </div>
+          </div>
+        )}
+
+        {/* Comments */}
+        {comments.length > 0 && (
+          <div>
+            <p className="text-[11px] text-zinc-500 uppercase tracking-wide mb-2">Comments</p>
             <div className="space-y-2">
-              {(profile.notes as any[]).map((n: any, i) => (
-                <div key={i} className="rounded-lg bg-zinc-900 border border-zinc-800 p-2.5 text-xs text-zinc-300">
-                  <p className="text-zinc-600 text-[10px] mb-0.5">{n.author?.slice(0, 6)}…</p>
-                  <p>{n.text}</p>
-                  {n.gitLink && (
-                    <a href={n.gitLink} target="_blank" rel="noreferrer" className="text-blue-400 text-[10px] mt-0.5 block truncate">{n.gitLink}</a>
-                  )}
+              {comments.map((n) => (
+                <div key={n.id} className="rounded-lg bg-zinc-900 border border-zinc-800 p-2.5 text-xs text-zinc-300">
+                  <p className="text-zinc-600 text-[10px] mb-0.5">{shortWallet(n.author)}</p>
+                  <p className="whitespace-pre-wrap break-words">{n.text}</p>
+                  {n.gitLink && <GithubCard url={n.gitLink} />}
                 </div>
               ))}
             </div>
           </div>
         )}
 
-        {/* Leave note */}
+        {/* Compose */}
         <div className="space-y-1.5">
-          <p className="text-[11px] text-zinc-500 uppercase tracking-wide">Leave a note</p>
+          <p className="text-[11px] text-zinc-500 uppercase tracking-wide">{composeTitle}</p>
+          {!canPost && (
+            <p className="rounded-lg border border-zinc-800 bg-zinc-900 px-2 py-1.5 text-[10px] text-zinc-500">Own at least one of this agent's skills to comment.</p>
+          )}
           <textarea
             className="w-full rounded-lg bg-zinc-900 border border-zinc-800 p-2 text-xs text-zinc-200 resize-none focus:outline-none focus:border-green-500/50"
             rows={2}
-            placeholder="Your message…"
+            placeholder={composePlaceholder}
             value={noteText}
+            disabled={!canPost}
             onChange={(e) => setNoteText(e.target.value)}
           />
           <input
             className="w-full rounded-lg bg-zinc-900 border border-zinc-800 px-2 py-1.5 text-xs text-zinc-300 placeholder-zinc-600 focus:outline-none focus:border-blue-500/50"
             placeholder="GitHub link (optional)"
             value={noteGitLink}
+            disabled={!canPost}
             onChange={(e) => setNoteGitLink(e.target.value)}
           />
           <button
             onClick={handleNote}
-            disabled={!noteText.trim()}
+            disabled={!noteText.trim() || !canPost}
             className="text-xs px-3 py-1.5 rounded-lg bg-zinc-800 text-zinc-300 disabled:opacity-40 active:bg-zinc-700"
           >
-            Post
+            {profile.self ? "Post" : "Comment"}
           </button>
         </div>
       </div>

--- a/surfaces/webview/src/platform/agentService.ts
+++ b/surfaces/webview/src/platform/agentService.ts
@@ -1,0 +1,53 @@
+// Bridge to the Android shell's background-execution control (issue #53). On desktop /
+// browser `window.AgentNetShell` is absent, so every call here is a no-op. The shell only
+// keeps its foreground service (and thus the proot node runtime) alive while a turn is
+// ACTIVE *and* the user opted into background execution — so we drive it from turn state,
+// not on app launch. Idle ⇒ no service ⇒ Android reclaims the process normally.
+//
+// The shell's notification actions (Stop / Approve / Reject) POST back to the loopback
+// server's /rpc, which needs the SSE client id to route — so we pass it on every call.
+declare global {
+  interface Window {
+    AgentNetShell?: {
+      openUrl?(url: string): void;
+      // Promote (true) / demote (false) the foreground service. `clientId` lets the
+      // persistent notification's Stop action reach /rpc.
+      setAgentActive?(active: boolean, clientId: string): void;
+      // Raise an approval notification (shell no-ops it when foreground). Its Approve/
+      // Reject actions POST an approvalDecision to /rpc?client=<clientId>.
+      requestApproval?(id: string, title: string, clientId: string): void;
+      // First time the user enables background exec: prompt for battery-optimization
+      // exemption so Android doesn't reap a long task. Guarded native-side against nagging.
+      onBackgroundEnabled?(): void;
+    };
+  }
+}
+
+const KEY = "agentnet.backgroundExec";
+
+// Only true inside the Android shell — gates the settings toggle's visibility.
+export function hasAgentService(): boolean {
+  return typeof window.AgentNetShell?.setAgentActive === "function";
+}
+
+export function backgroundExecEnabled(): boolean {
+  return localStorage.getItem(KEY) === "1";
+}
+
+export function setBackgroundExecEnabled(on: boolean, clientId: string | null): void {
+  localStorage.setItem(KEY, on ? "1" : "0");
+  if (on) window.AgentNetShell?.onBackgroundEnabled?.();
+  else window.AgentNetShell?.setAgentActive?.(false, clientId ?? ""); // demote at once when off
+}
+
+// Reflect agent activity to the shell. Promotes only when background exec is enabled AND a
+// turn is active; otherwise demotes so the idle process can be reclaimed.
+export function syncAgentService(active: boolean, clientId: string | null): void {
+  window.AgentNetShell?.setAgentActive?.(active && backgroundExecEnabled(), clientId ?? "");
+}
+
+// Ask the shell to surface a pending approval (it decides notify-vs-ignore by its own
+// foreground state).
+export function notifyApproval(id: string, title: string, clientId: string | null): void {
+  window.AgentNetShell?.requestApproval?.(id, title, clientId ?? "");
+}

--- a/surfaces/webview/src/platform/openExternalUrl.ts
+++ b/surfaces/webview/src/platform/openExternalUrl.ts
@@ -1,11 +1,4 @@
-declare global {
-  interface Window {
-    AgentNetShell?: {
-      openUrl(url: string): void;
-    };
-  }
-}
-
+// `window.AgentNetShell` type is declared in ./agentService (one canonical declaration).
 export function openExternalUrl(url: string): void {
   if (typeof window.AgentNetShell?.openUrl === "function") {
     window.AgentNetShell.openUrl(url);

--- a/surfaces/webview/src/state/store.tsx
+++ b/surfaces/webview/src/state/store.tsx
@@ -213,6 +213,7 @@ type LocalAction =
   | { type: "__clearAgentProfile" }
   | { type: "__changeMode"; mode: string }
   | { type: "__clearFiringSkill" }
+  | { type: "__setToast"; text: string }
   | { type: "__clearCelebrate" };
 type Action = ServerMessage | LocalAction;
 
@@ -224,6 +225,8 @@ function reducer(state: State, ev: Action): State {
       return { ...state, approvals: state.approvals.filter((a) => a.id !== ev.id) };
     case "__clearToast":
       return { ...state, toast: null };
+    case "__setToast":
+      return { ...state, toast: ev.text };
     case "__selectEngine": {
       if (!state.cliReport) {
         return { ...state, toast: "Checking engine sign-in. Try again in a moment." };
@@ -453,6 +456,10 @@ interface Store {
   clearAgentProfile: () => void;
   clearFiringSkill: () => void;
   clearCelebrate: () => void;
+  // Current SSE client id — native (Android) notification actions POST to /rpc with it.
+  getClientId: () => string | null;
+  // Show a transient toast locally (e.g. the foreground-only turn-off notice, #53).
+  notify: (text: string) => void;
 }
 
 const StoreContext = createContext<Store | null>(null);
@@ -596,6 +603,8 @@ export function StoreProvider({ children }: { children: ReactNode }) {
       clearAgentProfile: () => raw({ type: "__clearAgentProfile" }),
       clearFiringSkill: () => raw({ type: "__clearFiringSkill" }),
       clearCelebrate: () => raw({ type: "__clearCelebrate" }),
+      getClientId: () => transportRef.current?.getClientId() ?? null,
+      notify: (text) => raw({ type: "__setToast", text }),
     };
   }, [state]);
 

--- a/surfaces/webview/src/transport/client.ts
+++ b/surfaces/webview/src/transport/client.ts
@@ -19,6 +19,12 @@ export class Transport {
   private listeners = new Set<Listener>();
   private closed = false;
 
+  /** The SSE client id (null until the handshake lands). Native notification actions POST
+   *  to /rpc?client=<id> with it, so the Android shell needs to read it. */
+  getClientId(): string | null {
+    return this.clientId;
+  }
+
   /** Subscribe to server→UI events. Returns an unsubscribe fn. */
   onEvent(cb: Listener): () => void {
     this.listeners.add(cb);


### PR DESCRIPTION
## What

Implements issue #53 — Android background server lifecycle + all UI/UX criteria from comment 2.

## Changes

### Core
- `withTimeout()` composable wrapper around `ApprovalChannel` — auto-denies after 10 min, prevents infinite hangs. Applied to localhost + vscode surfaces.

### Android
- **ServerService**: promoted only when a turn is active + bg exec ON; `START_NOT_STICKY` — no auto-resurrection
- **RpcClient.kt** (new): minimal `HttpURLConnection` POST to `127.0.0.1:4317/rpc?client=<id>`
- **NotifActionReceiver.kt** (new): handles Stop / Approve / Reject notification buttons via `goAsync()` + thread; posts `{type:"interrupt"}` or `{type:"approvalDecision"}` — same message shape as in-app buttons, no protocol change
- **ServerService notification**: tap-to-open (REORDER_TO_FRONT) + Stop action
- **MainActivity.requestApproval()**: Approve / Reject actions on approval notification when app is backgrounded; clears on resume
- **Battery-opt exempt**: `ACTION_REQUEST_IGNORE_BATTERY_OPTIMIZATIONS` prompted once on first bg-exec enable (SharedPrefs guard)
- Manifest: `POST_NOTIFICATIONS` permission + `<receiver>` for NotifActionReceiver

### Web
- **agentService.ts** (new): centralises bridge calls; threads SSE client id to `setAgentActive` / `requestApproval` / `onBackgroundEnabled`
- **transport/client.ts**: exposes `getClientId()` so the store can surface it
- **store.tsx**: `getClientId()` + `notify()` on the store interface
- **App.tsx**: threads client id to both service sync effects
- **ChatScreen.tsx**: inline `StatusBadge` — green "Working" (pulse) / amber "Waiting for approval" / nothing at idle
- **Sessions.tsx**: improved copy ("Runs in background only while a task is active" / "Agent stops when you leave"), battery-cost hint, foreground-only toast on toggle-off mid-turn

## Turn-off-mid-turn policy

Toggle OFF while a turn is running → service demotes immediately (no background survival), turn keeps running while Activity is foreground (node is a child process of Activity, survives `stopService`). Toast explains this. No work lost.

## Verification

- Web: `npx tsc --noEmit` clean on both `surfaces/webview` and `packages/core`
- Android: `./gradlew assembleDebug` — BUILD SUCCESSFUL, warnings only (deprecated `addAction` 3-arg form, pre-existing `databaseEnabled`)

### On-device checklist
- [ ] Launch → no persistent notification
- [ ] Turn active + bg ON + background app → "AgentNet is working" notif with Stop + tap
- [ ] Stop → turn cancelled, demoted
- [ ] Tool approval + background app → "Approval needed" with Approve / Reject
- [ ] Approve → turn proceeds; Reject → denied; dismiss → `withTimeout` auto-denies at 10 min
- [ ] Toggle OFF mid-turn → service gone, turn keeps running, badge shows Working
- [ ] First bg-exec enable → battery-opt dialog (once only)

## Deferred

- `test-dispatch.ts` approvalDecision routing test (message shape verified by grep)
- Per-app notification channel settings UI

Closes #53

