### PR TITLE
Mobile webview card-swipe navigation

### DIFF
--- a/surfaces/webview/src/App.tsx
+++ b/surfaces/webview/src/App.tsx
@@ -6,8 +6,10 @@ import { ConnectClaude } from "./onboarding/ConnectClaude";
 import { ConnectCodex } from "./onboarding/ConnectCodex";
 import { ChatScreen } from "./chat/ChatScreen";
 import { MarketScreen } from "./market/MarketScreen";
+import { Sessions } from "./chat/Sessions";
 import { Toast } from "./Toast";
 import { useVisualViewportVars } from "./layoutEffects";
+import { useEffect, useRef, useState, type PointerEvent } from "react";
 
 // Phase router:
 //   connecting   → opening SSE stream / sent `ready`, waiting for init|sessions
@@ -18,7 +20,7 @@ import { useVisualViewportVars } from "./layoutEffects";
 //   codexAuth    → codex chosen, not logged in → device-auth (open URL, enter code)
 //   chat         → runtime ready → the chat shell
 export function App() {
-  const { state } = useStore();
+  const { state, openMarket, closeMarket } = useStore();
   useVisualViewportVars();
 
   return (
@@ -30,11 +32,109 @@ export function App() {
         {state.phase === "engineSelect" && <PickEngine />}
         {state.phase === "claudeAuth" && <ConnectClaude />}
         {state.phase === "codexAuth" && <ConnectCodex />}
-        {state.phase === "chat" && !state.marketOpen && <ChatScreen />}
-        {state.phase === "chat" && state.marketOpen && <MarketScreen />}
+        {state.phase === "chat" && (
+          <ChatDeck
+            marketOpen={state.marketOpen}
+            openMarket={openMarket}
+            closeMarket={closeMarket}
+          />
+        )}
       </div>
       <Toast />
     </>
+  );
+}
+
+function ChatDeck({
+  marketOpen,
+  openMarket,
+  closeMarket,
+}: {
+  marketOpen: boolean;
+  openMarket: () => void;
+  closeMarket: () => void;
+}) {
+  const [drawerOpen, setDrawerOpen] = useState(false);
+  const [dragDx, setDragDx] = useState(0);
+  const [dragging, setDragging] = useState(false);
+  const drag = useRef<{ id: number; startX: number; startY: number; dx: number; locked: boolean } | null>(null);
+
+  useEffect(() => {
+    if (marketOpen) setDrawerOpen(false);
+  }, [marketOpen]);
+
+  const page = drawerOpen ? -1 : marketOpen ? 1 : 0;
+  const base = -((page + 1) * 100) / 3;
+  const maxRight = page === -1 ? 0 : Number.POSITIVE_INFINITY;
+  const maxLeft = page === 1 ? 0 : Number.NEGATIVE_INFINITY;
+  const clampedDx = Math.max(maxLeft, Math.min(maxRight, dragDx));
+
+  function finishSwipe(dx: number) {
+    setDragging(false);
+    setDragDx(0);
+    drag.current = null;
+    const threshold = Math.min(96, window.innerWidth * 0.22);
+    if (Math.abs(dx) < threshold) return;
+    if (page === 0 && dx < 0) openMarket();
+    if (page === 0 && dx > 0) setDrawerOpen(true);
+    if (page === 1 && dx > 0) closeMarket();
+    if (page === -1 && dx < 0) setDrawerOpen(false);
+  }
+
+  function onPointerDown(e: PointerEvent<HTMLDivElement>) {
+    if (e.pointerType === "mouse") return;
+    drag.current = { id: e.pointerId, startX: e.clientX, startY: e.clientY, dx: 0, locked: false };
+  }
+
+  function onPointerMove(e: PointerEvent<HTMLDivElement>) {
+    const d = drag.current;
+    if (!d || d.id !== e.pointerId) return;
+    const dx = e.clientX - d.startX;
+    const dy = e.clientY - d.startY;
+    if (!d.locked && Math.abs(dx) < 10) return;
+    if (!d.locked && Math.abs(dy) > Math.abs(dx)) {
+      drag.current = null;
+      return;
+    }
+    d.locked = true;
+    d.dx = Math.max(maxLeft, Math.min(maxRight, dx));
+    setDragging(true);
+    setDragDx(d.dx);
+    e.preventDefault();
+  }
+
+  function onPointerEnd(e: PointerEvent<HTMLDivElement>) {
+    const d = drag.current;
+    if (!d || d.id !== e.pointerId) return;
+    finishSwipe(d.dx);
+  }
+
+  return (
+    <div
+      className="an-deck"
+      onPointerDown={onPointerDown}
+      onPointerMove={onPointerMove}
+      onPointerUp={onPointerEnd}
+      onPointerCancel={onPointerEnd}
+    >
+      <div
+        className="an-deck-track"
+        style={{
+          transform: `translate3d(calc(${base}% + ${clampedDx}px), 0, 0)`,
+          transition: dragging ? "none" : "transform 260ms cubic-bezier(0.2, 0.85, 0.2, 1)",
+        }}
+      >
+        <section className="an-deck-card an-deck-drawer" aria-hidden={!drawerOpen}>
+          <Sessions embedded onClose={() => setDrawerOpen(false)} />
+        </section>
+        <section className="an-deck-card" aria-hidden={page !== 0}>
+          <ChatScreen onOpenDrawer={() => setDrawerOpen(true)} />
+        </section>
+        <section className="an-deck-card" aria-hidden={!marketOpen}>
+          <MarketScreen />
+        </section>
+      </div>
+    </div>
   );
 }
 

--- a/surfaces/webview/src/chat/ChatScreen.tsx
+++ b/surfaces/webview/src/chat/ChatScreen.tsx
@@ -1,17 +1,15 @@
-import { useEffect, useRef, useState } from "react";
+import { useEffect, useRef } from "react";
 import { useStore } from "../state/store";
 import { MessageList } from "./MessageList";
 import { ApprovalDock } from "./ApprovalDock";
 import { Composer } from "./Composer";
-import { Sessions } from "./Sessions";
 import { SkillIcon } from "../icons";
 
 // Chat shell: header (sessions toggle + wallet) over the scrolling log, with the approval
 // dock + composer pinned at the bottom. Uses --vvh (visual viewport height) so the layout
 // shrinks above the on-screen keyboard instead of being covered by it.
-export function ChatScreen() {
-  const { state, openMarket, clearFiringSkill } = useStore();
-  const [drawer, setDrawer] = useState(false);
+export function ChatScreen({ onOpenDrawer }: { onOpenDrawer: () => void }) {
+  const { state, openMarket, openOwnedSkills, clearFiringSkill } = useStore();
   // Clear the firing skill glow after the dwell time
   const firingTimer = useRef<ReturnType<typeof setTimeout> | null>(null);
   useEffect(() => {
@@ -36,7 +34,7 @@ export function ChatScreen() {
         style={{ paddingTop: "max(0.25rem, env(safe-area-inset-top))", paddingBottom: "0.25rem" }}
       >
         <button
-          onClick={() => setDrawer(true)}
+          onClick={onOpenDrawer}
           className="an-iconbtn shrink-0"
           title="Chats"
           aria-label="Open chat list"
@@ -60,10 +58,10 @@ export function ChatScreen() {
             </span>
           )}
           <button
-            onClick={openMarket}
+            onClick={openOwnedSkills}
             className="an-iconbtn shrink-0"
-            title="Skills"
-            aria-label="Skills"
+            title="Owned skills"
+            aria-label="Owned skills"
           >
             <SkillIcon className="h-5 w-5" />
           </button>
@@ -82,8 +80,6 @@ export function ChatScreen() {
       <MessageList />
       <ApprovalDock />
       <Composer />
-
-      {drawer && <Sessions onClose={() => setDrawer(false)} />}
     </div>
   );
 }

--- a/surfaces/webview/src/chat/Sessions.tsx
+++ b/surfaces/webview/src/chat/Sessions.tsx
@@ -34,7 +34,7 @@ function MenuRow({ icon, label, subtitle, onClick, accent = false }: {
   );
 }
 
-export function Sessions({ onClose }: { onClose: () => void }) {
+export function Sessions({ onClose, embedded = false }: { onClose: () => void; embedded?: boolean }) {
   const { state, send, openMarket, openMarketAgents } = useStore();
   const { storage, cloudSync, googleLoginUrl, googleLoginError } = state;
 
@@ -78,11 +78,9 @@ export function Sessions({ onClose }: { onClose: () => void }) {
     return () => document.removeEventListener("keydown", onKey);
   }, [settingsMode, onClose]);
 
-  return (
-    <div className="fixed inset-0 z-50 flex" onClick={onClose}>
-      <div className="absolute inset-0 bg-black/60" />
+  const panel = (
       <div
-        className="relative flex w-[82vw] max-w-xs flex-col p-3"
+        className={embedded ? "flex h-full w-full flex-col p-3" : "relative flex w-[82vw] max-w-xs flex-col p-3"}
         style={{ background: "var(--an-bg-1)", borderRight: "1px solid var(--an-line)", paddingTop: "max(0.75rem, env(safe-area-inset-top))", paddingBottom: "max(0.75rem, env(safe-area-inset-bottom))" }}
         onClick={(e) => e.stopPropagation()}
       >
@@ -485,6 +483,14 @@ export function Sessions({ onClose }: { onClose: () => void }) {
           </div>
         )}
       </div>
+  );
+
+  if (embedded) return panel;
+
+  return (
+    <div className="fixed inset-0 z-50 flex" onClick={onClose}>
+      <div className="absolute inset-0 bg-black/60" />
+      {panel}
     </div>
   );
 }

--- a/surfaces/webview/src/index.css
+++ b/surfaces/webview/src/index.css
@@ -170,6 +170,31 @@ body {
   overflow: hidden;
 }
 
+.an-deck {
+  height: var(--vvh, 100dvh);
+  width: 100%;
+  overflow: hidden;
+  background: var(--an-bg-0);
+  touch-action: pan-y;
+}
+.an-deck-track {
+  display: grid;
+  grid-template-columns: repeat(3, minmax(0, 1fr));
+  height: 100%;
+  width: 300%;
+  will-change: transform;
+}
+.an-deck-card {
+  min-width: 0;
+  height: 100%;
+  overflow: hidden;
+  background: var(--an-bg-0);
+}
+.an-deck-drawer {
+  max-width: min(86vw, 22rem);
+  box-shadow: 18px 0 40px rgba(0, 0, 0, 0.34);
+}
+
 /* Turn-thread chat: user prompt pins at the top; assistant/tool replies hang from a
    thin rail. This mirrors the extension's reading model, but with tighter mobile spacing. */
 .an-turn {

--- a/surfaces/webview/src/market/MarketScreen.tsx
+++ b/surfaces/webview/src/market/MarketScreen.tsx
@@ -9,20 +9,22 @@ import { BuyCelebration } from "./BuyCelebration";
 import type { SkillCard } from "../transport/protocol";
 import { HeliusSetupPanel } from "../settings/HeliusKeyForm";
 
-type MarketView = "browse" | "publish" | "helius" | "agents";
+type MarketView = "browse" | "publish" | "helius" | "agents" | "owned";
 
 export function MarketScreen() {
   const { state, send, closeMarket, setMarketTab, setMarketQuery, marketSearching, clearMarketDetail, clearAgentProfile } = useStore();
   const [view, setView] = useState<MarketView>(state.marketInitialView);
 
-  // On first open: load owned skills, RPC status, and initial search
+  // On open: refresh owned skills/RPC state and honor the entry point that opened the card.
   useEffect(() => {
+    if (!state.marketOpen) return;
+    setView(state.marketInitialView);
     send({ type: "ownedSkills" });
     send({ type: "getRpcStatus" });
     send({ type: "getBalance" });
     marketSearching();
     send({ type: "searchSkills", query: "", kind: state.marketTab });
-  }, []);
+  }, [state.marketOpen, state.marketInitialView]);
 
   // When agent profile loads, switch to agents view to show it
   useEffect(() => {
@@ -67,6 +69,17 @@ export function MarketScreen() {
     );
   }
 
+  const resultByName = new Map((state.marketResults ?? []).map((card) => [card.name, card]));
+  const ownedCards: SkillCard[] = state.marketOwned.map((name) => {
+    const found = resultByName.get(name);
+    if (found) return found;
+    return {
+      id: state.marketOwnedMints[name] ?? name,
+      name,
+      description: "Owned skill",
+    } as SkillCard;
+  });
+
   // Agent profile
   if (view === "agents" && state.agentProfile) {
     return (
@@ -95,7 +108,7 @@ export function MarketScreen() {
         style={{ paddingTop: "max(0.5rem, env(safe-area-inset-top))" }}
       >
         <button onClick={closeMarket} className="shrink-0 text-zinc-400 active:text-zinc-200 px-1 text-lg">←</button>
-        <span className="font-semibold text-sm">Markets</span>
+        <span className="font-semibold text-sm">{view === "owned" ? "Owned skills" : "Markets"}</span>
         {balanceSol && (
           <span className="ml-auto text-xs text-zinc-500 font-mono">{balanceSol} SOL</span>
         )}
@@ -142,6 +155,17 @@ export function MarketScreen() {
           </button>
         ))}
         <button
+          onClick={() => setView("owned")}
+          className={[
+            "px-4 py-2 text-sm border-b-2 transition-colors",
+            view === "owned"
+              ? "border-green-500 text-green-400"
+              : "border-transparent text-zinc-500 active:text-zinc-300",
+          ].join(" ")}
+        >
+          Owned
+        </button>
+        <button
           onClick={() => setView("agents")}
           className={[
             "px-4 py-2 text-sm border-b-2 transition-colors",
@@ -179,6 +203,27 @@ export function MarketScreen() {
       <div className="flex-1 overflow-y-auto px-3 pb-[max(0.75rem,env(safe-area-inset-bottom))]">
         {view === "agents" ? (
           <AgentDirectory />
+        ) : view === "owned" ? (
+          <>
+            {state.marketOwned.length === 0 ? (
+              <div className="py-8 text-center text-sm text-zinc-600">
+                No owned skills yet. Browse Markets to buy one.
+              </div>
+            ) : (
+              <div className="space-y-2 pt-1">
+                {ownedCards.map((card) => (
+                  <SkillCardTile
+                    key={card.id}
+                    card={card}
+                    owned
+                    disposed={Object.values(state.marketDisposed).includes(card.id)}
+                    firing={state.firingSkill === card.name}
+                    onOpen={handleOpenCard}
+                  />
+                ))}
+              </div>
+            )}
+          </>
         ) : (
           <>
             {state.marketSearching && (

--- a/surfaces/webview/src/state/store.tsx
+++ b/surfaces/webview/src/state/store.tsx
@@ -46,7 +46,7 @@ export interface State {
     | "chat";
   // market overlay (accessible from chat phase via "Markets" button)
   marketOpen: boolean;
-  marketInitialView: "browse" | "agents";
+  marketInitialView: "browse" | "agents" | "owned";
   marketTab: "skill" | "workflow";
   marketQuery: string;
   marketResults: SkillCard[] | null;
@@ -54,6 +54,7 @@ export interface State {
   marketSearchError: string | null;
   marketDetail: SkillDetail | null;
   marketOwned: string[];
+  marketOwnedMints: Record<string, string>;
   marketDisposed: Record<string, string>;
   marketBalance: number | null;
   rpcStatus: RpcStatus | null;
@@ -130,6 +131,7 @@ const initialState: State = {
   marketSearchError: null,
   marketDetail: null,
   marketOwned: [],
+  marketOwnedMints: {},
   marketDisposed: {},
   marketBalance: null,
   rpcStatus: null,
@@ -199,7 +201,7 @@ type LocalAction =
   | { type: "__selectEngine"; cli: Cli }
   | { type: "__finishStorage" }
   | { type: "__savePlan"; text: string }
-  | { type: "__openMarket"; initialView?: "browse" | "agents" }
+  | { type: "__openMarket"; initialView?: "browse" | "agents" | "owned" }
   | { type: "__closeMarket" }
   | { type: "__setMarketTab"; tab: "skill" | "workflow" }
   | { type: "__setMarketQuery"; query: string }
@@ -386,7 +388,12 @@ function reducer(state: State, ev: Action): State {
           : state.marketDisposed,
       };
     case "ownedSkills":
-      return { ...state, marketOwned: Array.isArray(ev.names) ? ev.names : [], marketDisposed: ev.disposedMints ?? {} };
+      return {
+        ...state,
+        marketOwned: Array.isArray(ev.names) ? ev.names : [],
+        marketOwnedMints: ev.mints ?? {},
+        marketDisposed: ev.disposedMints ?? {},
+      };
     case "balance":
       return { ...state, marketBalance: ev.lamports };
     case "rpcStatus":
@@ -442,6 +449,7 @@ interface Store {
   savePlan: (text: string) => void;
   openMarket: () => void;
   openMarketAgents: () => void;
+  openOwnedSkills: () => void;
   closeMarket: () => void;
   setMarketTab: (tab: "skill" | "workflow") => void;
   setMarketQuery: (q: string) => void;
@@ -585,6 +593,7 @@ export function StoreProvider({ children }: { children: ReactNode }) {
       savePlan: (text) => raw({ type: "__savePlan", text }),
       openMarket: () => raw({ type: "__openMarket" }),
       openMarketAgents: () => raw({ type: "__openMarket", initialView: "agents" }),
+      openOwnedSkills: () => raw({ type: "__openMarket", initialView: "owned" }),
       closeMarket: () => raw({ type: "__closeMarket" }),
       setMarketTab: (tab) => raw({ type: "__setMarketTab", tab }),
       setMarketQuery: (query) => raw({ type: "__setMarketQuery", query }),


### PR DESCRIPTION
## Summary
- add a mobile card deck for drawer ← chat → market navigation with swipe gestures
- route drawer and market button taps through the same slide transition
- add the diamond-owned-skills entry and an Owned market view using existing ownedSkills / marketOwned data

## Test
- pnpm --filter agentnet-webview build

Closes #65