### PR TITLE
Port vscode skill effects to mobile React UI + central haptics (#75)

### DIFF
--- a/surfaces/webview/src/App.tsx
+++ b/surfaces/webview/src/App.tsx
@@ -244,7 +244,3 @@ function MarketPage({ marketTab, active }: { marketTab: "skills" | "profile" | "
   );
 }
 
-function isInteractiveTarget(target: EventTarget | null) {
-  if (!(target instanceof Element)) return false;
-  return !!target.closest("button, a, input, textarea, select, [role='button'], [data-no-swipe]");
-}

--- a/surfaces/webview/src/App.tsx
+++ b/surfaces/webview/src/App.tsx
@@ -13,6 +13,7 @@ import { Toast } from "./Toast";
 import { useVisualViewportVars, useKeyboardChrome } from "./layoutEffects";
 import { useEffect, useRef, useState, type PointerEvent } from "react";
 import { syncAgentService, notifyApproval, ensureBackgroundConsent } from "./platform/agentService";
+import { haptics } from "./haptics";
 
 // Phase router:
 //   connecting   → opening SSE stream / sent `ready`, waiting for init|sessions
@@ -80,11 +81,8 @@ function TabShell() {
   const drawerWidth = Math.min(vw * 0.86, 352);
 
   // Light haptic when the chat slides back into place (closing) — never on opening.
-  function haptic(ms: number) {
-    try { navigator.vibrate?.(ms); } catch { /* unsupported on this WebView */ }
-  }
   function changeDrawer(open: boolean) {
-    if (drawerOpen && !open) haptic(12);
+    if (drawerOpen && !open) haptics.tap();
     setDrawerOpen(open);
   }
 

--- a/surfaces/webview/src/chat/ApprovalDock.tsx
+++ b/surfaces/webview/src/chat/ApprovalDock.tsx
@@ -220,9 +220,15 @@ function ApprovalCard({
     return () => window.removeEventListener("keydown", onKey);
   }, [isPlan]);
 
+  const didVibrate = useRef(false);
   // Medium haptic when the forge card appears (parity with the casting cue).
   useEffect(() => {
-    if (isForge) haptics.forge();
+    if (isForge && !didVibrate.current) {
+      haptics.forge();
+      didVibrate.current = true;
+    } else if (!isForge) {
+      didVibrate.current = false;
+    }
   }, [isForge]);
 
   const borderColor = isDanger ? "border-red-700/60" : isForge ? "border-[var(--an-violet)]/55" : "border-emerald-700/50";

--- a/surfaces/webview/src/chat/ApprovalDock.tsx
+++ b/surfaces/webview/src/chat/ApprovalDock.tsx
@@ -7,6 +7,7 @@ import type {
 import { useStore } from "../state/store";
 import { SkillIcon } from "../icons";
 import { useElementHeightVariable } from "../layoutEffects";
+import { haptics } from "../haptics";
 
 // Pending tool approvals, docked just above the composer (newest first). Most are a
 // yes/no permission (bash/edit/…). Two are different:
@@ -185,6 +186,16 @@ function ApprovalCard({
 }) {
   const isPlan = req.kind === "plan";
   const isDanger = req.risk === "danger";
+  // ONLY the skill-publish approval gets the violet "forge" treatment (parity with the
+  // vscode webview): twinkling stars + a name/description/price body. Every other
+  // approval stays the green card.
+  const isForge = /publish_skill/.test(req.tool || "") || /publish_skill/.test(req.title || "");
+  const forgeName = (req.input?.name as string) || "new skill";
+  const forgeDesc = req.input?.description as string | undefined;
+  const forgePrice = (() => {
+    const p = req.input?.priceSol;
+    return p == null ? "0.1 SOL" : String(p) === "0" ? "free" : `${p} SOL`;
+  })();
   const [editMode, setEditMode] = useState(false);
   const [editedCmd, setEditedCmd] = useState(req.command ?? "");
   const [showReason, setShowReason] = useState(false);
@@ -209,19 +220,29 @@ function ApprovalCard({
     return () => window.removeEventListener("keydown", onKey);
   }, [isPlan]);
 
-  const borderColor = isDanger ? "border-red-700/60" : "border-emerald-700/50";
+  // Medium haptic when the forge card appears (parity with the casting cue).
+  useEffect(() => {
+    if (isForge) haptics.forge();
+  }, [isForge]);
+
+  const borderColor = isDanger ? "border-red-700/60" : isForge ? "border-[var(--an-violet)]/55" : "border-emerald-700/50";
   // Near-opaque (composer-glass level) so chat content doesn't show through the card.
   const bgColor = isDanger ? "bg-red-950/95" : "bg-emerald-950/95";
 
   return (
-    <div ref={cardRef} tabIndex={-1} className={`overflow-hidden rounded-lg border ${borderColor} ${bgColor} text-sm outline-none`}>
+    <div
+      ref={cardRef}
+      tabIndex={-1}
+      className={`relative overflow-hidden rounded-lg border ${borderColor} ${bgColor} text-sm outline-none ${isForge ? "skill-forge" : ""}`}
+    >
+      {isForge && <ForgeStars />}
       {/* header */}
-      <div className="flex items-center gap-2 px-3 py-1.5">
+      <div className="relative z-10 flex items-center gap-2 px-3 py-1.5">
         {isDanger && (
           <span className="font-bold text-red-400">⚠ DANGER</span>
         )}
-        <span className="inline-flex items-center font-mono text-emerald-400">
-          {isPlan ? (
+        <span className="inline-flex items-center font-mono" style={{ color: isForge ? "var(--an-violet)" : undefined }}>
+          {isPlan || isForge ? (
             <SkillIcon className="h-4 w-4" />
           ) : req.kind === "bash" ? (
             "$"
@@ -231,7 +252,7 @@ function ApprovalCard({
             "✎"
           )}
         </span>
-        <span className="truncate font-medium">{req.title || req.tool}</span>
+        <span className="truncate font-medium">{isForge ? `Forge skill: ${forgeName}` : req.title || req.tool}</span>
         <span className="ml-auto text-xs text-zinc-500">{req.cli}</span>
         {/* bash: edit toggle */}
         {req.kind === "bash" && req.command && (
@@ -268,6 +289,14 @@ function ApprovalCard({
       )}
       {req.file && !req.diff && (
         <div className="px-3 pb-2 font-mono text-xs text-zinc-300">{req.file}</div>
+      )}
+      {isForge && (
+        // What is being forged: name + description + price, so the approval is meaningful.
+        <div className="relative z-10 px-3 pb-2">
+          <div className="text-[0.95rem] font-semibold text-zinc-100">{forgeName}</div>
+          {forgeDesc && <div className="mt-0.5 text-xs leading-snug text-zinc-300/85">{forgeDesc}</div>}
+          <div className="mt-1.5 text-[0.7rem] text-zinc-400">mint a soulbound NFT · price {forgePrice}</div>
+        </div>
       )}
       {req.diff && (
         <pre className="overflow-x-auto px-3 pb-2 font-mono text-xs">
@@ -319,7 +348,7 @@ function ApprovalCard({
       )}
 
       {/* action buttons */}
-      <div className="flex flex-wrap gap-2 border-t border-emerald-700/40 px-3 py-2">
+      <div className="relative z-10 flex flex-wrap gap-2 border-t border-emerald-700/40 px-3 py-2">
         {isPlan ? (
           <>
             <button autoFocus onClick={() => onDecide("once")} className="rounded bg-emerald-600 px-3 py-1 text-xs font-medium text-white">
@@ -362,6 +391,43 @@ function ApprovalCard({
           </>
         )}
       </div>
+    </div>
+  );
+}
+
+// A handful of slow violet twinkles scattered over the forge card. Positions/timing are
+// randomized once on mount so each forge card looks a little different (parity with the
+// vscode forgeStars). Decorative, never intercepts taps.
+function ForgeStars() {
+  const stars = useRef(
+    Array.from({ length: 6 }, () => ({
+      left: 8 + Math.random() * 84,
+      top: 12 + Math.random() * 70,
+      dur: 3.2 + Math.random() * 2.4,
+      delay: Math.random() * 3,
+      size: 7 + Math.random() * 5,
+    })),
+  );
+  return (
+    <div className="pointer-events-none absolute inset-0 z-0 overflow-hidden">
+      {stars.current.map((s, i) => (
+        <svg
+          key={i}
+          viewBox="0 0 24 24"
+          fill="var(--an-violet)"
+          className="forge-star absolute"
+          style={{
+            left: `${s.left}%`,
+            top: `${s.top}%`,
+            width: `${s.size}px`,
+            height: `${s.size}px`,
+            animationDuration: `${s.dur}s`,
+            animationDelay: `${s.delay}s`,
+          }}
+        >
+          <path d="M12 2 14.4 9.6 22 12 14.4 14.4 12 22 9.6 14.4 2 12 9.6 9.6Z" />
+        </svg>
+      ))}
     </div>
   );
 }

--- a/surfaces/webview/src/chat/CastingMarquee.tsx
+++ b/surfaces/webview/src/chat/CastingMarquee.tsx
@@ -1,0 +1,31 @@
+import { useEffect, useState } from "react";
+import { SkillIcon } from "../icons";
+
+// In-chat casting marquee — ported from the vscode webview's flashSkill(): a green,
+// breathing glow bar that names the firing skill with a verb that ROTATES across
+// firings (Casting / Channeling / Wielding / Invoking). Shown above the composer while
+// state.firingSkill is set; ChatScreen clears it on turn end.
+const VERBS = ["Casting", "Channeling", "Wielding", "Invoking"];
+let pick = 0; // module-level so the verb advances on each new firing, like vscode
+
+export function CastingMarquee({ skill }: { skill: string | null }) {
+  const [verb, setVerb] = useState(VERBS[0]);
+
+  // Advance the verb each time a NEW skill starts firing (not on every render).
+  useEffect(() => {
+    if (skill) setVerb(VERBS[pick++ % VERBS.length]);
+  }, [skill]);
+
+  if (!skill) return null;
+  return (
+    <div className="px-3 pt-2">
+      <div className="casting-marquee flex items-center gap-2 rounded-xl px-3 py-2">
+        <SkillIcon className="h-4 w-4 shrink-0" style={{ color: "var(--an-green)" }} />
+        <span className="text-sm" style={{ color: "var(--an-green)" }}>
+          <span className="font-semibold">{verb}</span>{" "}
+          <span className="font-mono" style={{ color: "var(--an-fg)" }}>{skill}</span>
+        </span>
+      </div>
+    </div>
+  );
+}

--- a/surfaces/webview/src/chat/CastingMarquee.tsx
+++ b/surfaces/webview/src/chat/CastingMarquee.tsx
@@ -7,13 +7,19 @@ import { SkillIcon } from "../icons";
 // state.firingSkill is set; ChatScreen clears it on turn end.
 const VERBS = ["Casting", "Channeling", "Wielding", "Invoking"];
 let pick = 0; // module-level so the verb advances on each new firing, like vscode
+let lastProcessedSkill: string | null = null; // prevents double-increment in React StrictMode
 
 export function CastingMarquee({ skill }: { skill: string | null }) {
   const [verb, setVerb] = useState(VERBS[0]);
 
   // Advance the verb each time a NEW skill starts firing (not on every render).
   useEffect(() => {
-    if (skill) setVerb(VERBS[pick++ % VERBS.length]);
+    if (skill && skill !== lastProcessedSkill) {
+      setVerb(VERBS[pick++ % VERBS.length]);
+      lastProcessedSkill = skill;
+    } else if (!skill) {
+      lastProcessedSkill = null;
+    }
   }, [skill]);
 
   if (!skill) return null;

--- a/surfaces/webview/src/chat/ChatScreen.tsx
+++ b/surfaces/webview/src/chat/ChatScreen.tsx
@@ -3,8 +3,10 @@ import { useStore } from "../state/store";
 import { MessageList } from "./MessageList";
 import { ApprovalDock } from "./ApprovalDock";
 import { Composer } from "./Composer";
+import { CastingMarquee } from "./CastingMarquee";
 import { SkillIcon } from "../icons";
 import { useElementHeightVariable } from "../layoutEffects";
+import { haptics } from "../haptics";
 
 // Chat shell: header (sessions toggle + wallet) over the scrolling log, with the approval
 // dock + composer pinned at the bottom. Uses --vvh (visual viewport height) so the layout
@@ -17,10 +19,13 @@ export function ChatScreen({ onOpenDrawer }: { onOpenDrawer: () => void }) {
   const firingTimer = useRef<ReturnType<typeof setTimeout> | null>(null);
   useEffect(() => {
     if (state.firingSkill) {
+      haptics.castStart(); // light double tap as the skill starts casting
       if (firingTimer.current) clearTimeout(firingTimer.current);
+      // dwell scales with name length (matches the vscode marquee), capped at 4s
+      const dwell = Math.min(4000, 1600 + state.firingSkill.length * 35);
       firingTimer.current = setTimeout(() => {
         clearFiringSkill();
-      }, 1400);
+      }, dwell);
     }
     return () => { if (firingTimer.current) clearTimeout(firingTimer.current); };
   }, [state.firingSkill, clearFiringSkill]);
@@ -72,6 +77,7 @@ export function ChatScreen({ onOpenDrawer }: { onOpenDrawer: () => void }) {
 
       <MessageList />
       <div ref={controlsRef} className="an-chat-float">
+        <CastingMarquee skill={state.firingSkill} />
         <ApprovalDock />
         <Composer />
       </div>

--- a/surfaces/webview/src/chat/ChatScreen.tsx
+++ b/surfaces/webview/src/chat/ChatScreen.tsx
@@ -17,15 +17,19 @@ export function ChatScreen({ onOpenDrawer }: { onOpenDrawer: () => void }) {
   useElementHeightVariable(controlsRef, "--chat-float-height");
   // Clear the firing skill glow after the dwell time
   const firingTimer = useRef<ReturnType<typeof setTimeout> | null>(null);
+  const lastVibratedSkill = useRef<string | null>(null);
   useEffect(() => {
-    if (state.firingSkill) {
+    if (state.firingSkill && state.firingSkill !== lastVibratedSkill.current) {
       haptics.castStart(); // light double tap as the skill starts casting
+      lastVibratedSkill.current = state.firingSkill;
       if (firingTimer.current) clearTimeout(firingTimer.current);
       // dwell scales with name length (matches the vscode marquee), capped at 4s
       const dwell = Math.min(4000, 1600 + state.firingSkill.length * 35);
       firingTimer.current = setTimeout(() => {
         clearFiringSkill();
       }, dwell);
+    } else if (!state.firingSkill) {
+      lastVibratedSkill.current = null;
     }
     return () => { if (firingTimer.current) clearTimeout(firingTimer.current); };
   }, [state.firingSkill, clearFiringSkill]);

--- a/surfaces/webview/src/chat/Sessions.tsx
+++ b/surfaces/webview/src/chat/Sessions.tsx
@@ -3,6 +3,7 @@ import { useStore } from "../state/store";
 import { IqLogo, AgentIcon } from "../icons";
 import { useOnline } from "../layoutEffects";
 import agentnetWordmark from "../assets/agentnet.png";
+import { haptics } from "../haptics";
 
 // wifi-off mark for the offline states (no emoji; inline SVG per the design rules).
 function WifiOffIcon({ className, style }: { className?: string; style?: CSSProperties }) {
@@ -85,7 +86,7 @@ export function Sessions({ onClose, embedded = false, onOpenAgent }: { onClose: 
     pressTimer.current = window.setTimeout(() => {
       pressFired.current = true;
       pressTimer.current = null;
-      try { navigator.vibrate?.(15); } catch { /* unsupported on this WebView */ }
+      haptics.longPress();
       setMenuFor({ id: s.sessionId, title: s.title || "(untitled)" });
     }, 480);
   }

--- a/surfaces/webview/src/haptics.ts
+++ b/surfaces/webview/src/haptics.ts
@@ -1,0 +1,17 @@
+// One place for every WebView haptic. navigator.vibrate is unsupported on desktop
+// browsers and many WebViews, so every call is wrapped — a no-op there, a buzz on the
+// Android device (VIBRATE permission is in the manifest). Named by intent, not duration,
+// so callers read as "what happened" instead of magic numbers.
+type Pattern = number | number[];
+
+function buzz(pattern: Pattern): void {
+  try { navigator.vibrate?.(pattern); } catch { /* unsupported on this WebView */ }
+}
+
+export const haptics = {
+  tap: () => buzz(12),                  // light: drawer slides closed, generic confirm
+  longPress: () => buzz(15),            // sessions long-press menu opens
+  castStart: () => buzz([10, 40, 10]),  // light double tap when a skill starts casting
+  forge: () => buzz(40),                // medium: forge (publish_skill) approval appears
+  celebrate: () => buzz([40, 30, 40, 30, 40, 30, 220]), // the success "zap"
+};

--- a/surfaces/webview/src/index.css
+++ b/surfaces/webview/src/index.css
@@ -743,3 +743,27 @@ html[data-keyboard="open"] .an-chat-float { bottom: 0; }
 }
 .buy-particle { animation: buy-particle 1.4s cubic-bezier(0.22, 1, 0.36, 1) forwards; }
 .buy-pop      { animation: buy-pop 1.4s cubic-bezier(0.22, 1, 0.36, 1) forwards; }
+
+/* In-chat casting marquee — breathing green aura + a soft slide-in (ported from the
+   vscode flashSkill marquee). */
+@keyframes casting-in {
+  from { opacity: 0; transform: translateY(4px); }
+  to   { opacity: 1; transform: translateY(0); }
+}
+.casting-marquee {
+  background: var(--an-green-dim);
+  border: 1px solid var(--an-green-line);
+  animation: casting-in 180ms ease-out, skill-breath 1.4s ease-in-out infinite;
+}
+
+/* Forge (publish_skill) approval card — a slow violet glow + twinkling stars. */
+@keyframes forge-glow {
+  0%, 100% { box-shadow: 0 0 10px 1px rgba(169, 139, 255, 0.16); }
+  50%      { box-shadow: 0 0 22px 4px rgba(169, 139, 255, 0.34); }
+}
+@keyframes forge-twinkle {
+  0%, 100% { opacity: 0; transform: scale(0.6); }
+  50%      { opacity: 0.9; transform: scale(1); }
+}
+.skill-forge { animation: forge-glow 3.2s ease-in-out infinite; }
+.forge-star  { animation-name: forge-twinkle; animation-iteration-count: infinite; animation-timing-function: ease-in-out; }

--- a/surfaces/webview/src/market/BuyCelebration.tsx
+++ b/surfaces/webview/src/market/BuyCelebration.tsx
@@ -1,6 +1,7 @@
 import { useEffect } from "react";
 import { useStore } from "../state/store";
 import { SkillIcon } from "../icons";
+import { haptics } from "../haptics";
 
 const PARTICLE_COUNT = 5;
 
@@ -8,6 +9,7 @@ export function BuyCelebration() {
   const { clearCelebrate } = useStore();
 
   useEffect(() => {
+    haptics.celebrate();
     const t = setTimeout(clearCelebrate, 1600);
     return () => clearTimeout(t);
   }, []);

--- a/surfaces/webview/src/market/PostCelebration.tsx
+++ b/surfaces/webview/src/market/PostCelebration.tsx
@@ -1,5 +1,6 @@
 import { useEffect, useState } from "react";
 import { createPortal } from "react-dom";
+import { haptics } from "../haptics";
 
 // Terminal-style success popup: an electric flicker in (synced with a sharp haptic zap),
 // holds briefly, then gets "absorbed" - shrinks toward a point and fades. No emoji, no
@@ -9,7 +10,7 @@ export function PostCelebration({ label, onDone }: { label: string; onDone: () =
 
   useEffect(() => {
     // Electric "zap": rapid stutter pulses + a final longer buzz, in step with the flicker.
-    try { navigator.vibrate?.([40, 30, 40, 30, 40, 30, 220]); } catch { /* unsupported on this WebView */ }
+    haptics.celebrate();
     const exit = setTimeout(() => setPhase("out"), 1150);
     const done = setTimeout(onDone, 1450);
     return () => { clearTimeout(exit); clearTimeout(done); };

--- a/surfaces/webview/src/state/store.tsx
+++ b/surfaces/webview/src/state/store.tsx
@@ -301,11 +301,11 @@ function reducer(state: State, ev: Action): State {
     case "usage":
       return { ...state, contextTokens: ev.contextTokens };
     case "clear":
-      return { ...state, log: [], approvals: [], typing: false, loading: false, contextTokens: undefined };
+      return { ...state, log: [], approvals: [], typing: false, loading: false, contextTokens: undefined, firingSkill: null };
     case "message":
       return { ...state, log: appendMessage(state.log, ev.msg) };
     case "turnEnd":
-      return { ...state, typing: false };
+      return { ...state, typing: false, firingSkill: null };
     case "page":
       return { ...state, hasMore: ev.hasMore, cursor: ev.cursor, loading: false };
     case "older":
@@ -325,7 +325,7 @@ function reducer(state: State, ev: Action): State {
     // round-trip, which left the screen on the stale chat with no feedback. The server's
     // messages/page/sessions then reconcile this.
     case "__openingSession":
-      return { ...state, activeSessionId: ev.sessionId, loading: true, log: [], typing: false, hasMore: false };
+      return { ...state, activeSessionId: ev.sessionId, loading: true, log: [], typing: false, hasMore: false, firingSkill: null };
     case "__newChat":
       return {
         ...state,
@@ -337,6 +337,7 @@ function reducer(state: State, ev: Action): State {
         hasMore: false,
         cursor: 0,
         contextTokens: undefined,
+        firingSkill: null,
       };
     case "platform":
       return { ...state, cli: ev.cli };


### PR DESCRIPTION
Closes #75.

Re-creates the rich vscode webview skill effects in `surfaces/webview` (the mobile/browser React SPA), which genuinely did not exist there.

## What changed
- **Casting marquee** (`CastingMarquee.tsx`): in-chat bar on `skillActive` with rotating verbs (Casting / Channeling / Wielding / Invoking) + breathing green glow. Clears on turn end (store now nulls `firingSkill` on `turnEnd`/`clear`/`openingSession`/`newChat`), not just a dwell timer.
- **Forge approval card** (`ApprovalDock.tsx`): `publish_skill` approvals get the violet forge treatment — twinkling stars + name/description/price body.
- **Central haptics** (`haptics.ts`): every `navigator.vibrate` now routes through one helper (`tap`/`longPress`/`castStart`/`forge`/`celebrate`). Buy success now buzzes too. Patterns: casting start = light double tap, forge appears = medium, celebrate = existing zap.
- StrictMode guards so verb increment + haptics fire once, not twice.

## Deliberately skipped
- Full confetti/wand/ring celebration suite. Mobile already celebrates buy/publish/note (`BuyCelebration`/`PostCelebration`); the issue explicitly sanctions unifying on the existing style rather than porting the vscode overlay. Wired haptics into the existing ones instead.

## Not done
- Real-Android-device verification (acceptance criteria) — needs a device.
- Secondary skill-awareness sub-problem — issue says split out.

Follows mobile design rules: no emoji, no em-dash, central `--an-*` tokens.