### PR TITLE
feat: warn agent on cross-device session resume (#74)

### DIFF
--- a/packages/core/src/account/sessionLog.ts
+++ b/packages/core/src/account/sessionLog.ts
@@ -10,7 +10,7 @@ import { encryptForWallet, decryptForWallet, type SessionKey } from "../core/cry
 
 // A log record: either session meta (first line) or one chat message.
 type LogRecord =
-  | { kind: "meta"; sessionId: string; cli: string; title: string; ts: number }
+  | { kind: "meta"; sessionId: string; cli: string; title: string; ts: number; lastDevice?: { id: string; label: string } }
   | { kind: "msg"; msg: ChatMessage };
 
 const NL = new TextEncoder().encode("\n");
@@ -27,7 +27,7 @@ export async function encodeRecord(key: SessionKey, rec: LogRecord): Promise<Uin
 
 // Convenience encoders for the two record kinds.
 export function metaRecord(s: Omit<CanonicalSession, "messages">): LogRecord {
-  return { kind: "meta", sessionId: s.sessionId, cli: s.cli, title: s.title, ts: s.ts };
+  return { kind: "meta", sessionId: s.sessionId, cli: s.cli, title: s.title, ts: s.ts, lastDevice: s.lastDevice };
 }
 export function msgRecord(msg: ChatMessage): LogRecord {
   return { kind: "msg", msg };
@@ -45,6 +45,7 @@ export async function decodeLog(
   let cli: "claude" | "codex" = "claude";
   let title = "";
   let ts = 0;
+  let lastDevice: { id: string; label: string } | undefined = undefined;
   const messages: ChatMessage[] = [];
 
   for (const line of text.split("\n")) {
@@ -56,11 +57,12 @@ export async function decodeLog(
       cli = rec.cli as "claude" | "codex";
       title = rec.title;
       ts = rec.ts;
+      lastDevice = rec.lastDevice;
     } else {
       messages.push(rec.msg);
     }
   }
 
   if (!sessionId) return null;
-  return { sessionId, cli, title, messages, ts };
+  return { sessionId, cli, title, messages, ts, lastDevice };
 }

--- a/packages/core/src/account/store.ts
+++ b/packages/core/src/account/store.ts
@@ -133,6 +133,13 @@ export class SessionStore {
     state.count += 1;
   }
 
+  async recordMeta(meta: Omit<CanonicalSession, "messages">): Promise<void> {
+    const key = await this.getKey();
+    const state = await this.currentPage(meta.sessionId);
+    const pk = pageKey(meta.sessionId, state.page);
+    await this.write(pk, await encodeRecord(key, metaRecord(meta)));
+  }
+
   async remove(sessionId: string): Promise<void> {
     this.cur.delete(sessionId);
     for (const k of await this.storage.list()) {
@@ -231,7 +238,7 @@ export class SessionStore {
         // unreadable session never hides all the readable ones.
         try {
           const s = await this.loadPage(sessionId, page);
-          return s ? { sessionId, title: s.title, cli: s.cli, ts: s.ts } : null;
+          return s ? { sessionId, title: s.title, cli: s.cli, ts: s.ts, lastDevice: s.lastDevice } : null;
         } catch {
           return null; // undecryptable (foreign key / corrupt), omit from the list
         }

--- a/packages/core/src/core/device.spec.ts
+++ b/packages/core/src/core/device.spec.ts
@@ -1,0 +1,59 @@
+import { describe, it, expect, beforeEach, afterEach, vi } from "vitest";
+import { mkdtempSync, rmSync, existsSync, readFileSync } from "node:fs";
+import { tmpdir, hostname, platform } from "node:os";
+import { join } from "node:path";
+
+describe("core/device — getDeviceProfile and buildDeviceNotice", () => {
+  let home: string;
+  const origEnv = { ...process.env };
+
+  beforeEach(() => {
+    vi.resetModules();
+    home = mkdtempSync(join(tmpdir(), "agentnet-device-"));
+    process.env.AGENTNET_HOME = home;
+    delete process.env.AGENTNET_DEVICE_LABEL;
+  });
+
+  afterEach(() => {
+    process.env = { ...origEnv };
+    vi.unstubAllGlobals();
+    rmSync(home, { recursive: true, force: true });
+  });
+
+  it("generates a new stable UUID on first call and caches/persists it", async () => {
+    const { getDeviceProfile } = await import("./device.js");
+    const p1 = await getDeviceProfile();
+    expect(p1.id).toBeDefined();
+    expect(p1.id.length).toBe(36); // standard UUID v4 length
+    expect(p1.label).toBe(`${hostname()} (${platform()})`);
+
+    // Verify it is persisted
+    const deviceJsonPath = join(home, "device.json");
+    expect(existsSync(deviceJsonPath)).toBe(true);
+    const content = JSON.parse(readFileSync(deviceJsonPath, "utf8"));
+    expect(content.id).toBe(p1.id);
+
+    // Call again and verify it is stable
+    const p2 = await getDeviceProfile();
+    expect(p2.id).toBe(p1.id);
+  });
+
+  it("overrides the label via AGENTNET_DEVICE_LABEL env var", async () => {
+    process.env.AGENTNET_DEVICE_LABEL = "Pixel 8 (Android)";
+    const { getDeviceProfile } = await import("./device.js");
+    const p = await getDeviceProfile();
+    expect(p.label).toBe("Pixel 8 (Android)");
+  });
+
+  it("buildDeviceNotice formats the notice correctly with truncated ids", async () => {
+    const { buildDeviceNotice } = await import("./device.js");
+    const prev = { id: "1234567890abcdef1234567890abcdef", label: "My Desktop" };
+    const cur = { id: "abcdef1234567890abcdef1234567890", label: "My Phone" };
+
+    const notice = buildDeviceNotice(prev, cur);
+    expect(notice).toContain('"My Desktop" (12345678)');
+    expect(notice).toContain('"My Phone"');
+    expect(notice).toContain("Absolute paths");
+    expect(notice).toContain("Verify on THIS device");
+  });
+});

--- a/packages/core/src/core/device.ts
+++ b/packages/core/src/core/device.ts
@@ -1,0 +1,62 @@
+import { readFileSync, writeFileSync, existsSync } from "node:fs";
+import { hostname, platform } from "node:os";
+import { randomUUID } from "node:crypto";
+import { deviceFile, ensureDir, rootDir } from "./paths.js";
+
+interface DeviceData {
+  id: string;
+}
+
+let cachedProfile: { id: string; label: string } | null = null;
+
+export async function getDeviceProfile(): Promise<{ id: string; label: string }> {
+  if (cachedProfile) {
+    return cachedProfile;
+  }
+
+  const file = deviceFile();
+  let id: string = "";
+
+  if (existsSync(file)) {
+    try {
+      const data = JSON.parse(readFileSync(file, "utf8")) as DeviceData;
+      if (data && typeof data.id === "string") {
+        id = data.id;
+      }
+    } catch {
+      // ignore JSON parse/read errors and generate new UUID
+    }
+  }
+
+  if (!id) {
+    id = randomUUID();
+    await ensureDir(rootDir());
+    try {
+      writeFileSync(file, JSON.stringify({ id }, null, 2), { mode: 0o600, encoding: "utf8" });
+    } catch (e) {
+      console.error("Failed to write device file:", e);
+    }
+  }
+
+  const label = process.env.AGENTNET_DEVICE_LABEL || `${hostname()} (${platform()})`;
+
+  cachedProfile = { id, label };
+  return cachedProfile;
+}
+
+export function buildDeviceNotice(
+  prev: { id: string; label: string },
+  cur: { id: string; label: string },
+): string {
+  const prevShort = prev.id.slice(0, 8);
+  const curShort = cur.id.slice(0, 8);
+  return (
+    `[device] This session last ran on "${prev.label}" (${prevShort}).\n` +
+    `Absolute paths and "already installed" notes in the history may belong to that machine. ` +
+    `Verify on THIS device ("${cur.label}", ${curShort}) before relying on them.`
+  );
+}
+
+export function _clearCache(): void {
+  cachedProfile = null;
+}

--- a/packages/core/src/core/paths.ts
+++ b/packages/core/src/core/paths.ts
@@ -49,6 +49,11 @@ export function cliMapFile(): string {
   return join(rootDir(), "cli-map.json");
 }
 
+/** Device identity file. Local, never synced. */
+export function deviceFile(): string {
+  return join(rootDir(), "device.json");
+}
+
 // ── the CLIs' own homes (we inject native session files INTO these) ──
 // Cross-CLI resume rewrites a canonical session into claude/codex's native
 // jsonl at the exact path that CLI reads, so `--resume` continues it.

--- a/packages/core/src/runtime/contract.ts
+++ b/packages/core/src/runtime/contract.ts
@@ -169,6 +169,7 @@ export interface SessionMeta {
   title: string; // derived (e.g. first user line)
   cli: "claude" | "codex";
   ts: number; // last updated
+  lastDevice?: { id: string; label: string };
 }
 
 // what gets encrypted to storage (CLI-neutral, so codex↔claude + cross-device)
@@ -178,4 +179,5 @@ export interface CanonicalSession {
   title: string;
   messages: ChatMessage[];
   ts: number;
+  lastDevice?: { id: string; label: string };
 }

--- a/packages/core/src/runtime/convert/claude.ts
+++ b/packages/core/src/runtime/convert/claude.ts
@@ -146,7 +146,7 @@ export function mapClaudeMessage(m: unknown): ParseResult {
 
   // a compact boundary = claude condensed the history; surface a summary record so
   // it folds in cross-CLI exactly like the line path's isCompactSummary.
-  if (msg.type === "compact_boundary") {
+  if (msg.type === "compact_boundary" || (msg.type === "system" && msg.subtype === "compact_boundary")) {
     out.messages.push({ role: "summary", text: "[conversation compacted]", ts: Date.now() });
     return out;
   }

--- a/packages/core/src/runtime/device-resume.spec.ts
+++ b/packages/core/src/runtime/device-resume.spec.ts
@@ -1,0 +1,166 @@
+import { describe, it, expect, vi, beforeEach, afterEach } from "vitest";
+import { mkdtempSync, rmSync } from "node:fs";
+import { tmpdir } from "node:os";
+import { join } from "node:path";
+import { createRuntime } from "./index.js";
+import { manualStorage } from "../account/storage/manual.js";
+import { testWallet } from "../account/keypairWallet.js";
+import { SessionStore } from "../account/store.js";
+import { buildDeviceNotice } from "../core/device.js";
+
+// Mock spawnCli
+const mockCliSend = vi.fn();
+let mockCliOnSessionId: any = null;
+let mockCliOnMessage: any = null;
+let mockCliOnTurnEnd: any = null;
+
+vi.mock("./spawn.js", () => {
+  return {
+    spawnCli: vi.fn((opts: any) => {
+      return {
+        send: mockCliSend,
+        onSessionId: (cb: any) => {
+          mockCliOnSessionId = cb;
+          cb(opts.sessionId || "test-session-id");
+        },
+        onMessage: (cb: any) => { mockCliOnMessage = cb; },
+        onSkill: () => {},
+        onUsage: () => {},
+        onTurnEnd: (cb: any) => { mockCliOnTurnEnd = cb; },
+        onError: () => {},
+      };
+    }),
+  };
+});
+
+// Mock getDeviceProfile to return B by default
+let currentDeviceProfile = { id: "device-B", label: "Device B" };
+vi.mock("../core/device.js", async (importOriginal) => {
+  const original = await importOriginal<typeof import("../core/device.js")>();
+  return {
+    ...original,
+    getDeviceProfile: vi.fn(() => Promise.resolve(currentDeviceProfile)),
+  };
+});
+
+describe("runtime/device-resume — cross-device notice resume flow", () => {
+  let home: string;
+  const origEnv = { ...process.env };
+
+  beforeEach(() => {
+    home = mkdtempSync(join(tmpdir(), "agentnet-runtime-"));
+    process.env.AGENTNET_HOME = home;
+    mockCliSend.mockClear();
+  });
+
+  afterEach(() => {
+    process.env = { ...origEnv };
+    rmSync(home, { recursive: true, force: true });
+  });
+
+  it("injects cross-device notice on first send and updates page meta, but doesn't persist notice", async () => {
+    const wallet = testWallet();
+    const storage = manualStorage();
+    const store = new SessionStore(wallet, storage);
+    const sessionId = "test-session-123";
+
+    // 1. Seed session with device-A
+    await store.appendMessage(
+      {
+        sessionId,
+        cli: "claude",
+        title: "Hello World",
+        ts: Date.now(),
+        lastDevice: { id: "device-A", label: "Device A" },
+      },
+      {
+        role: "user",
+        text: "first user message",
+        ts: Date.now(),
+      }
+    );
+
+    // 2. Start session with device B (switch detected)
+    const runtime = createRuntime(wallet, storage);
+    const handle = await runtime.startSession({
+      cli: "claude",
+      cwd: "/some/dir",
+      sessionId,
+    });
+
+    // 3. Verify newest page meta immediately updated to device B to guard against re-fire
+    const loadedSessionAfterStart = await store.load(sessionId);
+    expect(loadedSessionAfterStart?.lastDevice?.id).toBe("device-B");
+    expect(loadedSessionAfterStart?.lastDevice?.label).toBe("Device B");
+
+    // 4. Send message and verify notice prefix is sent to engine but NOT stored/emitted
+    const emitMsgs: any[] = [];
+    handle.onMessage((m) => {
+      emitMsgs.push(m);
+    });
+
+    handle.send("second user message");
+    await new Promise((r) => setTimeout(r, 50));
+
+    // Check sent message to CLI has the notice prefix
+    expect(mockCliSend).toHaveBeenCalledTimes(1);
+    const noticeStr = buildDeviceNotice(
+      { id: "device-A", label: "Device A" },
+      { id: "device-B", label: "Device B" }
+    );
+    expect(mockCliSend.mock.calls[0][0]).toBe(noticeStr + "\n\nsecond user message");
+
+    // Check emitted message lacks the notice prefix
+    expect(emitMsgs).toHaveLength(1);
+    expect(emitMsgs[0].text).toBe("second user message");
+
+    // Check stored messages lacks notice prefix
+    const loadedAfterSend = await store.load(sessionId);
+    expect(loadedAfterSend?.messages).toHaveLength(2);
+    expect(loadedAfterSend?.messages[1].text).toBe("second user message");
+
+    // 5. Send another message and verify it does NOT carry the notice
+    mockCliSend.mockClear();
+    handle.send("third user message");
+
+    expect(mockCliSend).toHaveBeenCalledTimes(1);
+    expect(mockCliSend.mock.calls[0][0]).toBe("third user message");
+  });
+
+  it("does not inject notice on same-device resume", async () => {
+    const wallet = testWallet();
+    const storage = manualStorage();
+    const store = new SessionStore(wallet, storage);
+    const sessionId = "test-session-456";
+
+    // 1. Seed session with device-B (same as current)
+    await store.appendMessage(
+      {
+        sessionId,
+        cli: "claude",
+        title: "Hello World",
+        ts: Date.now(),
+        lastDevice: { id: "device-B", label: "Device B" },
+      },
+      {
+        role: "user",
+        text: "first user message",
+        ts: Date.now(),
+      }
+    );
+
+    // 2. Start session
+    const runtime = createRuntime(wallet, storage);
+    const handle = await runtime.startSession({
+      cli: "claude",
+      cwd: "/some/dir",
+      sessionId,
+    });
+
+    // 3. Send message and verify NO notice prefix is sent
+    handle.send("second user message");
+
+    expect(mockCliSend).toHaveBeenCalledTimes(1);
+    expect(mockCliSend.mock.calls[0][0]).toBe("second user message");
+  });
+});

--- a/packages/core/src/runtime/index.ts
+++ b/packages/core/src/runtime/index.ts
@@ -8,6 +8,7 @@ import { Connection } from "@solana/web3.js";
 import { spawnCli } from "./spawn.js";
 import { SessionStore } from "../account/store.js";
 import { prepareResume } from "./inject/index.js";
+import { getDeviceProfile, buildDeviceNotice } from "../core/device.js";
 import { MemorySync, updateSkillsSection } from "../memory/index.js";
 import { getSkillShopping } from "../account/login.js";
 import { setSkillShoppingActive } from "../skill-market/passive.js";
@@ -88,14 +89,30 @@ export function createRuntime(
 
   return {
     async startSession(opts): Promise<SessionHandle> {
+      const device = await getDeviceProfile();
       // RESUME: opts.sessionId is the CANONICAL id. Rewrite its history into the
       // target cli's native jsonl and resume under the NATIVE id (claude/codex only
       // accept their own ids) — this is what lets a session cross between CLIs.
       // FRESH: no sessionId; the cli mints its own, which becomes the canonical id.
       const resuming = !!opts.sessionId;
-      const nativeId = resuming
+      const resumeResult = resuming
         ? await prepareResume(store, opts.cli, opts.cwd, opts.sessionId!, opts.ephemeral)
         : undefined;
+      const nativeId = resumeResult?.nativeId;
+
+      let pendingDeviceNotice: string | null = null;
+      if (resuming && resumeResult) {
+        if (resumeResult.hasMessages && resumeResult.lastDevice?.id && resumeResult.lastDevice.id !== device.id) {
+          pendingDeviceNotice = buildDeviceNotice(resumeResult.lastDevice, device);
+          if (!opts.ephemeral) await store.recordMeta({
+            sessionId: opts.sessionId!,
+            cli: opts.cli,
+            title: resumeResult.title ?? "",
+            ts: Date.now(),
+            lastDevice: device,
+          });
+        }
+      }
 
       // Inject the project's shared memory into this CLI's native files (Claude's
       // memory dir / Codex's AGENTS.md) BEFORE it starts so it loads this run. Best
@@ -140,7 +157,7 @@ export function createRuntime(
       const usageCbs: Array<(n: number) => void> = [];
       const pending: ChatMessage[] = []; // messages awaiting a known sessionId
 
-      const meta = () => ({ sessionId, cli: opts.cli, title, ts: Date.now() });
+      const meta = () => ({ sessionId, cli: opts.cli, title, ts: Date.now(), lastDevice: device });
 
       // Show the message to the UI, then append it to the encrypted log. Stamp the
       // producing CLI on every message so the UI badges each turn with the right
@@ -212,7 +229,11 @@ export function createRuntime(
           // Persist only a COUNT of attached images, never the base64 (keeps the encrypted
           // log small). The live UI still gets thumbnails — it holds the originals itself.
           emit({ role: "user", text: userText, ts: Date.now(), imageCount: images?.length || undefined });
-          cli.send(userText, images);
+          const textToSend = pendingDeviceNotice
+            ? pendingDeviceNotice + "\n\n" + userText
+            : userText;
+          pendingDeviceNotice = null;
+          cli.send(textToSend, images);
         },
         runSlashCommand(command: string, arg?: string) {
           cli.runSlashCommand?.(command, arg);

--- a/packages/core/src/runtime/inject/index.ts
+++ b/packages/core/src/runtime/inject/index.ts
@@ -60,9 +60,15 @@ export async function prepareResume(
   cwd: string,
   canonicalId: string,
   ephemeral?: boolean,
-): Promise<string> {
+): Promise<{
+  nativeId: string;
+  lastDevice?: { id: string; label: string };
+  title?: string;
+  hasMessages: boolean;
+}> {
   const canon = await store.load(canonicalId);
   const messages = replayable(canon?.messages ?? []);
+  const hasMessages = messages.length > 0;
 
   // The canonical id IS the native id for the cli that birthed the session.
   const birthCli = canon?.cli;
@@ -80,5 +86,10 @@ export async function prepareResume(
   } else {
     await injectCodex({ threadId: resolvedId, cwd, messages });
   }
-  return resolvedId;
+  return {
+    nativeId: resolvedId,
+    lastDevice: canon?.lastDevice,
+    title: canon?.title,
+    hasMessages,
+  };
 }

--- a/surfaces/android/app/src/main/java/com/iqlabs/agentnet/ServerManager.kt
+++ b/surfaces/android/app/src/main/java/com/iqlabs/agentnet/ServerManager.kt
@@ -1,6 +1,7 @@
 package com.iqlabs.agentnet
 
 import android.content.Context
+import android.os.Build
 import android.util.Log
 import java.io.BufferedReader
 import java.io.File
@@ -87,6 +88,7 @@ class ServerManager(private val ctx: Context) {
             // the first model request by ~90s on Android. Local skills live under .codex/skills;
             // this only disables the Codex "plugins" feature for the Android app-server.
             "AGENTNET_CODEX_DISABLE_PLUGINS=1",
+            "AGENTNET_DEVICE_LABEL=${Build.MANUFACTURER} ${Build.MODEL} (Android)",
             *googleClientIdEnv.toTypedArray(),
             *googleNativeAuthEnv.toTypedArray(),
             "/bin/sh", "-lc", cmd,


### PR DESCRIPTION
Closes #74

## Summary

- Injects a one-shot notice into the first `cli.send` after a cross-device resume — not into `emit`, so it never touches the encrypted log or Drive sync
- Zero-token cost on same-device resume; ~50 tokens once on a switch
- Notice text tells the agent to verify paths and "already installed" facts from the previous machine

## Changes

**`core/device.ts`** — new `getDeviceProfile()`: stable UUID in `~/.agentnet/device.json` (local only, never synced), label from `AGENTNET_DEVICE_LABEL` env or `hostname (platform)` fallback

**`sessionLog / contract / store`** — `lastDevice?: { id, label }` added to `LogRecord`, `CanonicalSession`, `SessionMeta`; new `store.recordMeta()` writes a fresh meta line to the current page so the device updates on switch and same-device resumes stay silent

**`runtime/index.ts`** — detects `lastDevice.id !== device.id` on resume, builds notice, prepends to `cli.send` only (not `emit`), clears flag after first turn; ephemeral sessions skip the `recordMeta` write

**`runtime/inject/index.ts`** — `prepareResume` returns `{ nativeId, lastDevice, title, hasMessages }` instead of bare string

**`ServerManager.kt`** — sets `AGENTNET_DEVICE_LABEL=${Build.MANUFACTURER} ${Build.MODEL} (Android)` in proot guest env

## Test plan

- `device.spec.ts` — UUID stability, persistence, `AGENTNET_DEVICE_LABEL` override, notice format
- `device-resume.spec.ts` — cross-device: notice on first send only, not in emit, not on second send; same-device: no notice; fresh session: no notice