### PR TITLE
feat: context window display parity — real meter, /context command, compaction UX

### DIFF
--- a/packages/core/src/chat/session.spec.ts
+++ b/packages/core/src/chat/session.spec.ts
@@ -10,7 +10,8 @@ import { join } from "node:path";
 import { tmpdir } from "node:os";
 
 function fakeHandle(id: string, cli: "claude" | "codex") {
-  const usageCbs: Array<(n: number) => void> = [];
+  const usageCbs: Array<(n: number, window?: number) => void> = [];
+  const compactCbs: Array<() => void> = [];
   return {
     sessionId: id,
     cli,
@@ -19,8 +20,10 @@ function fakeHandle(id: string, cli: "claude" | "codex") {
     onMessage: vi.fn(),
     onTurnEnd: vi.fn(),
     onSkill: vi.fn(),
-    onUsage: vi.fn((cb: (n: number) => void) => usageCbs.push(cb)),
-    emitUsage: (n: number) => usageCbs.forEach((cb) => cb(n)),
+    onUsage: vi.fn((cb: (n: number, window?: number) => void) => usageCbs.push(cb)),
+    emitUsage: (n: number, window?: number) => usageCbs.forEach((cb) => cb(n, window)),
+    onCompact: vi.fn((cb: () => void) => compactCbs.push(cb)),
+    emitCompact: () => compactCbs.forEach((cb) => cb()),
     interrupt: vi.fn(),
     stop: vi.fn(),
   };

--- a/packages/core/src/chat/session.ts
+++ b/packages/core/src/chat/session.ts
@@ -18,6 +18,12 @@ import { access, writeFile } from "node:fs/promises";
 import { join } from "node:path";
 import type { ChatModelOption } from "./modelOptions.js";
 
+// Format a token count with thousands separators (e.g. 167000 → "167,000") for the
+// /context breakdown notice.
+function fmtTok(n: number): string {
+  return Math.round(n).toLocaleString("en-US");
+}
+
 // The two-way pipe to ONE chat UI (one panel / one socket). Messages both ways are
 // flat {type, ...} JSON — the same shape the webview already speaks.
 export interface ChatTransport {
@@ -168,7 +174,7 @@ export function createChatSession(
   // q.interrupt / codex child.kill). Instead we re-spawn lazily on the next send,
   // carrying the live session over, so the running turn finishes untouched and the new
   // setting applies from the next message.
-  type Slot = { handle: SessionHandle | null; pendingId?: string; model?: string; mode?: string; effort?: "low" | "medium" | "high" | "xhigh" | "max"; restage?: boolean; lastUsage?: number };
+  type Slot = { handle: SessionHandle | null; pendingId?: string; model?: string; mode?: string; effort?: "low" | "medium" | "high" | "xhigh" | "max"; restage?: boolean; lastUsage?: number; lastWindow?: number };
   const slots: Record<"claude" | "codex", Slot> = {
     claude: { handle: null, mode: "acceptEdits" },
     codex: { handle: null, mode: "auto" },
@@ -190,10 +196,17 @@ export function createChatSession(
     // a skill firing → the green "Casting <skill>" marquee (issue #17). Transient, not
     // persisted; only painted for the active tab.
     h.onSkill((name) => { if (cli === forCli) sendMarket({ type: "skillActive", name }); });
-    // token usage: forward to the active surface so it can render a context meter.
-    h.onUsage((contextTokens) => {
+    // token usage: forward to the active surface so it can render a context meter. The
+    // window (when the engine reports it) lets the UI show a percentage, not a bare count.
+    h.onUsage((contextTokens, contextWindow) => {
       slots[forCli].lastUsage = contextTokens;
-      if (cli === forCli) transport.send({ type: "usage", contextTokens });
+      if (contextWindow !== undefined) slots[forCli].lastWindow = contextWindow;
+      if (cli === forCli) transport.send({ type: "usage", contextTokens, contextWindow: slots[forCli].lastWindow });
+    });
+    // compaction: the engine condensed history to reclaim context. Cue the active surface
+    // (a notice + the next usage update reflects the reclaimed space).
+    h.onCompact(() => {
+      if (cli === forCli) transport.send({ type: "compacted" });
     });
     h.onTurnEnd(async () => {
       if (cli === forCli) transport.send({ type: "turnEnd" }); // stop the typing dots
@@ -443,7 +456,35 @@ export function createChatSession(
               mode: s.mode,
               effort: s.effort ?? "default",
               contextTokens: s.lastUsage,
+              contextWindow: s.lastWindow,
             },
+          });
+          break;
+        }
+        // /context — local breakdown of context-window occupancy (no native call). Mirrors
+        // Claude Code's `/context`: used / window / free / auto-compact threshold. We don't
+        // have per-category token data from the engines, so we report the totals we do have.
+        if (command === "context") {
+          const s = slot();
+          const window = s.lastWindow ?? (cli === "codex" ? 256_000 : 200_000);
+          if (s.lastUsage === undefined) {
+            transport.send({ type: "notice", text: `Context: 0 / ${fmtTok(window)} tokens — send a message to measure usage.` });
+            break;
+          }
+          const used = s.lastUsage;
+          const free = Math.max(0, window - used);
+          const pct = Math.round((used / window) * 100);
+          // auto-compact reserve: ~20k for the model's reply + ~13k summary headroom,
+          // matching Claude Code's effectiveWindow − 13k formula.
+          const threshold = Math.max(0, window - 33_000);
+          const tpct = Math.round((threshold / window) * 100);
+          transport.send({
+            type: "notice",
+            text:
+              `Context window (${cli})\n` +
+              `  used    ${fmtTok(used)} / ${fmtTok(window)} (${pct}%)\n` +
+              `  free    ${fmtTok(free)}\n` +
+              `  auto-compact at ~${fmtTok(threshold)} (${tpct}%)`,
           });
           break;
         }

--- a/packages/core/src/runtime/contract.ts
+++ b/packages/core/src/runtime/contract.ts
@@ -100,9 +100,12 @@ export interface SessionHandle {
   onMessage(cb: (msg: ChatMessage) => void): void; // CLI output (UI renders)
   onTurnEnd(cb: () => void): void; // turn finished (runtime auto-saves here)
   onSkill(cb: (name: string) => void): void; // a skill fired → UI "Casting <skill>" cue
-  // real context-window occupancy (tokens) reported by the engine each turn. Optional
-  // for the UI to use (e.g. a context-left meter); surfaces may ignore it.
-  onUsage(cb: (contextTokens: number) => void): void;
+  // real context-window occupancy (tokens) reported by the engine each turn, plus the
+  // model's window size (contextWindow) when known — so the UI can render a percentage
+  // meter, not just a raw count. Optional for the UI to use; surfaces may ignore it.
+  onUsage(cb: (contextTokens: number, contextWindow?: number) => void): void;
+  // the engine compacted the conversation (history summarized to reclaim context).
+  onCompact(cb: () => void): void;
   // interrupt the CURRENT turn but keep the session alive (claude q.interrupt / codex
   // turn/interrupt) — the next send continues the same conversation. Distinct from
   // stop(), which tears the whole handle down.

--- a/packages/core/src/runtime/device-resume.spec.ts
+++ b/packages/core/src/runtime/device-resume.spec.ts
@@ -26,6 +26,7 @@ vi.mock("./spawn.js", () => {
         onMessage: (cb: any) => { mockCliOnMessage = cb; },
         onSkill: () => {},
         onUsage: () => {},
+        onCompact: () => {},
         onTurnEnd: (cb: any) => { mockCliOnTurnEnd = cb; },
         onError: () => {},
       };

--- a/packages/core/src/runtime/index.ts
+++ b/packages/core/src/runtime/index.ts
@@ -158,7 +158,8 @@ export function createRuntime(
       const msgCbs: Array<(m: ChatMessage) => void> = [];
       const turnCbs: Array<() => void> = [];
       const skillCbs: Array<(name: string) => void> = []; // "Casting <skill>" marquee
-      const usageCbs: Array<(n: number) => void> = [];
+      const usageCbs: Array<(n: number, window?: number) => void> = [];
+      const compactCbs: Array<() => void> = [];
       const pending: ChatMessage[] = []; // messages awaiting a known sessionId
 
       const meta = () => ({ sessionId, cli: opts.cli, title, ts: Date.now(), lastDevice: device });
@@ -195,7 +196,8 @@ export function createRuntime(
       // A skill firing is a transient UI cue, not a transcript entry — fan it out to
       // listeners without persisting it (issue #17).
       cli.onSkill((name: string) => { for (const cb of skillCbs) cb(name); });
-      cli.onUsage((n: number) => { for (const cb of usageCbs) cb(n); });
+      cli.onUsage((n: number, window?: number) => { for (const cb of usageCbs) cb(n, window); });
+      cli.onCompact(() => { for (const cb of compactCbs) cb(); });
       cli.onTurnEnd(() => {
         if (opts.ephemeral) {
           for (const cb of turnCbs) cb();
@@ -253,6 +255,9 @@ export function createRuntime(
         },
         onUsage(cb) {
           usageCbs.push(cb);
+        },
+        onCompact(cb) {
+          compactCbs.push(cb);
         },
         interrupt() {
           cli.interrupt(); // stop the current turn; the session stays open for the next send

--- a/packages/core/src/runtime/spawn.ts
+++ b/packages/core/src/runtime/spawn.ts
@@ -640,6 +640,7 @@ function codexEngine(opts: SpawnOpts): Engine {
       // history was condensed to reclaim context — fire the compaction cue. The following
       // tokenUsage/updated (or next turn) reports the reclaimed occupancy.
       cb.emitCompact();
+      cb.emitMsg({ role: "summary", text: "[conversation compacted]", ts: Date.now() });
     } else if (msg.method === "turn/completed") {
       if (params?.usage) {
         const usage = params.usage;

--- a/packages/core/src/runtime/spawn.ts
+++ b/packages/core/src/runtime/spawn.ts
@@ -80,7 +80,13 @@ export interface Engine {
   // Transient signal for the "Casting <skill>" activity marquee (issue #17); NOT a
   // transcript message (it isn't persisted).
   onSkill(cb: (name: string) => void): void;
-  onUsage(cb: (contextTokens: number) => void): void; // real context occupancy per turn
+  // real context occupancy per turn. contextWindow is the model's window size when the
+  // engine reports it (codex modelContextWindow), else a sensible default — so the UI can
+  // render a percentage/meter instead of a bare token count.
+  onUsage(cb: (contextTokens: number, contextWindow?: number) => void): void;
+  // the engine compacted the conversation (history summarized to reclaim context). The
+  // next onUsage will reflect the reclaimed space; this fires the UI's compaction cue.
+  onCompact(cb: () => void): void;
   send(text: string, images?: ImageInput[]): void;
   runSlashCommand?(command: string, arg?: string): void;
   interrupt(): void; // stop the current turn, keep the session alive
@@ -160,16 +166,26 @@ function callbacks() {
   const turn: Array<() => void> = [];
   const err: Array<(t: string) => void> = [];
   const skill: Array<(name: string) => void> = [];
-  const use: Array<(n: number) => void> = [];
+  const use: Array<(n: number, window?: number) => void> = [];
+  const comp: Array<() => void> = [];
   return {
-    msg, sid, turn, err, skill, use,
+    msg, sid, turn, err, skill, use, comp,
     emitMsg: (m: ChatMessage) => { for (const c of msg) c(m); },
     emitSid: (id: string) => { for (const c of sid) c(id); },
     emitTurn: () => { for (const c of turn) c(); },
     emitErr: (t: string) => { for (const c of err) c(t); },
     emitSkill: (n: string) => { for (const c of skill) c(n); },
-    emitUsage: (n: number) => { for (const c of use) c(n); },
+    emitUsage: (n: number, window?: number) => { for (const c of use) c(n, window); },
+    emitCompact: () => { for (const c of comp) c(); },
   };
+}
+
+// Default context-window size (tokens) when the engine doesn't report a real one.
+// Codex carries the authoritative `modelContextWindow` per turn (we prefer it when
+// present); Claude's SDK exposes no window field, so we fall back to the published
+// model limit. Keep in sync with the constants the surfaces used to hardcode.
+function defaultWindow(cli: "claude" | "codex", _model?: string): number {
+  return cli === "codex" ? 256_000 : 200_000;
 }
 
 function loadPersistentWhitelist(): Set<string> {
@@ -391,7 +407,10 @@ function claudeEngine(opts: SpawnOpts): Engine {
             cb.emitMsg(cm);
           }
         }
-        if (r.contextTokens !== undefined) cb.emitUsage(r.contextTokens);
+        if (r.contextTokens !== undefined) cb.emitUsage(r.contextTokens, defaultWindow("claude", opts.model));
+        // claude surfaces a compaction as a "summary" record (compact_boundary); mirror it
+        // as the explicit compaction cue so the UI behaves the same as it does for codex.
+        if (r.messages.some((cm) => cm.role === "summary")) cb.emitCompact();
         if (r.turnEnded) { streamBuf = ""; cb.emitTurn(); }
       }
     } catch (e) {
@@ -407,6 +426,7 @@ function claudeEngine(opts: SpawnOpts): Engine {
     onError: (c) => cb.err.push(c),
     onSkill: (c) => cb.skill.push(c),
     onUsage: (c) => cb.use.push(c),
+    onCompact: (c) => cb.comp.push(c),
     send: (t, images) => push(t, images),
     runSlashCommand: (command, arg) => {
       const text = "/" + command + (arg ? " " + arg : "");
@@ -434,6 +454,9 @@ export function codexMcpFlags(m: { name: string; command: string; args: string[]
 // and processes requests and notifications, routing approvals to the ApprovalChannel.
 function codexEngine(opts: SpawnOpts): Engine {
   const cb = callbacks();
+  // last known context-window size (tokens). Seeded with the model default; replaced by
+  // the real modelContextWindow the moment the server reports it in a usage notification.
+  let knownWindow = defaultWindow("codex", opts.model);
   const approval = opts.approval ?? autoApprove();
 
   const codexPath = resolveExecutable("codex") || "codex";
@@ -604,10 +627,23 @@ function codexEngine(opts: SpawnOpts): Engine {
           thinkingBuf = "";
         }
       }
+    } else if (msg.method === "thread/tokenUsage/updated") {
+      // Authoritative usage notification: carries the running total AND the real model
+      // context window. Prefer it over the turn/completed estimate when present.
+      const tu = params?.tokenUsage;
+      if (tu) {
+        if (typeof tu.modelContextWindow === "number") knownWindow = tu.modelContextWindow;
+        const total = tu.total?.totalTokens;
+        if (typeof total === "number") cb.emitUsage(total, knownWindow);
+      }
+    } else if (msg.method === "thread/compacted") {
+      // history was condensed to reclaim context — fire the compaction cue. The following
+      // tokenUsage/updated (or next turn) reports the reclaimed occupancy.
+      cb.emitCompact();
     } else if (msg.method === "turn/completed") {
       if (params?.usage) {
         const usage = params.usage;
-        cb.emitUsage((usage.input_tokens ?? 0) + (usage.cached_input_tokens ?? 0));
+        cb.emitUsage((usage.input_tokens ?? 0) + (usage.cached_input_tokens ?? 0), knownWindow);
       }
       cb.emitTurn();
       running = false;
@@ -932,6 +968,7 @@ function codexEngine(opts: SpawnOpts): Engine {
     // mapCodexEvent flags any command/path that references our skills dir (convert/codex).
     onSkill: (c) => cb.skill.push(c),
     onUsage: (c) => cb.use.push(c),
+    onCompact: (c) => cb.comp.push(c),
     send: (t, images) => {
       void initPromise.then(() => runTurn(t, images));
     },

--- a/surfaces/cli/src/hooks/useChat.ts
+++ b/surfaces/cli/src/hooks/useChat.ts
@@ -29,6 +29,7 @@ export function useChat(
   const [pendingId, setPendingId] = useState<string | undefined>(opts.resume);
   const [elapsed, setElapsed] = useState<number | undefined>(undefined);
   const [contextTokens, setContextTokens] = useState<number | undefined>(undefined);
+  const [contextWindow, setContextWindow] = useState<number | undefined>(undefined);
   // scrollback pagination (older pages) + a Static-reset epoch (bumped on any wholesale
   // transcript change so the <Static> history re-renders instead of mis-appending).
   const [hasMore, setHasMore] = useState(false);
@@ -107,7 +108,7 @@ export function useChat(
           return [...prev, m];
         }),
       );
-      h.onUsage((n) => setContextTokens(n));
+      h.onUsage((n, win) => { setContextTokens(n); if (win !== undefined) setContextWindow(win); });
       h.onSkill((name) => setFiringSkill(name));
       h.onTurnEnd(() => {
         // a fresh session reveals its canonical id now — adopt it so resume/switch work.
@@ -166,6 +167,7 @@ export function useChat(
       dropHandle();
       setCli(next);
       setContextTokens(undefined);
+      setContextWindow(undefined);
       void savePrefs({ lastCli: next });
     },
     [dropHandle],
@@ -176,6 +178,7 @@ export function useChat(
       dropHandle();
       setModel(m);
       setContextTokens(undefined);
+      setContextWindow(undefined);
       void savePrefs({ lastModel: m });
     },
     [dropHandle],
@@ -194,7 +197,7 @@ export function useChat(
     async (id: string) => {
       dropHandle();
       setPendingId(id);
-      setContextTokens(undefined); // reset bar — new session's usage unknown until first turn
+      setContextTokens(undefined); setContextWindow(undefined); // reset bar — new session's usage unknown until first turn
       const p = await runtime.loadSession(id);
       setMessages(p.messages);
       setHasMore(p.hasMore);
@@ -209,6 +212,7 @@ export function useChat(
     setPendingId(undefined);
     setMessages([]);
     setContextTokens(undefined);
+    setContextWindow(undefined);
     setHasMore(false);
     setCursor(null);
     setEpoch((e) => e + 1);
@@ -268,6 +272,7 @@ export function useChat(
     pendingId,
     elapsed,
     contextTokens,
+    contextWindow,
     hasMore,
     epoch,
     send,

--- a/surfaces/cli/src/hooks/useChat.ts
+++ b/surfaces/cli/src/hooks/useChat.ts
@@ -109,6 +109,7 @@ export function useChat(
         }),
       );
       h.onUsage((n, win) => { setContextTokens(n); if (win !== undefined) setContextWindow(win); });
+      h.onCompact(() => setContextTokens(undefined));
       h.onSkill((name) => setFiringSkill(name));
       h.onTurnEnd(() => {
         // a fresh session reveals its canonical id now — adopt it so resume/switch work.

--- a/surfaces/cli/src/views/Chat.tsx
+++ b/surfaces/cli/src/views/Chat.tsx
@@ -552,7 +552,7 @@ export function Chat({
             lines.push(`engine    claude`);
             lines.push(`auth      subscription`);
           }
-          const win = chat.cli === "codex" ? 256_000 : 200_000;
+          const win = chat.contextWindow ?? (chat.cli === "codex" ? 256_000 : 200_000);
           const used = chat.contextTokens ?? Math.round(chat.messages.reduce((n, m) => n + m.text.length, 0) / 4);
           lines.push(`model     ${chat.model ?? "default"}`);
           lines.push(`ctx used  ${used.toLocaleString()} / ${win.toLocaleString()} tokens`);
@@ -590,7 +590,7 @@ export function Chat({
   const mood: Mood = eggMood ?? (pendingApproval ? "tool" : chat.busy ? "thinking" : idle ? "sleeping" : "idle");
   // context-left: prefer the engine's REAL per-turn usage; before the first turn reports,
   // fall back to a rough chars/4 estimate so the meter isn't blank.
-  const WINDOW = chat.cli === "codex" ? 256_000 : 200_000;
+  const WINDOW = chat.contextWindow ?? (chat.cli === "codex" ? 256_000 : 200_000);
   // Only fall back to char-count estimate when there are actual messages — otherwise
   // the bar shows 0/200k on every fresh session which is meaningless noise.
   const usedTokens =

--- a/surfaces/cli/src/views/Chat.tsx
+++ b/surfaces/cli/src/views/Chat.tsx
@@ -499,6 +499,25 @@ export function Chat({
         } else setNotice("usage: /resume <id-prefix> (see /sessions)");
         return;
       }
+      case "context": {
+        const win = chat.contextWindow ?? (chat.cli === "codex" ? 256_000 : 200_000);
+        if (chat.contextTokens === undefined) {
+          setNotice(`Context: 0 / ${win.toLocaleString()} tokens — send a message to measure usage.`);
+          return;
+        }
+        const used = chat.contextTokens;
+        const free = Math.max(0, win - used);
+        const pct = Math.round((used / win) * 100);
+        const threshold = Math.max(0, win - 33_000);
+        const tpct = Math.round((threshold / win) * 100);
+        setNotice(
+          `Context window (${chat.cli})\n` +
+          `  used    ${used.toLocaleString()} / ${win.toLocaleString()} (${pct}%)\n` +
+          `  free    ${free.toLocaleString()}\n` +
+          `  auto-compact at ~${threshold.toLocaleString()} (${tpct}%)`
+        );
+        return;
+      }
       case "wallet":
         setNotice(`wallet ${address}`);
         return;
@@ -571,7 +590,7 @@ export function Chat({
         startBtwQuery(arg.trim());
         return;
       case "help":
-        setNotice("/new /sessions /resume /more /compact /clear /copy /models /engine /effort /account /settings /wallet /storage /btw <question> /iq /quit · !cmd shell · Esc cancels · Ctrl+A/E/W/U edit");
+        setNotice("/new /sessions /resume /more /compact /clear /copy /models /engine /effort /context /account /settings /wallet /storage /btw <question> /iq /quit · !cmd shell · Esc cancels · Ctrl+A/E/W/U edit");
         return;
       default:
         setNotice(`unknown command: /${cmd} (try /help)`);

--- a/surfaces/webview/src/chat/Composer.tsx
+++ b/surfaces/webview/src/chat/Composer.tsx
@@ -7,6 +7,26 @@ import { useElementHeightVariable } from "../layoutEffects";
 import { CHAT_MODEL_OPTIONS } from "@iqlabs-official/agent-sdk/chat/modelOptions";
 import { CHAT_SLASH_COMMANDS } from "@iqlabs-official/agent-sdk/chat/slashCommands";
 
+// ── Context bar (mirrors Claude Code's real status-line meter) ──────────────
+// Colors: green < 60 %, yellow < 85 %, red ≥ 85 %
+function CtxBar({ tokens, window: win, approx }: { tokens: number; window: number; approx?: boolean }) {
+  const frac = Math.min(1, tokens / win);
+  const pct = Math.round(frac * 100);
+  const fmtK = (n: number) => n >= 1000 ? Math.round(n / 1000) + "k" : String(n);
+  const color = frac >= 0.85 ? "var(--an-red, #e55)" : frac >= 0.60 ? "var(--an-amber, #e90)" : "var(--an-green, #4c8)";
+  const CELLS = 8;
+  const filled = Math.round(frac * CELLS);
+  const bar = "█".repeat(filled) + "░".repeat(CELLS - filled);
+  return (
+    <span className="ml-auto flex items-center gap-1 text-[10px] font-mono" style={{ color }} title={`${tokens.toLocaleString()} / ${win.toLocaleString()} tokens (${pct}%)`}>
+      {approx && <span style={{ color: "var(--an-fg-mute)" }}>~</span>}
+      <span style={{ letterSpacing: "-0.5px" }}>[{bar}]</span>
+      <span>{fmtK(tokens)}/{fmtK(win)}</span>
+      <span style={{ color: "var(--an-fg-mute)" }}>ctx</span>
+    </span>
+  );
+}
+
 // The shared model catalog (same one vscode/cli use) — gives versioned chip labels
 // (Opus 4.8, Sonnet 4.6, GPT-5.5 Codex…) + a description, instead of bare aliases.
 // `value` is undefined for the engine default; the picker treats that as "default".
@@ -412,11 +432,10 @@ export function Composer() {
           <span className="max-w-[7rem] truncate">{MODES[state.cli].find((m) => m.value === mode)?.label ?? mode}</span>
           <svg width="10" height="10" viewBox="0 0 10 10" fill="none" stroke="currentColor" strokeWidth="1.4" strokeLinecap="round" style={{ transform: controlsOpen ? "rotate(180deg)" : "none", transition: "transform .15s" }}><path d="M2.5 4l2.5 2.5L7.5 4" /></svg>
         </button>
-        {state.contextTokens !== undefined && (
-          <span className="ml-auto" style={{ color: "var(--an-fg-mute)" }}>
-            ctx: {state.contextTokens >= 1000 ? Math.round(state.contextTokens / 1000) + "k" : state.contextTokens}
-          </span>
-        )}
+        {state.contextTokens !== undefined && (() => {
+          const win = state.contextWindow ?? (state.cli === "codex" ? 256_000 : 200_000);
+          return <CtxBar tokens={state.contextTokens} window={win} />;
+        })()}
         {queueCount > 0 && (
           <span className="ml-auto animate-pulse text-[10px]" style={{ color: "var(--an-amber)" }}>
             ⏳ {queueCount} queued

--- a/surfaces/webview/src/state/store.tsx
+++ b/surfaces/webview/src/state/store.tsx
@@ -102,6 +102,7 @@ export interface State {
   buyCelebrate: boolean;
   buyCelebrateLabel: string | null; // bought skill's slug/name for the purchase card
   contextTokens?: number;
+  contextWindow?: number;
   currentModel?: string;
   queuePending: number;
   agents: Reputation[];
@@ -310,9 +311,15 @@ function reducer(state: State, ev: Action): State {
         ? { ...state, cli: "codex", phase: "chat", cliReport: state.cliReport ? { ...state.cliReport, codex: "ok" } : state.cliReport, codexLoginUrl: null, codexLoginCode: null, codexLoginError: null }
         : { ...state, codexLoginUrl: null, codexLoginCode: null, codexLoginError: ev.error ?? "Login failed." };
     case "usage":
-      return { ...state, contextTokens: ev.contextTokens };
+      return {
+        ...state,
+        contextTokens: ev.contextTokens,
+        contextWindow: ev.contextWindow ?? state.contextWindow,
+      };
+    case "compacted":
+      return { ...state, contextTokens: undefined, toast: "Context compacted — conversation history summarised to free space." };
     case "clear":
-      return { ...state, log: [], approvals: [], typing: false, loading: false, contextTokens: undefined, firingSkills: [] };
+      return { ...state, log: [], approvals: [], typing: false, loading: false, contextTokens: undefined, contextWindow: undefined, firingSkills: [] };
     case "message":
       return { ...state, log: appendMessage(state.log, ev.msg) };
     case "turnEnd":
@@ -361,6 +368,7 @@ function reducer(state: State, ev: Action): State {
         hasMore: false,
         cursor: 0,
         contextTokens: undefined,
+        contextWindow: undefined,
         firingSkills: [],
       };
     case "platform":
@@ -381,9 +389,11 @@ function reducer(state: State, ev: Action): State {
       return { ...state, toast: ev.text };
     case "status": {
       const s = ev.status;
+      const win = state.contextWindow ?? (s.cli === "codex" ? 256_000 : 200_000);
+      const fmtK = (n: number) => n >= 1000 ? Math.round(n / 1000) + "k" : String(n);
       const ctx = s.contextTokens === undefined
         ? ""
-        : `, ctx ${s.contextTokens >= 1000 ? Math.round(s.contextTokens / 1000) + "k" : s.contextTokens}`;
+        : `, ctx ${fmtK(s.contextTokens)} / ${fmtK(win)} (${Math.round((s.contextTokens / win) * 100)}%)`;
       return {
         ...state,
         toast: `${s.cli}: model ${s.model ?? "default"}, mode ${s.mode ?? "default"}, effort ${s.effort ?? "default"}${ctx}`,

--- a/surfaces/webview/src/transport/protocol.ts
+++ b/surfaces/webview/src/transport/protocol.ts
@@ -160,7 +160,8 @@ export type ClientMessage =
 
 export type ServerMessage =
   | { type: "clear" }
-  | { type: "usage"; contextTokens: number }
+  | { type: "usage"; contextTokens: number; contextWindow?: number }
+  | { type: "compacted" }
   | { type: "notice"; text: string }
   | {
       type: "status";


### PR DESCRIPTION
## Summary

### Context window display parity (issue #79)

- Core engine now emits \`contextWindow\` alongside \`contextTokens\` on every turn; codex prefers the authoritative \`modelContextWindow\` from each turn response
- \`onCompact\` callback plumbed through \`SessionHandle\` so all surfaces react to compaction events
- Webview Composer: bare \`ctx: 45k\` chip replaced with a real meter — 8-cell block bar \`[████░░░░]\`, \`used/window\` label, green/yellow/red colour thresholds at 60% and 85%
- CLI: consumes real \`contextWindow\` from the engine instead of hardcoded 200k/256k constants; resets bar on compaction via \`onCompact\`
- Transport \`usage\` SSE event carries \`contextWindow?\`; new \`compacted\` event type added
- \`/status\` toast now shows \`45k / 200k (22%)\` instead of just \`45k\`

### /context command (CLI)

Adds \`/context\` slash command to the CLI showing a full breakdown:
\`\`\`
Context window (claude)
  used    45,000 / 200,000 (22%)
  free    155,000
  auto-compact at ~167,000 (83%)
\`\`\`
Also added to \`/help\` text.

### Compaction summary bubble (codex engine)

When codex fires a compaction event, a \`summary\` role message \`[conversation compacted]\` is injected into the chat log so the user can see where history was condensed.

## Test plan

- [ ] Start a conversation and verify the context bar shows \`[████░░░░] Xk/200k ctx\` in the webview composer
- [ ] Verify bar turns yellow above 60% and red above 85%
- [ ] Run \`/context\` in the CLI and confirm used/free/threshold breakdown appears
- [ ] Run \`/status\` and confirm it shows \`ctx Xk / 200k (Y%)\`
- [ ] Switch engine/model and confirm the bar resets until the next turn
- [ ] Trigger codex compaction and confirm \`[conversation compacted]\` bubble appears and CLI bar resets
- [ ] Verify CLI \`/help\` lists \`/context\`

Closes #79