### PR TITLE
Fix devnet skill buy, blog post feedback, and mobile app UX

### DIFF
--- a/packages/core/src/chat/marketMessages.ts
+++ b/packages/core/src/chat/marketMessages.ts
@@ -94,6 +94,7 @@ export type MarketRequest =
   | { type: "reEquipSkill"; skillId: string } // undo a dispose (re-install, no re-buy)
   | { type: "ownedSkills" } // ask the host to (re)send the owned list
   | { type: "getBalance" } // ask the host for the wallet's native SOL balance
+  | { type: "airdrop" } // devnet only: ask the host to fund this wallet from the faucet
   | { type: "setHeliusKey" } // host opens a native input to capture + save the key
   | { type: "useDefaultRpc" } // clear any key, fall back to the default
   | { type: "getRpcStatus" } // ask the host to (re)send rpcStatus
@@ -126,7 +127,9 @@ export type MarketEvent =
   | { type: "searchError"; message: string } // search threw (RPC/DAS failure) — show why, don't hang
   | { type: "skillDetail"; detail: SkillDetail } // full detail for the opened item (includes notes)
   | { type: "skillDoc"; name: string; text: string | null } // installed skill's SKILL.md (null = not found)
-  | { type: "buyResult"; skillId: string; ok: boolean; slug?: string; error?: string }
+  // code "insufficient_funds" lets the UI open the fund prompt (Get devnet SOL) instead of
+  // only toasting a raw chain error, so a broke wallet gets an actionable path, not a dead end.
+  | { type: "buyResult"; skillId: string; ok: boolean; slug?: string; error?: string; code?: "insufficient_funds" }
   | { type: "disposeResult"; skillId: string; ok: boolean; slug?: string; error?: string }
   | { type: "reEquipResult"; skillId: string; ok: boolean; slug?: string; error?: string }
   // installed skill names (panel fill) + slug->mint for bought NFTs (reuse market detail) +
@@ -135,6 +138,7 @@ export type MarketEvent =
   // holdings from chain (ownedSkillCards); absent on the names-only emits (chat panel/buy).
   | { type: "ownedSkills"; names: string[]; mints?: Record<string, string>; disposedMints?: Record<string, string>; cards?: SkillCard[] }
   | { type: "balance"; lamports: number | null } // wallet SOL balance (null = read failed)
+  | { type: "airdropResult"; ok: boolean; lamports?: number; error?: string } // devnet faucet result (lamports = the new balance)
   | { type: "skillActive"; name: string } // a skill fired -> "Casting <name>" cue
   | { type: "rpcStatus"; status: RpcStatus } // DAS-ready? which source? (issue #23)
   // issue #34: comment write result + refreshed comment list

--- a/packages/core/src/chat/session.ts
+++ b/packages/core/src/chat/session.ts
@@ -57,7 +57,7 @@ export interface ChatEnv {
   searchSkills?(query: string, kind?: "skill" | "workflow"): Promise<SkillCard[]>;
   getSkillDetail?(mint: string): Promise<import("./marketMessages.js").SkillDetail>;
   getSkillDoc?(name: string): Promise<string | null>;
-  buySkill?(skillId: string, creatorWallet?: string): Promise<{ ok: boolean; slug?: string; error?: string }>;
+  buySkill?(skillId: string, creatorWallet?: string): Promise<{ ok: boolean; slug?: string; error?: string; code?: "insufficient_funds" }>;
   // dispose (un-equip) an owned skill: local + sticky (soulbound NFT stays owned, no refund).
   disposeSkill?(skillId: string): Promise<{ ok: boolean; slug?: string; error?: string }>;
   // re-equip a previously-disposed skill the wallet still owns (undo, no re-buy).
@@ -79,6 +79,9 @@ export interface ChatEnv {
   buyAllSkills?(wallet: string): Promise<{ ok: boolean; bought: number; failed: number; error?: string }>;
   postAgentNote?(agentWallet: string, text: string, gitLink?: string, title?: string, image?: string): Promise<{ ok: boolean; notes?: import("./marketMessages.js").Note[]; error?: string }>;
   solBalance?(): Promise<number | null>; // wallet's native SOL balance (lamports), for the UI funds display
+  // devnet-only: fund the wallet from the faucet (manual "Get devnet SOL" on an insufficient-
+  // funds buy). Returns the new balance so the UI refreshes and lets the buyer retry.
+  airdrop?(): Promise<{ ok: boolean; lamports?: number; error?: string }>;
   // make-skill: publish a new skill from the UI. priceSol is the human SOL string; the
   // host converts to lamports and calls core publishSkill. Returns the new mint on success.
   publishSkill?(input: {
@@ -292,34 +295,40 @@ export function createChatSession(
     // throw, not a hang). Local is instant and can't hang, so `page` is always sent.
     transport.send({ type: "loading" });
     let localCount = 0;
+    let localNewestTs = 0;
     try {
       const page = await rt.loadSessionLocal(id);
       for (const msg of page.messages) transport.send({ type: "message", msg });
       transport.send({ type: "page", hasMore: page.hasMore, cursor: page.cursor });
       localCount = page.messages.length;
+      if (localCount) localNewestTs = page.messages[localCount - 1].ts ?? 0;
     } catch (err) {
       console.error(`[session] loadSessionLocal failed for ${String(id).slice(0, 8)}:`, err);
       transport.send({ type: "page", hasMore: false, cursor: 0 }); // release the spinner
     }
-    // If this device held NOTHING local for the session (created/continued on another
-    // device), reconcile from the cloud OFF the paint path: a best-effort fetch that, if it
-    // lands, repaints with the cloud history. If the cloud has nothing — or never responds —
-    // the UI has already moved on, so there is no hang. Guard on pendingId so a late cloud
-    // result can't clobber a tab the user switched away from in the meantime.
-    if (localCount === 0) {
-      void (async () => {
-        try {
-          const page = await rt.loadSession(id); // mirror: local-miss → cloud (may be slow)
-          if (slot().pendingId !== id) return;   // user switched tabs while we waited
-          if (!page.messages.length) return;     // cloud had nothing either — leave as-is
-          transport.send({ type: "clear" });
-          for (const msg of page.messages) transport.send({ type: "message", msg });
-          transport.send({ type: "page", hasMore: page.hasMore, cursor: page.cursor });
-        } catch (err) {
-          console.error(`[session] cloud reconcile failed for ${String(id).slice(0, 8)}:`, err);
-        }
-      })();
-    }
+    // Reconcile from the mirror (local-then-cloud) OFF the paint path. The instant local paint
+    // above can be STALE: the just-ended turn may not have flushed to disk yet (so an engine
+    // switch, which repaints, would show a blank/partial chat until a manual reload), or the
+    // session may carry newer turns from another device. Re-read and ADOPT the result only
+    // when it is FRESHER than what we painted — a newer last-turn ts, or local was empty — so
+    // a fresher local view is never clobbered by a staler mirror copy. Guard on pendingId so a
+    // late result can't overwrite a tab the user switched away from. (The old guard reconciled
+    // only when local was EMPTY, so a stale-but-nonempty local page stuck until a reload — the
+    // "model switch wipes the chat" bug. Now it self-heals with no refresh.)
+    void (async () => {
+      try {
+        const page = await rt.loadSession(id); // mirror: newest page across local+cloud
+        if (slot().pendingId !== id) return;   // user switched tabs while we waited
+        if (!page.messages.length) return;     // nothing to adopt — leave the local paint as-is
+        const newestTs = page.messages[page.messages.length - 1].ts ?? 0;
+        if (localCount > 0 && newestTs <= localNewestTs) return; // local already as fresh
+        transport.send({ type: "clear" });
+        for (const msg of page.messages) transport.send({ type: "message", msg });
+        transport.send({ type: "page", hasMore: page.hasMore, cursor: page.cursor });
+      } catch (err) {
+        console.error(`[session] cloud reconcile failed for ${String(id).slice(0, 8)}:`, err);
+      }
+    })();
   }
 
   // Open a session into the CURRENT tab's slot — cross-CLI: opening a session
@@ -714,6 +723,12 @@ export function createChatSession(
       case "getBalance":
         sendMarket({ type: "balance", lamports: env.solBalance ? await env.solBalance() : null });
         break;
+      case "airdrop": {
+        if (!env.airdrop) break; // another handler owns this on some surfaces (e.g. localhost)
+        const res = await env.airdrop();
+        sendMarket({ type: "airdropResult", ...res });
+        break;
+      }
       // ── RPC config (issue #23): set/clear the Helius key, report status ──
       case "setHeliusKey":
         await env.setHeliusKey?.(); // host opens a native secret input + saves

--- a/packages/core/src/skill-market/index.spec.ts
+++ b/packages/core/src/skill-market/index.spec.ts
@@ -28,6 +28,7 @@ vi.mock("../core/seed.js", () => ({
   getSkillsCollectionMint: vi.fn().mockReturnValue("skillsCollection111"),
   getWorkflowsCollectionMint: vi.fn().mockReturnValue("workflowsCollection111"),
   getIndexerUrl: vi.fn().mockReturnValue("https://nft-index.example"),
+  getNetwork: vi.fn().mockReturnValue("devnet"),
 }));
 
 describe("skill-market", () => {
@@ -147,11 +148,21 @@ describe("skill-market", () => {
   });
 
   it("should handle buy_skill errors", async () => {
+    // A broke-wallet error is translated to friendly, actionable copy (friendlyBuyError):
+    // the raw "insufficient funds" / "no record of a prior credit" chain error is not shown.
     vi.mocked(buySkill).mockRejectedValue(new Error("Insufficient funds"));
     vi.mocked(readSkillMintMetadata).mockResolvedValue(null as any);
     const result = await handleToolCall(mockConn, signer, "defaultCreator", "buy_skill", { skillId: "skill1" });
     expect(result.isError).toBe(true);
-    expect(result.content[0].text).toContain("Insufficient funds");
+    expect(result.content[0].text).toContain("Not enough SOL");
+  });
+
+  it("should pass through a non-funds buy error verbatim", async () => {
+    vi.mocked(buySkill).mockRejectedValue(new Error("mint account not found"));
+    vi.mocked(readSkillMintMetadata).mockResolvedValue(null as any);
+    const result = await handleToolCall(mockConn, signer, "defaultCreator", "buy_skill", { skillId: "skill1" });
+    expect(result.isError).toBe(true);
+    expect(result.content[0].text).toContain("mint account not found");
   });
 
   it("should handle post_skill_comment tool call", async () => {

--- a/packages/core/src/skill-market/index.ts
+++ b/packages/core/src/skill-market/index.ts
@@ -36,7 +36,7 @@ import { loadHeliusKey } from "../core/rpc.js";
 import { signerAddress } from "../core/chain.js";
 import { scanSkillText } from "./scan.js";
 import { VERIFY_RUBRIC } from "./rubric.js";
-import { solToLamports } from "./ingest/env.js";
+import { solToLamports, friendlyBuyError, isInsufficientFundsError } from "./ingest/env.js";
 import { isHttpsGithubUrl } from "../links/github.js";
 
 /**
@@ -323,8 +323,10 @@ export async function handleToolCall(
         : " (purchase landed; its SKILL.md will install once the mint metadata is readable)";
       return { content: [{ type: "text", text: `Purchased skill ${skillId}${where}.\nTransaction Signature: ${txSig}` }] };
     } catch (err: any) {
-      emit({ type: "buyResult", skillId, ok: false, error: err.message });
-      return { isError: true, content: [{ type: "text", text: `Failed to buy skill: ${err.message}` }] };
+      const friendly = friendlyBuyError(err);
+      const code = isInsufficientFundsError(err) ? ("insufficient_funds" as const) : undefined;
+      emit({ type: "buyResult", skillId, ok: false, error: friendly, code });
+      return { isError: true, content: [{ type: "text", text: `Failed to buy skill: ${friendly}` }] };
     }
   }
 
@@ -365,8 +367,14 @@ export async function handleToolCall(
     if (!agentWallet || !text) throw new Error("Missing required argument: agentWallet and text");
     try {
       const noteId = await postAgentNote(conn, signer, { agentWallet, text, gitLink });
+      // Mirror the UI post path: fire agentNoteResult so an OPEN webview toasts the success
+      // (a chat-tool post otherwise lands on-chain with zero UI feedback — issue: "no error,
+      // nothing appears"). The UI-direct path also re-pushes the profile (session.ts); this
+      // tool path can only signal, so the toast is the confirmation the user gets.
+      emit({ type: "agentNoteResult", agentWallet, ok: true });
       return { content: [{ type: "text", text: `Comment posted (id: ${noteId})` }] };
     } catch (err: any) {
+      emit({ type: "agentNoteResult", agentWallet, ok: false, error: err.message });
       return { isError: true, content: [{ type: "text", text: `Failed to post comment: ${err.message}` }] };
     }
   }
@@ -390,8 +398,13 @@ export async function handleToolCall(
     try {
       const noteId = await postAgentNote(conn, signer, { agentWallet: self, text, gitLink });
       recordBlogPost(self);
+      // Signal the OPEN webview so a chat-tool blog post gets a success toast instead of
+      // silently landing on-chain with no visible trace (the reported "no error, nothing
+      // appears anywhere"). agentWallet == self here (a blog is a self-note).
+      emit({ type: "agentNoteResult", agentWallet: self, ok: true });
       return { content: [{ type: "text", text: `Blog post published (id: ${noteId})` }] };
     } catch (err: any) {
+      emit({ type: "agentNoteResult", agentWallet: self, ok: false, error: err.message });
       return { isError: true, content: [{ type: "text", text: `Failed to post blog entry: ${err.message}` }] };
     }
   }

--- a/packages/core/src/skill-market/ingest/env.ts
+++ b/packages/core/src/skill-market/ingest/env.ts
@@ -8,7 +8,7 @@
 // dirs (SkillSync) so it's discovered next session — search/buy were built yesterday,
 // this is the wiring that makes a purchase actually equip the skill.
 
-import { Connection } from "@solana/web3.js";
+import { Connection, PublicKey } from "@solana/web3.js";
 import { readdir, readFile } from "node:fs/promises";
 import { join } from "node:path";
 import type { Wallet } from "../../runtime/contract.js";
@@ -26,7 +26,7 @@ import { init as initChain } from "../../core/chain.js";
 import type { AgentProfile, Reputation, SkillCard, SkillDetail, VerifiedRepo } from "../../chat/marketMessages.js";
 import type { Skill } from "../../core/types.js";
 import { readNotes, postNote as corePostNote, readAgentNotes, postAgentNote as corePostAgentNote } from "../../notes/notes.js";
-import { getSkillsCollectionMint, getWorkflowsCollectionMint, getIndexerUrl } from "../../core/seed.js";
+import { getSkillsCollectionMint, getWorkflowsCollectionMint, getIndexerUrl, getNetwork, type Network } from "../../core/seed.js";
 import { getLeaderboard, getReputation } from "../../reputation/reputation.js";
 import { SkillSync } from "./index.js";
 
@@ -126,6 +126,34 @@ export function solToLamports(sol: string): bigint | null {
   if (frac.length > 9) return null; // more precision than a lamport can hold
   return BigInt(whole) * LAMPORTS_PER_SOL + BigInt(frac.padEnd(9, "0") || "0");
 }
+
+// A wallet with no SOL on the active cluster fails fee payment before any program runs,
+// surfacing as "Attempt to debit an account but found no record of a prior credit. Logs: []"
+// (or a bare "insufficient lamports"). To a person these all mean one thing: not enough SOL.
+const INSUFFICIENT_FUNDS_RE = /no record of a prior credit|attempt to debit|insufficient lamports|insufficient funds/i;
+
+/** True when a buy error is really "the wallet is out of SOL" (so the UI can offer to fund). */
+export function isInsufficientFundsError(err: unknown): boolean {
+  return INSUFFICIENT_FUNDS_RE.test(err instanceof Error ? err.message : String(err));
+}
+
+// Turn an opaque buy/simulation error into one line a buyer can act on. Anything we don't
+// recognise is passed through verbatim so real errors stay debuggable. Shared by the UI buy
+// (env.buySkill) and the agent buy (buy_skill tool) so both explain a broke wallet the same
+// way. No emoji / em-dash (UI copy rules).
+export function friendlyBuyError(err: unknown, network: Network = getNetwork()): string {
+  const raw = err instanceof Error ? err.message : String(err);
+  if (INSUFFICIENT_FUNDS_RE.test(raw)) {
+    return network === "devnet"
+      ? "Not enough SOL on devnet to cover this purchase and the network fee. Fund this wallet with devnet SOL, then try again."
+      : "Not enough SOL to cover this purchase and the network fee. Add funds to this wallet, then try again.";
+  }
+  return raw;
+}
+
+// One devnet faucet grant. 1 SOL is comfortably above any skill price + fees and within the
+// per-request devnet cap; the public faucet is rate-limited, so a request can still fail.
+const AIRDROP_LAMPORTS = 1_000_000_000;
 
 function publishFrontmatter(text: string): { type?: string; requiredSkills?: string[] } {
   const lines = text.split("\n");
@@ -233,9 +261,13 @@ export async function marketplaceEnv(wallet: Wallet) {
         // buy on-chain + equip (install SKILL.md) in one shared call — the SAME path the
         // agent's buy_skill MCP tool uses, so a UI buy and an agent buy equip identically.
         const { slug } = await skills.buyAndEquip(wallet, skillId, creatorWallet || wallet.address);
-        return { ok: true, slug: slug ?? undefined };
+        return { ok: true as const, slug: slug ?? undefined };
       } catch (e) {
-        return { ok: false, error: e instanceof Error ? e.message : String(e) };
+        return {
+          ok: false as const,
+          error: friendlyBuyError(e),
+          code: isInsufficientFundsError(e) ? ("insufficient_funds" as const) : undefined,
+        };
       }
     },
 
@@ -337,6 +369,24 @@ export async function marketplaceEnv(wallet: Wallet) {
         return await getSolBalance(conn, wallet.address);
       } catch {
         return null;
+      }
+    },
+
+    // Manual "Get devnet SOL": request one faucet grant to the connected wallet, wait for
+    // it, and report the new balance so the UI can refresh and let the buyer retry. Devnet
+    // only, since mainnet has no faucet. The public devnet faucet is rate-limited, so a
+    // failure here is expected sometimes; we surface the reason rather than swallowing it.
+    async airdrop(): Promise<{ ok: boolean; lamports?: number; error?: string }> {
+      if (getNetwork() !== "devnet") {
+        return { ok: false, error: "Airdrop is available on devnet only. Add SOL to this wallet to continue." };
+      }
+      try {
+        const sig = await conn.requestAirdrop(new PublicKey(wallet.address), AIRDROP_LAMPORTS);
+        await conn.confirmTransaction(sig, "confirmed");
+        const lamports = await getSolBalance(conn, wallet.address).catch(() => undefined);
+        return { ok: true, lamports };
+      } catch (e) {
+        return { ok: false, error: e instanceof Error ? e.message : String(e) };
       }
     },
 

--- a/surfaces/android/app/src/main/java/com/iqlabs/agentnet/MainActivity.kt
+++ b/surfaces/android/app/src/main/java/com/iqlabs/agentnet/MainActivity.kt
@@ -117,13 +117,18 @@ class MainActivity : AppCompatActivity() {
     // ActivityResultSender registers an activity-result callback in its constructor, which
     // must happen before the activity reaches STARTED — so build it as a field, not lazily.
     private val activityResultSender = ActivityResultSender(this)
+    // MUST match the app's on-chain network (core seed.ts `NETWORK`, currently devnet). If
+    // the wallet signs on a different cluster than the one the app builds and submits the tx
+    // to, the buyer account has no lamports there and every buy fails at fee payment with
+    // "Attempt to debit an account but found no record of a prior credit. Logs: []". Keep
+    // this in lockstep with seed.ts when flipping devnet/mainnet.
     private val walletAdapter = MobileWalletAdapter(
         connectionIdentity = ConnectionIdentity(
             identityUri = Uri.parse(IDENTITY_URI),
             iconUri = Uri.parse(IDENTITY_ICON),
             identityName = IDENTITY_NAME,
         ),
-    ).apply { blockchain = Solana.Mainnet }
+    ).apply { blockchain = Solana.Devnet }
 
     @SuppressLint("SetJavaScriptEnabled")
     override fun onCreate(savedInstanceState: Bundle?) {

--- a/surfaces/localhost/src/index.ts
+++ b/surfaces/localhost/src/index.ts
@@ -482,6 +482,9 @@ function attachMarketHandlers(c: Client) {
       case "getBalance":
         c.send({ type: "balance", lamports: null });
         return;
+      case "airdrop":
+        c.send({ type: "airdropResult", ok: false, error: message });
+        return;
       case "ownedSkills":
         c.send({ type: "ownedSkills", names: [] });
         return;
@@ -600,6 +603,17 @@ function attachMarketHandlers(c: Client) {
           const lamports = await mkt.solBalance();
           c.send({ type: "balance", lamports });
         } catch { c.send({ type: "balance", lamports: null }); }
+        return;
+      }
+      case "airdrop": {
+        // Manual "Get devnet SOL" from the fund prompt (mobile/web wallet has no keypair here,
+        // but a faucet grant needs no signature). mkt.airdrop already reports its own failures.
+        try {
+          const r = await mkt.airdrop();
+          c.send({ type: "airdropResult", ...r });
+        } catch (e) {
+          c.send({ type: "airdropResult", ok: false, error: (e as Error).message });
+        }
         return;
       }
       case "publishSkill": {

--- a/surfaces/webview/src/App.tsx
+++ b/surfaces/webview/src/App.tsx
@@ -9,6 +9,7 @@ import { ChatScreen } from "./chat/ChatScreen";
 import { MarketScreen } from "./market/MarketScreen";
 import { BuyCelebration } from "./market/BuyCelebration";
 import { PublishCelebration } from "./market/PublishCelebration";
+import { FundModal } from "./market/FundModal";
 import { Sessions } from "./chat/Sessions";
 import { TabBar } from "./shell/TabBar";
 import { Toast } from "./Toast";
@@ -97,7 +98,7 @@ export function App() {
   return (
     <>
       <div className="app-viewport">
-        {state.phase === "connecting" && <Splash />}
+        {(state.phase === "connecting" || state.phase === "restoring") && <Splash />}
         {state.phase === "onboarding" && <ConnectWallet />}
         {state.phase === "storageSelect" && <ConnectStorage />}
         {state.phase === "engineSelect" && <PickEngine />}
@@ -107,6 +108,7 @@ export function App() {
       </div>
       <Toast />
       {state.buyCelebrate && <BuyCelebration />}
+      {state.fundOpen && <FundModal />}
       {publishCelebrate && <PublishCelebration kind={state.publishKind ?? "skill"} onDone={() => setPublishCelebrate(false)} />}
     </>
   );

--- a/surfaces/webview/src/chat/Sessions.tsx
+++ b/surfaces/webview/src/chat/Sessions.tsx
@@ -57,6 +57,29 @@ function MenuRow({ icon, label, subtitle, onClick, accent = false }: {
   );
 }
 
+// One row in the Storage radio picker: a filled dot marks the active backend, tap to switch.
+// Compact + token-styled to sit naturally in the settings drawer (no emoji / em-dash).
+function StorageOption({ active, title, subtitle, onClick }: { active: boolean; title: string; subtitle: string; onClick: () => void }) {
+  return (
+    <button
+      onClick={onClick}
+      className="flex w-full items-center gap-3 rounded-lg border px-3 py-3 text-left transition active:scale-[0.98]"
+      style={{
+        borderColor: active ? "var(--an-green-line)" : "#18181b",
+        background: active ? "var(--an-green-dim)" : "rgba(24,24,27,0.2)",
+      }}
+    >
+      <span className="flex h-4 w-4 shrink-0 items-center justify-center rounded-full border" style={{ borderColor: active ? "var(--an-green)" : "#3f3f46" }}>
+        {active && <span className="h-2 w-2 rounded-full" style={{ background: "var(--an-green)" }} />}
+      </span>
+      <span className="min-w-0 flex-1">
+        <span className="block text-xs font-semibold" style={{ color: "var(--an-fg)" }}>{title}</span>
+        <span className="block text-[10px] mt-0.5" style={{ color: "var(--an-fg-mute)" }}>{subtitle}</span>
+      </span>
+    </button>
+  );
+}
+
 export function Sessions({ onClose, embedded = false, onOpenAgent }: { onClose: () => void; embedded?: boolean; onOpenAgent?: () => void }) {
   const { state, send, getClientId, notify } = useStore();
   const { storage, cloudSync, googleLoginUrl, googleLoginError } = state;
@@ -381,41 +404,54 @@ export function Sessions({ onClose, embedded = false, onOpenAgent }: { onClose: 
             <div>
               <div className="mb-4 flex items-center justify-between border-b border-zinc-900 pb-2">
                 <span className="text-xs font-semibold tracking-wide text-zinc-500 uppercase">
-                  Connect Cloud
+                  Storage
                 </span>
                 <button
-                  onClick={() => setSettingsMode("list")}
+                  onClick={() => setSettingsMode("configure")}
                   className="text-xs text-zinc-400 hover:text-zinc-200"
                 >
                   Back
                 </button>
               </div>
               <div className="flex flex-col gap-2.5">
-                <button
+                {/* Radio picker: the filled dot = the active backend. Local = disconnect any
+                    cloud; gdrive/custom open their existing connect flow. */}
+                <StorageOption
+                  active={!cloudConnected}
+                  title="This device only"
+                  subtitle="Sessions stay local. No cloud mirror."
+                  onClick={() => {
+                    if (cloudConnected) send({ type: "disconnectCloud" });
+                    setSettingsMode("configure");
+                  }}
+                />
+                <StorageOption
+                  active={info?.kind === "gdrive" && !!info?.connected}
+                  title="Google Drive"
+                  subtitle={
+                    info?.kind === "gdrive" && info?.connected
+                      ? `Connected${info.account ? ` · ${info.account}` : ""}`
+                      : "Mirror sessions to your own Google account"
+                  }
                   onClick={() => setSettingsMode("gdrive")}
-                  className="w-full text-left rounded-lg border border-zinc-900 bg-zinc-900/20 px-3 py-3 text-xs text-zinc-300 hover:bg-zinc-900/40 active:scale-[0.98] transition"
-                >
-                  <div className="font-semibold text-zinc-200">Google Drive</div>
-                  <div className="text-[10px] text-zinc-500 mt-0.5">
-                    Mirror sessions to your own Google account
-                  </div>
-                </button>
-                <button
+                />
+                <StorageOption
+                  active={info?.kind === "custom" && !!info?.connected}
+                  title="Custom Storage"
+                  subtitle={
+                    info?.kind === "custom" && info?.connected
+                      ? `Connected${info.location ? ` · ${info.location}` : ""}`
+                      : "Mirror to an S3 / WebDAV / HTTP endpoint"
+                  }
                   onClick={() => setSettingsMode("custom")}
-                  className="w-full text-left rounded-lg border border-zinc-900 bg-zinc-900/20 px-3 py-3 text-xs text-zinc-300 hover:bg-zinc-900/40 active:scale-[0.98] transition"
-                >
-                  <div className="font-semibold text-zinc-200">Custom Storage</div>
-                  <div className="text-[10px] text-zinc-500 mt-0.5">
-                    Mirror sessions to a custom S3/WebDAV/HTTP endpoint
-                  </div>
-                </button>
+                />
               </div>
             </div>
             <button
               onClick={() => setSettingsMode("configure")}
               className="w-full rounded-lg bg-zinc-800 hover:bg-zinc-700 py-2.5 text-xs text-zinc-200"
             >
-              Cancel
+              Done
             </button>
           </div>
         ) : settingsMode === "custom" ? (

--- a/surfaces/webview/src/market/FundModal.tsx
+++ b/surfaces/webview/src/market/FundModal.tsx
@@ -1,0 +1,73 @@
+import { createPortal } from "react-dom";
+import { useStore } from "../state/store";
+
+// Shown when a buy fails because the wallet is out of SOL (buyResult code
+// "insufficient_funds"). On devnet it offers a one-tap faucet grant (Get devnet SOL) and
+// refreshes the balance so the buyer can retry; on mainnet there is no faucet, so it just
+// explains how to add funds. Copy rules: no emoji, no em-dash.
+export function FundModal() {
+  const { state, closeFund, requestAirdrop } = useStore();
+  const network = state.rpcStatus?.network ?? "devnet";
+  const isDevnet = network === "devnet";
+  const sol = state.marketBalance != null ? (state.marketBalance / 1e9).toFixed(3) : null;
+
+  return createPortal(
+    <div className="fixed inset-0 z-[60] flex items-end justify-center sm:items-center">
+      <div className="absolute inset-0" style={{ background: "rgba(0,0,0,0.6)" }} onClick={closeFund} aria-hidden="true" />
+      <div
+        className="relative flex w-full flex-col overflow-hidden rounded-t-2xl border sm:max-w-md sm:rounded-2xl"
+        style={{ background: "var(--an-bg-1)", borderColor: "var(--an-line)" }}
+      >
+        <div className="flex shrink-0 items-center justify-between border-b px-4 py-3.5" style={{ borderColor: "var(--an-line)" }}>
+          <h2 className="an-term-title text-[14px]" style={{ letterSpacing: "1px" }}>Add funds</h2>
+          <button onClick={closeFund} aria-label="Close" className="-mr-1 p-1.5 active:opacity-70" style={{ color: "var(--an-fg-mute)" }}>
+            <svg className="h-7 w-7" viewBox="0 0 24 24" fill="none" stroke="currentColor" strokeWidth="2" strokeLinecap="round" aria-hidden="true">
+              <path d="M18 6 6 18M6 6l12 12" />
+            </svg>
+          </button>
+        </div>
+
+        <div className="p-4" style={{ paddingBottom: "max(1rem, env(safe-area-inset-bottom))" }}>
+          <p className="text-sm" style={{ color: "var(--an-fg)" }}>
+            {isDevnet
+              ? "This wallet does not have enough SOL on devnet to cover the purchase and the network fee."
+              : "This wallet does not have enough SOL to cover the purchase and the network fee."}
+          </p>
+          <p className="mt-2 text-[12px]" style={{ color: "var(--an-fg-dim)" }}>
+            Balance: {sol != null ? `${sol} SOL` : "unknown"} on {network}.
+          </p>
+
+          {isDevnet ? (
+            <button
+              onClick={requestAirdrop}
+              disabled={state.funding}
+              className="mt-4 w-full rounded-xl py-3 text-sm font-semibold active:opacity-80 disabled:opacity-60"
+              style={{ background: "var(--an-green)", color: "var(--an-on-green)" }}
+            >
+              {state.funding ? "Requesting devnet SOL..." : "Get devnet SOL"}
+            </button>
+          ) : (
+            <p className="mt-4 text-[12px]" style={{ color: "var(--an-fg-dim)" }}>
+              Send SOL to this wallet from an exchange or another wallet, then try the purchase again.
+            </p>
+          )}
+
+          <button
+            onClick={closeFund}
+            className="mt-2 w-full rounded-xl py-3 text-sm active:opacity-80"
+            style={{ background: "var(--an-bg-2)", color: "var(--an-fg-dim)" }}
+          >
+            Close
+          </button>
+
+          {isDevnet && (
+            <p className="mt-3 text-[11px]" style={{ color: "var(--an-fg-mute)" }}>
+              The public devnet faucet is rate-limited. If this fails, wait a moment and try again, or add a Helius key in Market RPC settings.
+            </p>
+          )}
+        </div>
+      </div>
+    </div>,
+    document.body,
+  );
+}

--- a/surfaces/webview/src/onboarding/ConnectWallet.tsx
+++ b/surfaces/webview/src/onboarding/ConnectWallet.tsx
@@ -3,11 +3,11 @@
 // sign the FIXED SESSION_KEY_MESSAGE once (that signature derives the session key), and
 // send {connectWallet, address, signature}. The store flips to chat on `walletConnected`.
 
-import { useEffect, useMemo, useState } from "react";
+import { useMemo, useState } from "react";
 // Subpath import (not the barrel) — the core index drags in node-only modules that can't
 // bundle for the browser. webWallet.ts is browser-safe (only @solana/web3.js + types).
 import { SESSION_KEY_MESSAGE } from "@iqlabs-official/agent-sdk/account/webWallet";
-import { isAndroidWallet, connectAndroidWallet, restoreAndroidWallet } from "./androidWallet";
+import { isAndroidWallet, connectAndroidWallet } from "./androidWallet";
 import { OnboardingShell, OnboardingButton } from "./OnboardingShell";
 import { useStore } from "../state/store";
 
@@ -63,25 +63,10 @@ export function ConnectWallet() {
   // Inside the Android shell there are no injected providers — the native MWA bridge is
   // the only path. Detect it once and, if present, show a single native connect button.
   const android = useMemo(isAndroidWallet, []);
-  // On the Android shell, try a SILENT reconnect from the Keystore-saved signature first, so
-  // a fresh process (rotation / background kill / return from the wallet app) lands straight
-  // back in chat with no wallet round-trip. Until we know, show "Reconnecting…" instead of a
-  // bare Connect button. Falls through to the manual button when nothing is saved.
-  const [restoring, setRestoring] = useState(android);
-  useEffect(() => {
-    if (!android) return;
-    let cancelled = false;
-    void (async () => {
-      const creds = await restoreAndroidWallet().catch(() => null);
-      if (cancelled) return;
-      if (creds) {
-        send({ type: "connectWallet", address: creds.address, signature: creds.signature });
-        return; // keep the "Reconnecting…" veil until the store flips phase to chat
-      }
-      setRestoring(false);
-    })();
-    return () => { cancelled = true; };
-  }, [android, send]);
+  // The SILENT Keystore reconnect now runs earlier, off the Splash, while the store is in its
+  // "restoring" phase (see store.tsx) — so by the time this signup screen renders, a returning
+  // user has already been reconnected or the restore came back empty. This screen is purely the
+  // manual connect path.
 
   async function connectWith(name: string, provider: SolanaProvider) {
     setBusy(name);
@@ -141,8 +126,8 @@ export function ConnectWallet() {
       {android ? (
         // Android shell: one button drives the native wallet picker (Phantom/Solflare/…).
         <>
-          <OnboardingButton disabled={busy !== null || restoring} onClick={connectAndroid}>
-            {restoring ? "Reconnecting…" : busy ? "Connecting…" : hint ? phantomStore().label : "Connect Wallet"}
+          <OnboardingButton disabled={busy !== null} onClick={connectAndroid}>
+            {busy ? "Connecting…" : hint ? phantomStore().label : "Connect Wallet"}
           </OnboardingButton>
           {hint ? (
             <p className="text-center text-sm text-zinc-500">{hint}</p>

--- a/surfaces/webview/src/state/store.tsx
+++ b/surfaces/webview/src/state/store.tsx
@@ -14,7 +14,7 @@ import {
 } from "react";
 import { Transport } from "../transport/client";
 import { openExternalUrl } from "../platform/openExternalUrl";
-import { isAndroidWallet, signAndroidTransaction } from "../onboarding/androidWallet";
+import { isAndroidWallet, signAndroidTransaction, restoreAndroidWallet } from "../onboarding/androidWallet";
 import { providerSignBase64 } from "@iqlabs-official/agent-sdk/account/webWallet";
 import type {
   AgentProfile,
@@ -38,6 +38,7 @@ export type EngineStatus = "ok" | "no-login" | "missing";
 export interface State {
   phase:
     | "connecting"
+    | "restoring" // Android cold boot: attempting a silent Keystore reconnect (shows Splash, not the signup screen)
     | "onboarding"
     | "storageSelect"
     | "engineSelect"
@@ -58,6 +59,10 @@ export interface State {
   marketOwnedCards: SkillCard[]; // wallet's on-chain owned skill cards (My Skills grid)
   marketDisposed: Record<string, string>;
   marketBalance: number | null;
+  // Fund prompt (Get devnet SOL): opened when a buy fails for insufficient funds; `funding`
+  // is the in-flight airdrop so the button can spin. See FundModal.
+  fundOpen: boolean;
+  funding: boolean;
   rpcStatus: RpcStatus | null;
   publishResult: { ok: boolean; mint?: string; error?: string } | null;
   // Live publish progress while a multi-signature publish runs (web wallet); null when idle.
@@ -161,6 +166,8 @@ const initialState: State = {
   marketOwnedCards: [],
   marketDisposed: {},
   marketBalance: null,
+  fundOpen: false,
+  funding: false,
   rpcStatus: null,
   publishResult: null,
   publishProgress: null,
@@ -253,6 +260,9 @@ type LocalAction =
   | { type: "__setToast"; text: string }
   | { type: "__openingSession"; sessionId: string }
   | { type: "__newChat" }
+  | { type: "__closeFund" }
+  | { type: "__funding" }
+  | { type: "__restoreFailed" }
   | { type: "__clearCelebrate" };
 type Action = ServerMessage | LocalAction;
 
@@ -281,7 +291,11 @@ function reducer(state: State, ev: Action): State {
       // preserve the current wallet-derived phase. If the server explicitly says it has
       // no wallet, the app/server process restarted and the local wallet state is stale:
       // clear it so sends don't get stuck in a chat UI backed by an onboarding handler.
-      if (ev.hasWallet === false) return { ...state, walletAddress: null, phase: "onboarding" };
+      // No wallet on the server (cold boot / restart). On the Android shell a silent Keystore
+      // reconnect may still succeed, so land on a neutral "restoring" splash and let the boot
+      // effect try it — only fall to the signup screen if it returns nothing (or on web, where
+      // there is no silent restore). Prevents the signup UI from flashing as a loading screen.
+      if (ev.hasWallet === false) return { ...state, walletAddress: null, phase: isAndroidWallet() ? "restoring" : "onboarding" };
       if (state.walletAddress) return state;
       return { ...state, phase: "onboarding" };
     case "walletConnected":
@@ -480,6 +494,9 @@ function reducer(state: State, ev: Action): State {
         marketOwned: ev.ok ? [...state.marketOwned, ev.slug ?? ev.skillId] : state.marketOwned,
         buyCelebrate: ev.ok ? true : state.buyCelebrate,
         buyCelebrateLabel: ev.ok ? (ev.slug ?? ev.skillId) : state.buyCelebrateLabel,
+        // Broke wallet -> open the fund prompt so the buyer can top up and retry, instead of
+        // only flashing a transient error toast that leaves them stuck.
+        fundOpen: !ev.ok && ev.code === "insufficient_funds" ? true : state.fundOpen,
       };
     case "disposeResult":
       return {
@@ -509,6 +526,10 @@ function reducer(state: State, ev: Action): State {
       };
     case "balance":
       return { ...state, marketBalance: ev.lamports };
+    case "airdropResult":
+      return ev.ok
+        ? { ...state, funding: false, fundOpen: false, marketBalance: ev.lamports ?? state.marketBalance, toast: "Funded. Try the purchase again." }
+        : { ...state, funding: false, toast: `Get SOL failed: ${ev.error ?? "unknown"}` };
     case "rpcStatus":
       return { ...state, rpcStatus: ev.status };
     case "skillActive": {
@@ -574,6 +595,13 @@ function reducer(state: State, ev: Action): State {
       };
     case "__clearFiringSkill":
       return { ...state, firingSkills: [] };
+    case "__closeFund":
+      return { ...state, fundOpen: false };
+    case "__funding":
+      return { ...state, funding: true };
+    case "__restoreFailed":
+      // Silent Android reconnect found nothing (or failed) — show the signup screen now.
+      return { ...state, phase: "onboarding" };
     case "__clearCelebrate":
       return { ...state, buyCelebrate: false, buyCelebrateLabel: null };
     default:
@@ -606,6 +634,9 @@ interface Store {
   clearAgentProfile: () => void;
   clearFiringSkill: () => void;
   clearCelebrate: () => void;
+  // Fund prompt (Get devnet SOL): close it, or request a faucet grant (spins until airdropResult).
+  closeFund: () => void;
+  requestAirdrop: () => void;
   // Current SSE client id — native (Android) notification actions POST to /rpc with it.
   getClientId: () => string | null;
   // Show a transient toast locally (e.g. the foreground-only turn-off notice, #53).
@@ -674,6 +705,22 @@ export function StoreProvider({ children }: { children: ReactNode }) {
       t.close();
     };
   }, []);
+
+  // Android cold boot: while phase is "restoring", try a SILENT Keystore reconnect off the
+  // splash. Success -> post connectWallet (the server rebuilds the runtime and flips us toward
+  // chat); nothing saved / failure -> fall to the signup screen. Prevents the signup UI from
+  // showing as the loading screen for an already-signed-in user. Runs once per entry.
+  useEffect(() => {
+    if (state.phase !== "restoring") return;
+    let cancelled = false;
+    void (async () => {
+      const creds = await restoreAndroidWallet().catch(() => null);
+      if (cancelled) return;
+      if (creds) void transportRef.current?.post({ type: "connectWallet", address: creds.address, signature: creds.signature });
+      else raw({ type: "__restoreFailed" });
+    })();
+    return () => { cancelled = true; };
+  }, [state.phase]);
 
   // Keep busyRef in sync so send() (stable closure) can read current busy state.
   useEffect(() => { busyRef.current = state.typing; }, [state.typing]);
@@ -790,6 +837,11 @@ export function StoreProvider({ children }: { children: ReactNode }) {
       clearAgentProfile: () => raw({ type: "__clearAgentProfile" }),
       clearFiringSkill: () => raw({ type: "__clearFiringSkill" }),
       clearCelebrate: () => raw({ type: "__clearCelebrate" }),
+      closeFund: () => raw({ type: "__closeFund" }),
+      requestAirdrop: () => {
+        raw({ type: "__funding" });
+        void transportRef.current?.post({ type: "airdrop" });
+      },
       getClientId: () => transportRef.current?.getClientId() ?? null,
       notify: (text) => raw({ type: "__setToast", text }),
       markCompacting: () => raw({ type: "__compactStart" }),

--- a/surfaces/webview/src/transport/protocol.ts
+++ b/surfaces/webview/src/transport/protocol.ts
@@ -131,6 +131,7 @@ export type ClientMessage =
   | { type: "reEquipSkill"; skillId: string }
   | { type: "ownedSkills" }
   | { type: "getBalance" }
+  | { type: "airdrop" }
   | { type: "getRpcStatus" }
   | { type: "submitHeliusKey"; key: string }
   | { type: "useDefaultRpc" }
@@ -207,11 +208,12 @@ export type ServerMessage =
   | { type: "searchResults"; results: import("@iqlabs-official/agent-sdk").SkillCard[] }
   | { type: "searchError"; message: string }
   | { type: "skillDetail"; detail: import("@iqlabs-official/agent-sdk").SkillDetail }
-  | { type: "buyResult"; skillId: string; ok: boolean; slug?: string; error?: string }
+  | { type: "buyResult"; skillId: string; ok: boolean; slug?: string; error?: string; code?: "insufficient_funds" }
   | { type: "disposeResult"; skillId: string; ok: boolean; slug?: string; error?: string }
   | { type: "reEquipResult"; skillId: string; ok: boolean; slug?: string; error?: string }
   | { type: "ownedSkills"; names: string[]; mints?: Record<string, string>; disposedMints?: Record<string, string>; cards?: import("@iqlabs-official/agent-sdk").SkillCard[] }
   | { type: "balance"; lamports: number | null }
+  | { type: "airdropResult"; ok: boolean; lamports?: number; error?: string }
   | { type: "skillActive"; name: string }
   | { type: "rpcStatus"; status: import("@iqlabs-official/agent-sdk").RpcStatus }
   | { type: "postNoteResult"; skillId: string; ok: boolean; error?: string }


### PR DESCRIPTION
## Summary

Fixes five user-reported issues across the skill marketplace and the mobile app, and adds the success/failure feedback that was missing for each.

- **Skill buy failed on devnet (Android).** The Mobile Wallet Adapter signed on `Solana.Mainnet` while the app targets devnet (core `seed.ts` `NETWORK`), so the buyer had no lamports on the simulated cluster and every buy died at fee payment with `Attempt to debit an account but found no record of a prior credit. Logs: []`. The MWA now follows the app network. On top of the fix, a broke wallet gets a clear message plus a devnet **Get devnet SOL** fund prompt, and a successful buy still fires the existing celebration.
- **Blog posts silently disappeared.** The `post_blog` / `post_agent_comment` tools wrote on-chain but emitted no UI event, so nothing showed and there was no error either. They now emit `agentNoteResult`, giving a success or friendly-failure toast on every surface.
- **Could not change storage after onboarding.** The settings drawer only offered Google Drive / Custom with no way back to local. Added a radio-style picker (this device / Google Drive / Custom) that marks the active backend and can disconnect.
- **Switching model wiped the chat (graphical).** `repaint` read the local tier only and reconciled from the cloud just when local was empty, so an engine switch before the latest turn had flushed blanked the chat until a manual refresh. It now reconciles in the background and adopts the result only when it is fresher (newer last-turn timestamp), never clobbering a fresher local view.
- **Signup screen shown as the loading screen.** On Android cold boot the app dropped straight to the signup screen while a silent Keystore reconnect ran. Added a neutral `restoring` splash that only falls to signup when the reconnect returns nothing.

## Flow

```mermaid
flowchart LR
    subgraph P["User-reported issues"]
        direction TB
        P1["Buy fails on devnet"]
        P2["Blog post vanishes"]
        P3["Cannot change storage"]
        P4["Model switch wipes chat"]
        P5["Signup shown as loading"]
    end
    subgraph F["Fixes"]
        direction TB
        F1["MWA to devnet + friendly error + fund prompt"]
        F2["Emit agentNoteResult (success / failure toast)"]
        F3["Radio storage picker + disconnect"]
        F4["repaint: freshness-guarded cloud reconcile"]
        F5["restoring splash before signup"]
    end
    subgraph S["Surfaces touched"]
        direction TB
        S1["Android + core + localhost + webview"]
        S2["core (all surfaces)"]
        S3["webview"]
        S4["core (all surfaces)"]
        S5["webview (Android)"]
    end
    P1 --> F1 --> S1
    P2 --> F2 --> S2
    P3 --> F3 --> S3
    P4 --> F4 --> S4
    P5 --> F5 --> S5
```

## Commits

1. `fix(android)` sign the Mobile Wallet Adapter on devnet to match the app network
2. `feat(market)` friendly insufficient-funds error and devnet fund plumbing (contract + localhost + transport)
3. `fix(market)` report blog and comment posts to the UI, translate buy errors
4. `fix(chat)` self-heal a stale session repaint from the cloud
5. `feat(webview)` storage switcher, restoring splash, and fund prompt

## Verification

- `packages/core` `tsc --noEmit`: clean
- `packages/core` test suite: 344 passed
- `surfaces/vscode` and `surfaces/webview` `tsc`: no new errors (only pre-existing unused-var / JSX noise, which is not the build gate)

## Applying

- Android: rebuild and reinstall the APK (native change plus the bundled webview/localhost assets).
- VSCode / CLI: a rebuild picks up the core changes (friendly buy errors, blog feedback, repaint self-heal).

## Notes

- Scoped to this session's files only. A parallel session's in-progress changes (`vscode` approval-notify, `core/chat/ui` webview/skillSigil) are intentionally left out, so VSCode airdrop wiring is not included here (Android/localhost do not need it).
