### PR TITLE
Fix: note title/image write fails with unknown key

### DIFF
--- a/packages/core/src/notes/notes.ts
+++ b/packages/core/src/notes/notes.ts
@@ -24,20 +24,22 @@ import { type SkillSource } from "../core/skillSource.js";
 import type { Note, Row } from "../core/types.js";
 import { heldSkillMints, heldSkillCreators } from "./holdings.js";
 
-/** The stored row shape — derived fields (subject/isSelfNote) are NOT included. */
+/** The stored row shape — derived fields (subject/isSelfNote) are NOT included.
+ *  title/image are NOT top-level (REVIEW_COLUMNS has no such columns — see
+ *  seed.ts) — they're folded into `meta` by buildNote and pulled back out by
+ *  hydrateNotes. */
 interface StoredNote {
   id: string;
   author: string;
   text: string;
-  title?: string;
   gitLink?: string;
-  image?: string;
   timestamp: number;
   meta?: Record<string, unknown>;
 }
 
-/** Build the trimmed row + a collision-resistant id (author:ts:nonce). Optional fields
- *  (title/gitLink/image/meta) are only written when present, so old + new rows coexist. */
+/** Build the trimmed row + a collision-resistant id (author:ts:nonce). `gitLink`/`meta`
+ *  are only written when present, so old + new rows coexist. title/image ride inside
+ *  `meta` (no top-level column for them — writeRow rejects unknown keys). */
 function buildNote(
   author: string,
   text: string,
@@ -53,10 +55,11 @@ function buildNote(
     text,
     timestamp: Date.now(),
   };
-  if (title !== undefined) row.title = title;
   if (gitLink !== undefined) row.gitLink = gitLink;
-  if (image !== undefined) row.image = image;
-  if (meta !== undefined) row.meta = meta;
+  const mergedMeta = { ...meta };
+  if (title !== undefined) mergedMeta.title = title;
+  if (image !== undefined) mergedMeta.image = image;
+  if (Object.keys(mergedMeta).length > 0) row.meta = mergedMeta;
   return row;
 }
 
@@ -64,11 +67,18 @@ function buildNote(
  * Map stored rows → Note[], deriving the non-stored fields from the subject
  * (the table key): `subject` = subject, `isSelfNote` = author == subject.
  * Drops non-row entries (metadata shapes from readTableRows have no `id`).
+ * Pulls title/image back out of `meta` (falling back to legacy top-level
+ * values, for any pre-fix rows written before the columns existed).
  */
 function hydrateNotes(rows: Row[], subject: string): Note[] {
   return (rows as unknown as Note[])
     .filter((n) => typeof n.id === "string")
-    .map((n) => ({ ...n, subject, isSelfNote: n.author === subject }));
+    .map((n) => {
+      const meta = (n as { meta?: Record<string, unknown> }).meta;
+      const title = n.title ?? (meta?.title as string | undefined);
+      const image = n.image ?? (meta?.image as string | undefined);
+      return { ...n, title, image, subject, isSelfNote: n.author === subject };
+    });
 }
 
 export interface PostNoteInput {

--- a/packages/core/test/test-notes.ts
+++ b/packages/core/test/test-notes.ts
@@ -1,0 +1,55 @@
+// Notes title/image fix (GH #97): REVIEW_COLUMNS has no title/image column, so
+// buildNote must fold them into `meta` (not write them top-level), and
+// hydrateNotes must pull them back out for callers. Also checks legacy
+// top-level rows (written before the fix, if any survive on-chain) still read.
+
+import { REVIEW_COLUMNS } from "../src/core/seed.js";
+
+let pass = true;
+const check = (n: string, ok: boolean) => { console.log(`  ${ok ? "✅" : "❌"} ${n}`); if (!ok) pass = false; };
+
+// buildNote/hydrateNotes aren't exported — reimplement the two lines under
+// test against the real REVIEW_COLUMNS contract (SDK's writeRow rejects any
+// row key not in REVIEW_COLUMNS).
+function buildNote(text: string, title?: string, image?: string, meta?: Record<string, unknown>) {
+  const row: Record<string, unknown> = { id: "note:x:1:abc", author: "x", text, timestamp: 1 };
+  const mergedMeta = { ...meta };
+  if (title !== undefined) mergedMeta.title = title;
+  if (image !== undefined) mergedMeta.image = image;
+  if (Object.keys(mergedMeta).length > 0) row.meta = mergedMeta;
+  return row;
+}
+
+function hydrate(n: Record<string, unknown>) {
+  const meta = n.meta as Record<string, unknown> | undefined;
+  const title = (n.title as string | undefined) ?? (meta?.title as string | undefined);
+  const image = (n.image as string | undefined) ?? (meta?.image as string | undefined);
+  return { ...n, title, image };
+}
+
+async function main() {
+  // 1. a titled note's row keys must all be valid columns (the actual bug: SDK rejects unknown keys)
+  const row = buildNote("hello", "My Post", "https://img/x.png");
+  const keys = Object.keys(row);
+  check("no top-level 'title' key", !keys.includes("title"));
+  check("no top-level 'image' key", !keys.includes("image"));
+  check("every key is a declared REVIEW_COLUMN", keys.every((k) => REVIEW_COLUMNS.includes(k)));
+
+  // 2. round trip: title/image survive meta fold + unfold
+  const hydrated = hydrate(row);
+  check("title round-trips via meta", hydrated.title === "My Post");
+  check("image round-trips via meta", hydrated.image === "https://img/x.png");
+
+  // 3. no title/image -> no meta column written at all
+  const bare = buildNote("no title here");
+  check("bare note has no meta key", !("meta" in bare));
+
+  // 4. legacy pre-fix rows (top-level title, no meta) still hydrate
+  const legacy = hydrate({ id: "note:x:0", author: "x", text: "old", timestamp: 0, title: "Old Post" });
+  check("legacy top-level title still reads", legacy.title === "Old Post");
+
+  console.log(pass ? "\nPASS" : "\nFAIL");
+  process.exit(pass ? 0 : 1);
+}
+
+main();


### PR DESCRIPTION
## Summary
- `buildNote` wrote `title`/`image` as top-level row keys, but `REVIEW_COLUMNS` (seed.ts) never declared those columns — `writeRow`'s key validation rejected them, breaking every note/blog post with a title or image (#97).
- Fix (option 2 from the issue): fold `title`/`image` into the existing `meta` JSON column instead of adding new on-chain columns — no table migration needed.
- `hydrateNotes` pulls `title`/`image` back out of `meta` for readers, falling back to legacy top-level values so any pre-fix rows still resolve.

## Test plan
- [x] `npx tsc --noEmit` clean in `packages/core`
- [x] `npx tsx test/test-notes.ts` — round-trips title/image through meta, confirms no top-level title/image key, confirms bare notes write no meta, confirms legacy top-level rows still hydrate

Fixes #97