### PR TITLE
CLI: fix cloud reconnect, cross-engine model leak, bundling crashes, oauth error visibility

### DIFF
--- a/packages/core/src/account/storage/oauth.ts
+++ b/packages/core/src/account/storage/oauth.ts
@@ -161,6 +161,11 @@ export interface GoogleLogin {
   submitCode(code: string): Promise<void>;
   cancel(): void;
   done: Promise<boolean>;
+  // Set once `done` resolves false. The loopback server's landing page says "connected"
+  // unconditionally (it can't know yet whether the code exchange will succeed) — this is
+  // the only reliable way for the UI to show WHY a login actually failed, instead of a
+  // generic "not completed" message that hides state-mismatch/missing-code/exchange errors.
+  readonly error: string | null;
 }
 
 export function startGoogleLogin(): Promise<GoogleLogin> {
@@ -170,14 +175,19 @@ export function startGoogleLogin(): Promise<GoogleLogin> {
   let settleDone: (ok: boolean) => void;
   const done = new Promise<boolean>((r) => (settleDone = r));
 
+  let lastError: string | null = null;
   // Settle `done` exactly once and clear the abandon-timeout. Callers still close the server
   // at their own site (they already did); this only owns the settle + timer.
   let settled = false;
   let timer: ReturnType<typeof setTimeout> | undefined;
-  const finishDone = (ok: boolean) => {
+  const finishDone = (ok: boolean, reason?: string) => {
     if (settled) return;
     settled = true;
     if (timer) clearTimeout(timer);
+    if (!ok) {
+      lastError = reason ?? "Google sign-in failed.";
+      console.error(`[oauth] google sign-in failed: ${lastError}`);
+    }
     settleDone(ok);
   };
 
@@ -191,14 +201,16 @@ export function startGoogleLogin(): Promise<GoogleLogin> {
     if (code && gotState === state) {
       exchangeCode(code, verifier, redirect)
         .then(() => finishDone(true))
-        .catch(() => finishDone(false));
+        .catch((e: unknown) => finishDone(false, e instanceof Error ? e.message : String(e)));
+    } else if (!code) {
+      finishDone(false, "no code in Google's redirect");
     } else {
-      finishDone(false);
+      finishDone(false, "state mismatch (possible CSRF or stale login)");
     }
   });
   // Abandoned login (tab closed, code never submitted): auto-clean after 10 min so the
   // loopback server + pkce session don't linger forever.
-  timer = setTimeout(() => { server.close(); finishDone(false); }, 10 * 60_000);
+  timer = setTimeout(() => { server.close(); finishDone(false, "timed out waiting for Google redirect"); }, 10 * 60_000);
   timer.unref?.();
 
   return new Promise<GoogleLogin>((resolve, reject) => {
@@ -239,15 +251,16 @@ export function startGoogleLogin(): Promise<GoogleLogin> {
               finishDone(true);
             } catch (e) {
               server.close();
-              finishDone(false);
+              finishDone(false, e instanceof Error ? e.message : String(e));
               throw e;
             }
           },
           cancel() {
             server.close();
-            finishDone(false);
+            finishDone(false, "canceled");
           },
           done,
+          get error() { return lastError; },
         });
       } catch (e) {
         server.close();
@@ -267,6 +280,13 @@ export function startGoogleLoginFixed(redirectUri: string): GoogleLogin {
 
   let settleDone: (ok: boolean) => void;
   const done = new Promise<boolean>((r) => (settleDone = r));
+
+  let lastError: string | null = null;
+  const fail = (reason: string) => {
+    lastError = reason;
+    console.error(`[oauth] google sign-in failed: ${reason}`);
+    settleDone(false);
+  };
 
   const url = `${AUTH_URL}?${new URLSearchParams({
     client_id: clientId(),
@@ -290,25 +310,40 @@ export function startGoogleLoginFixed(redirectUri: string): GoogleLogin {
       // exchanged. No regex fallback — if the URL won't parse or the state doesn't match,
       // refuse rather than salvage a code we can't tie to this request.
       if (code.startsWith("http://") || code.startsWith("https://") || code.includes("code=")) {
-        const urlParsed = new URL(code); // throws on malformed input → submission refused
+        let urlParsed: URL;
+        try {
+          urlParsed = new URL(code);
+        } catch (e) {
+          fail(e instanceof Error ? e.message : String(e));
+          throw e;
+        }
         const gotState = urlParsed.searchParams.get("state");
-        if (!gotState || gotState !== state) throw new Error("oauth: state mismatch");
+        if (!gotState || gotState !== state) {
+          const e = new Error("oauth: state mismatch");
+          fail(e.message);
+          throw e;
+        }
         const gotCode = urlParsed.searchParams.get("code");
-        if (!gotCode) throw new Error("oauth: no code in callback");
+        if (!gotCode) {
+          const e = new Error("oauth: no code in callback");
+          fail(e.message);
+          throw e;
+        }
         code = gotCode;
       }
       try {
         await exchangeCode(code, verifier, redirectUri);
         settleDone(true);
       } catch (e) {
-        settleDone(false);
+        fail(e instanceof Error ? e.message : String(e));
         throw e;
       }
     },
     cancel() {
-      settleDone(false);
+      fail("canceled");
     },
     done,
+    get error() { return lastError; },
   };
 }
 

--- a/surfaces/cli/README.md
+++ b/surfaces/cli/README.md
@@ -63,7 +63,7 @@ The input box is full-featured:
 /models               pick a model from a menu (or /model <name> to set directly)
 /engine claude|codex  switch engine — the current session CARRIES over (cross-CLI resume)
 /wallet               show your wallet address
-/storage              show where sessions are saved
+/storage              view/change where sessions are saved (connect or reconnect cloud)
 /iq                   a random IQ fact (+ Iggy spins)
 /dance                Iggy dances
 /quit  (/q)           leave

--- a/surfaces/cli/src/app.tsx
+++ b/surfaces/cli/src/app.tsx
@@ -2,6 +2,7 @@ import React, { useEffect, useState } from "react";
 import { Box, Text } from "ink";
 import type { AgentRuntime } from "@iqlabs-official/agent-sdk/runtime/contract";
 import { autoApprove, type StorageConfig, type CliReport } from "@iqlabs-official/agent-sdk";
+import type { CloudStatus } from "@iqlabs-official/agent-sdk/account/storage/mirror";
 import { InkApprovalChannel } from "./InkApprovalChannel.js";
 import { Banner } from "./components/Banner.js";
 import { BootChecklist, type BootStep } from "./components/BootChecklist.js";
@@ -49,14 +50,20 @@ export function App({ options }: { options: AppOptions }) {
   const [prefs, setPrefs] = useState<Prefs>({});
   // tool-approval seam: --yolo skips the UI (auto-allow); otherwise prompts route here.
   const approval = React.useRef<InkApprovalChannel | null>(options.yolo ? null : new InkApprovalChannel());
+  // reported by mirrorStorage after each cloud write attempt — drives the StatusLine
+  // sync chip so a dead/offline cloud is visible instead of silently drifting.
+  const [cloudStatus, setCloudStatus] = useState<CloudStatus | null>(null);
 
   const set = (i: number, patch: Partial<BootStep>) =>
     setSteps((s) => s.map((step, j) => (j === i ? { ...step, ...patch } : step)));
 
-  // connect wallet → runtime, then enter chat. Reused after onboarding too.
-  async function go(addr: string, w: Awaited<ReturnType<typeof loadWallet>>["wallet"]) {
+  // connect wallet → runtime, then enter chat. Reused after onboarding too. `freshCloud`
+  // is set when onboarding just connected a cloud backend for the FIRST time on this
+  // device — an explicit connect, so (same as a mid-session reconnect) it gets a one-shot
+  // backfill of anything already local (e.g. sessions from a prior local-only run).
+  async function go(addr: string, w: Awaited<ReturnType<typeof loadWallet>>["wallet"], freshCloud?: boolean) {
     set(3, { status: "pending", label: "connecting storage" });
-    const rt = await buildRuntime(w, approval.current ?? autoApprove());
+    const rt = await buildRuntime(w, approval.current ?? autoApprove(), setCloudStatus);
     setRuntime(rt);
     setWallet(w);
     set(3, { status: "ok", label: "storage ready" });
@@ -64,6 +71,19 @@ export function App({ options }: { options: AppOptions }) {
     // clean screen (Ink leaves prior static output in the terminal history otherwise).
     process.stdout.write("\x1b[2J\x1b[3J\x1b[H");
     setPhase("chat");
+    if (freshCloud) {
+      void rt.syncCloud().catch(() => { /* best-effort; a later write or reconnect re-syncs */ });
+    }
+  }
+
+  // Re-bind the runtime to whatever storage config.json now holds (called after Chat
+  // writes a new storage choice mid-session — connect, reconnect, or disconnect). Without
+  // this the already-built runtime keeps mirroring the OLD cloud/local choice forever,
+  // since it was bound once at boot and storage config changes don't self-apply.
+  async function rebuildRuntime(): Promise<AgentRuntime> {
+    const rt = await buildRuntime(wallet!, approval.current ?? autoApprove(), setCloudStatus);
+    setRuntime(rt);
+    return rt;
   }
 
   useEffect(() => {
@@ -98,7 +118,7 @@ export function App({ options }: { options: AppOptions }) {
           onboardFinish.current = async (engine: "claude" | "codex", cfg?: StorageConfig) => {
             if (cfg) await chooseStorage(cfg);
             await savePrefs({ onboarded: true, lastCli: engine });
-            await go(addr, wallet);
+            await go(addr, wallet, !!cfg && cfg.kind !== "local");
           };
         }
       } catch (e) {
@@ -138,15 +158,27 @@ export function App({ options }: { options: AppOptions }) {
   }
 
   // chat — apply remembered prefs as defaults (explicit flags win); --continue resumes
-  // the most recent session.
+  // the most recent session. model comes from the resolved ENGINE's own remembered
+  // model — a claude model id (e.g. "sonnet") sent to codex's API is a 400, so the two
+  // must never share one field.
+  const effectiveCli = options.cli ?? prefs.lastCli ?? "claude";
   const effective: AppOptions = {
     ...options,
-    cli: options.cli ?? prefs.lastCli ?? "claude",
-    model: options.model ?? prefs.lastModel,
+    cli: effectiveCli,
+    model: options.model ?? (effectiveCli === "codex" ? prefs.lastModelCodex : prefs.lastModelClaude),
     effort: options.effort ?? prefs.lastEffort,
     resume: options.resume ?? (options.continue ? prefs.lastSessionId : undefined),
   };
   return (
-    <Chat runtime={runtime!} wallet={wallet!} address={address} report={report} options={effective} approval={approval.current} />
+    <Chat
+      runtime={runtime!}
+      wallet={wallet!}
+      address={address}
+      report={report}
+      options={effective}
+      approval={approval.current}
+      cloudStatus={cloudStatus}
+      onRebuildRuntime={rebuildRuntime}
+    />
   );
 }

--- a/surfaces/cli/src/commands.ts
+++ b/surfaces/cli/src/commands.ts
@@ -22,7 +22,7 @@ export const SLASH_COMMANDS: SlashCmd[] = [
   { name: "settings", desc: "show current engine/model/effort/cwd" },
   { name: "btw", desc: "side-channel question without interrupting session", args: "<question>" },
   { name: "wallet", desc: "show wallet address" },
-  { name: "storage", desc: "show where sessions save" },
+  { name: "storage", desc: "view/change where sessions save (connect or reconnect cloud)" },
   { name: "iq", desc: "a random IQ fact" },
   { name: "dance", desc: "Iggy dances" },
   { name: "help", desc: "list commands" },

--- a/surfaces/cli/src/components/StatusLine.tsx
+++ b/surfaces/cli/src/components/StatusLine.tsx
@@ -41,7 +41,7 @@ export function StatusLine({
   effort?: string;
   cwd: string;
   elapsed?: number;
-  sync?: { ok: boolean; error?: string } | null;
+  sync?: { ok: boolean; error?: string; reason?: "reauth" | "transient" } | null;
   ctx?: number;        // fraction USED (0..1); undefined = no data yet
   ctxTokens?: number; // raw tokens used (for label)
   ctxWindow?: number; // model window size (for label)
@@ -65,7 +65,8 @@ export function StatusLine({
         {elapsed !== undefined ? <Text color={colors.iqCyan}> · {elapsed.toFixed(1)}s</Text> : null}
         {sync ? (
           <Text color={sync.ok ? colors.ok : colors.err}>
-            {" · "}{sync.ok ? "☁ synced" : "☁ offline"}
+            {" · "}
+            {sync.ok ? "☁ synced" : sync.reason === "reauth" ? "☁ reconnect needed (/storage)" : "☁ offline"}
           </Text>
         ) : null}
       </Box>

--- a/surfaces/cli/src/hooks/useChat.ts
+++ b/surfaces/cli/src/hooks/useChat.ts
@@ -7,7 +7,8 @@ import type {
   SessionMeta,
 } from "@iqlabs-official/agent-sdk/runtime/contract";
 import type { ApprovalChannel } from "@iqlabs-official/agent-sdk/runtime/approval/channel";
-import { savePrefs, type EffortLevel } from "../prefs.js";
+import { readPrefs, savePrefs, type EffortLevel } from "../prefs.js";
+import { loadModelOptions } from "../models.js";
 
 export type Engine = "claude" | "codex";
 export type { EffortLevel };
@@ -126,9 +127,28 @@ export function useChat(
 
   const ensureHandle = useCallback(async (): Promise<SessionHandle> => {
     if (handle.current) return handle.current;
+    // Guard against a stale/invalid model string reaching the engine's API — not just the
+    // cross-engine case (switchEngine already fixes that) but anything else that could
+    // leave modelRef holding a name the ACTIVE engine doesn't recognize: --model with a
+    // typo, an old prefs value for a model since removed from the catalog, etc. Mirrors
+    // the webview Composer's catalog-validate-and-fallback (`models.some(...) ? model :
+    // models[0]?.value`) — validate against the live per-engine catalog, fall back to its
+    // first entry (often "default", i.e. no override) instead of sending garbage.
+    let modelToUse = modelRef.current;
+    if (modelToUse) {
+      try {
+        const catalog = await loadModelOptions(cliRef.current);
+        if (!catalog.some((m) => m.value === modelToUse)) {
+          modelToUse = catalog[0]?.value;
+        }
+      } catch {
+        /* catalog probe failed — send what we have; the engine call itself will surface
+           a clear error if it's genuinely invalid */
+      }
+    }
     const h = await runtime.startSession({
       cli: cliRef.current,
-      model: modelRef.current,
+      model: modelToUse,
       effort: effortRef.current,
       cwd: opts.cwd,
       sessionId: pendingRef.current,
@@ -170,6 +190,10 @@ export function useChat(
       setContextTokens(undefined);
       setContextWindow(undefined);
       void savePrefs({ lastCli: next });
+      // a model id is engine-specific (claude's "sonnet" is a 400 on codex's API and vice
+      // versa) — load whatever the NEW engine last used (or its own default) instead of
+      // carrying over the previous engine's model string.
+      void readPrefs().then((p) => setModel(next === "codex" ? p.lastModelCodex : p.lastModelClaude));
     },
     [dropHandle],
   );
@@ -180,7 +204,7 @@ export function useChat(
       setModel(m);
       setContextTokens(undefined);
       setContextWindow(undefined);
-      void savePrefs({ lastModel: m });
+      void savePrefs(cliRef.current === "codex" ? { lastModelCodex: m } : { lastModelClaude: m });
     },
     [dropHandle],
   );

--- a/surfaces/cli/src/index.tsx
+++ b/surfaces/cli/src/index.tsx
@@ -1,10 +1,34 @@
 import { render } from "ink";
 import React from "react";
 import { program } from "commander";
+import { appendFileSync } from "node:fs";
+import { homedir } from "node:os";
+import { join } from "node:path";
 import { DelightProvider } from "./components/DelightProvider.js";
 import { App, type AppOptions } from "./app.js";
 import { detectCli } from "./bootstrap.js";
 import { readPrefsSync, savePrefs } from "./prefs.js";
+
+// Diagnostics from the core/engine layer (codex app-server tracing, the claudeModels probe,
+// bigint's native-binding fallback notice, etc.) are all plain console.error/warn calls —
+// fine for vscode/mobile, where that goes to a log nobody's staring at, but the CLI's stderr
+// IS the visible terminal: every such line punches through the Ink UI mid-render. Route them
+// to a log file instead (same content, just not in front of the user), unless the user asked
+// for exactly this kind of visibility (AGENTNET_DEBUG, or AGENTNET_PERF for the traffic-audit
+// [perf] lines) — then leave the real console methods alone.
+function quietDiagnosticsToFile() {
+  if (process.env.AGENTNET_DEBUG || process.env.AGENTNET_PERF) return;
+  const logFile = join(homedir(), ".agentnet", "cli-debug.log");
+  const redirect = (level: string) => (...args: unknown[]) => {
+    try {
+      appendFileSync(logFile, `[${new Date().toISOString()}] ${level}: ${args.map(String).join(" ")}\n`);
+    } catch {
+      /* best-effort — a logging failure must never break the session */
+    }
+  };
+  console.error = redirect("error");
+  console.warn = redirect("warn");
+}
 
 // Launch the interactive TUI with the given options (and optional session to resume).
 // The TUI needs a real terminal (raw-mode keyboard input); when piped/redirected we
@@ -20,10 +44,16 @@ function launch(options: AppOptions, calmFlag?: boolean) {
     );
     process.exit(1);
   }
+  quietDiagnosticsToFile();
+  // Ink's own render() re-patches console.log/error/warn by default (patchConsole: true)
+  // to inject any stray console output above the live UI — which is exactly what clobbers
+  // our redirect above the moment render() runs, since Ink's patch installs AFTER ours and
+  // forwards straight to the terminal. Disable Ink's patching so our file-redirect sticks.
   render(
     <DelightProvider calm={calm}>
       <App options={options} />
     </DelightProvider>,
+    { patchConsole: false },
   );
 }
 

--- a/surfaces/cli/src/prefs.ts
+++ b/surfaces/cli/src/prefs.ts
@@ -12,7 +12,10 @@ export type EffortLevel = "low" | "medium" | "high" | "xhigh" | "max";
 export interface Prefs {
   onboarded?: boolean;
   lastCli?: "claude" | "codex";
-  lastModel?: string;
+  // per-engine: a claude model id (e.g. "sonnet") is meaningless to codex's API and vice
+  // versa, so each engine remembers its own last model rather than sharing one field.
+  lastModelClaude?: string;
+  lastModelCodex?: string;
   lastSessionId?: string;
   lastEffort?: EffortLevel;
   calm?: boolean; // remembered animation preference

--- a/surfaces/cli/src/views/Chat.tsx
+++ b/surfaces/cli/src/views/Chat.tsx
@@ -1,7 +1,8 @@
 import React, { useEffect, useMemo, useRef, useState, useCallback } from "react";
 import { Box, Text, Static, useApp, useInput } from "ink";
 import type { AgentRuntime, Wallet, ChatMessage } from "@iqlabs-official/agent-sdk/runtime/contract";
-import type { CliReport } from "@iqlabs-official/agent-sdk";
+import type { CliReport, StorageConfig } from "@iqlabs-official/agent-sdk";
+import type { CloudStatus } from "@iqlabs-official/agent-sdk/account/storage/mirror";
 import type { ApprovalRequest } from "@iqlabs-official/agent-sdk/runtime/approval/channel";
 import type { AppOptions } from "../app.js";
 import type { InkApprovalChannel } from "../InkApprovalChannel.js";
@@ -18,8 +19,10 @@ import {
   hasDasRpc,
   marketplaceEnv,
   BUNDLED_SKILLS,
+  startGoogleLogin,
+  type GoogleLogin,
 } from "@iqlabs-official/agent-sdk";
-import { Select } from "@inkjs/ui";
+import { Select, TextInput } from "@inkjs/ui";
 import { chooseStorage } from "../bootstrap.js";
 import { copyToClipboard } from "../clipboard.js";
 import { Message } from "../components/Message.js";
@@ -54,6 +57,8 @@ export function Chat({
   options,
   approval,
   address,
+  cloudStatus,
+  onRebuildRuntime,
 }: {
   runtime: AgentRuntime;
   wallet: Wallet;
@@ -61,6 +66,8 @@ export function Chat({
   report: CliReport;
   options: AppOptions;
   approval: InkApprovalChannel | null;
+  cloudStatus: CloudStatus | null;
+  onRebuildRuntime: () => Promise<AgentRuntime>;
 }) {
   const { exit } = useApp();
   const cwd = options.cwd ?? process.cwd();
@@ -186,6 +193,16 @@ export function Chat({
   // the panel to edit settings. showCloud opens the storage picker from the panel's cloud row.
   const [panelFocused, setPanelFocused] = useState(false);
   const [showCloud, setShowCloud] = useState(false);
+  // gdrive reconnect/connect overlay — reuses the same OAuth flow as first-run onboarding
+  // (packages/core startGoogleLogin: loopback server + a manual code/url paste fallback
+  // for remote/SSH terminals where the browser can't reach the CLI's loopback listener).
+  const [showGdriveConnect, setShowGdriveConnect] = useState(false);
+  const [gdriveUrl, setGdriveUrl] = useState<string | null>(null);
+  const [gdriveErr, setGdriveErr] = useState<string | null>(null);
+  const [googleSession, setGoogleSession] = useState<GoogleLogin | null>(null);
+  // icloud/custom need a folder path / endpoint URL before they can connect.
+  const [pendingCloudKind, setPendingCloudKind] = useState<StorageKind | null>(null);
+  const [showLocationInput, setShowLocationInput] = useState(false);
   const [celebrate, setCelebrate] = useState<"sparkle" | "confetti" | null>(null);
   const [eggMood, setEggMood] = useState<Mood | null>(null);
   const [idle, setIdle] = useState(false);
@@ -334,7 +351,9 @@ export function Chat({
         !showBtw &&
         !showAccount &&
         !showSettings &&
-        !showCloud,
+        !showCloud &&
+        !showGdriveConnect &&
+        !showLocationInput,
     },
   );
 
@@ -352,6 +371,19 @@ export function Chat({
   useInput(
     (_input, key) => { if (key.escape) setShowCloud(false); },
     { isActive: showCloud },
+  );
+
+  // Esc cancels an in-flight gdrive connect/reconnect (the effect's cleanup cancels the
+  // OAuth session/loopback server).
+  useInput(
+    (_input, key) => { if (key.escape) setShowGdriveConnect(false); },
+    { isActive: showGdriveConnect },
+  );
+
+  // Esc backs out of the icloud/custom location prompt (TextInput owns Enter/typing).
+  useInput(
+    (_input, key) => { if (key.escape) { setShowLocationInput(false); setPendingCloudKind(null); } },
+    { isActive: showLocationInput },
   );
 
   // Escape or Return closes the /btw overlay.
@@ -417,19 +449,87 @@ export function Chat({
     setShowMarket(true);
   }
 
-  // apply a storage choice picked from the panel. local applies in place; a cloud (gdrive)
-  // needs the OAuth flow, which lives in onboarding — point there rather than half-doing it.
+  // Write the storage choice, then rebuild the runtime so it actually picks up the new
+  // config (the runtime is bound once at boot; without this a config change is silently
+  // ignored until the next launch — same bug whether connecting, reconnecting, or going
+  // back to local-only). One-shot backfill mirrors vscode/localhost's connectCloud /
+  // reconnectCloud handlers: push whatever's missing, fire-and-forget, never on a timer.
+  async function finishCloudConnect(cfg: StorageConfig) {
+    await chooseStorage(cfg);
+    const rt = await onRebuildRuntime();
+    setCloud(await getStorageInfo());
+    setNotice(`storage → ${cfg.kind} connected, syncing history…`);
+    void rt.syncCloud()
+      .then((r) => setNotice(r.uploaded ? `synced ${r.uploaded} session${r.uploaded === 1 ? "" : "s"} to ${cfg.kind}` : `storage → ${cfg.kind} (already in sync)`))
+      .catch(() => { /* best-effort; a later write or reconnect re-syncs */ });
+  }
+
+  // apply a storage choice picked from the panel. local applies immediately; gdrive opens
+  // the same OAuth flow onboarding uses; icloud/custom need a path/URL first.
   function applyCloud(kind: StorageKind) {
     setShowCloud(false);
     setPanelFocused(false);
     if (kind === "local") {
-      void chooseStorage({ kind: "local" }).then(() => {
+      void chooseStorage({ kind: "local" }).then(async () => {
+        await onRebuildRuntime();
         setCloud(null);
         setNotice("storage → local only");
       });
       return;
     }
-    setNotice(`${kind} needs sign-in: re-run onboarding to connect (rm ~/.config/agentnet to reset)`);
+    if (kind === "gdrive") {
+      setGdriveErr(null);
+      setGdriveUrl(null);
+      setShowGdriveConnect(true);
+      return;
+    }
+    setPendingCloudKind(kind);
+    setShowLocationInput(true);
+  }
+
+  // drive the gdrive OAuth flow while the connect overlay is open (mirrors Onboarding's
+  // gdriveLogin step: loopback server auto-completes if the browser can reach it, with a
+  // manual code/url paste as fallback for remote/SSH terminals).
+  useEffect(() => {
+    if (!showGdriveConnect) return;
+    let activeSession: GoogleLogin | null = null;
+    let cancelled = false;
+    startGoogleLogin().then((session) => {
+      if (cancelled) { session.cancel(); return; }
+      activeSession = session;
+      setGdriveUrl(session.url);
+      setGoogleSession(session);
+      session.done.then((ok) => {
+        if (cancelled) return;
+        if (ok) {
+          setShowGdriveConnect(false);
+          void finishCloudConnect({ kind: "gdrive" });
+        } else {
+          setGdriveErr("Google sign-in was not completed.");
+        }
+      });
+    }).catch((e: unknown) => {
+      if (!cancelled) setGdriveErr(e instanceof Error ? e.message : String(e));
+    });
+    return () => {
+      cancelled = true;
+      if (activeSession) activeSession.cancel();
+    };
+    // eslint-disable-next-line react-hooks/exhaustive-deps
+  }, [showGdriveConnect]);
+
+  function submitGdriveCode(codeVal: string) {
+    if (!codeVal.trim() || !googleSession) return;
+    void googleSession.submitCode(codeVal.trim()).catch((e: unknown) => {
+      setGdriveErr(e instanceof Error ? e.message : String(e));
+    });
+  }
+
+  function submitCloudLocation(value: string) {
+    if (!pendingCloudKind) return;
+    setShowLocationInput(false);
+    void finishCloudConnect({ kind: pendingCloudKind, location: value });
+    setPendingCloudKind(null);
   }
 
   function runSlash(raw: string) {
@@ -556,9 +656,10 @@ export function Chat({
         return;
       }
       case "storage":
-        void getStorageInfo().then((info) =>
-          setNotice(info ? `storage: ${info.kind}${info.account ? ` (${info.account})` : ""}` : "storage: local only"),
-        );
+        // Opens the same picker as the welcome panel's cloud row — the one-tap entry
+        // point for connect / reconnect (a dead gdrive token surfaces via the status
+        // line's "reconnect needed" chip, which points here).
+        setShowCloud(true);
         return;
       case "account":
         void (async () => {
@@ -668,6 +769,46 @@ export function Chat({
             />
           </Box>
           <Box marginTop={1}><Text dimColor>Esc  close</Text></Box>
+        </Box>
+      </Box>
+    );
+  }
+
+  // gdrive connect/reconnect overlay — same flow as first-run onboarding's gdriveLogin step.
+  if (showGdriveConnect) {
+    return (
+      <Box flexDirection="column" paddingX={1}>
+        <Box borderStyle="round" borderColor={colors.iqCyan} flexDirection="column" paddingX={2} paddingY={1} gap={1}>
+          <Text bold color={colors.iqCyan}>sign in to Google Drive</Text>
+          {!gdriveUrl && !gdriveErr && <Text dimColor>starting OAuth flow…</Text>}
+          {gdriveUrl && (
+            <>
+              <Text>1. open in browser (or copy link):</Text>
+              <Text color={colors.iqCyan}>{gdriveUrl}</Text>
+              <Text>2. paste the redirected URL or authorization code here:</Text>
+              <TextInput placeholder="Paste URL or code here" onSubmit={submitGdriveCode} />
+            </>
+          )}
+          {gdriveErr && <Text color={colors.err}>{gdriveErr}</Text>}
+          <Box marginTop={1}><Text dimColor>Esc  cancel</Text></Box>
+        </Box>
+      </Box>
+    );
+  }
+
+  // icloud/custom connect overlay — needs a folder path / endpoint URL before connecting.
+  if (showLocationInput && pendingCloudKind) {
+    return (
+      <Box flexDirection="column" paddingX={1}>
+        <Box borderStyle="round" borderColor={colors.iqCyan} flexDirection="column" paddingX={2} paddingY={1}>
+          <Text bold color={colors.iqCyan}>
+            {pendingCloudKind === "icloud" ? "iCloud folder path:" : "endpoint base URL:"}
+          </Text>
+          <TextInput
+            placeholder={pendingCloudKind === "icloud" ? "~/Library/Mobile Documents/…" : "https://…"}
+            onSubmit={submitCloudLocation}
+          />
+          <Box marginTop={1}><Text dimColor>Esc  cancel</Text></Box>
         </Box>
       </Box>
     );
@@ -843,7 +984,7 @@ export function Chat({
       <Celebrate kind={celebrate} />
       {idle && !chat.busy ? <Text dimColor>{copy.idleNudge}</Text> : null}
 
-      <StatusLine mood={mood} cli={chat.cli} model={chat.model} effort={chat.effort} cwd={cwd} elapsed={chat.busy ? chat.elapsed : undefined} ctx={usedFrac} ctxTokens={usedTokens !== undefined ? Math.round(usedTokens) : undefined} ctxWindow={usedFrac !== undefined ? WINDOW : undefined} ctxApprox={!ctxReal} />
+      <StatusLine mood={mood} cli={chat.cli} model={chat.model} effort={chat.effort} cwd={cwd} elapsed={chat.busy ? chat.elapsed : undefined} sync={cloud && cloud.kind !== "local" ? (cloudStatus ? { ok: cloudStatus.ok, error: cloudStatus.ok ? undefined : cloudStatus.error, reason: cloudStatus.ok ? undefined : cloudStatus.reason } : { ok: true }) : null} ctx={usedFrac} ctxTokens={usedTokens !== undefined ? Math.round(usedTokens) : undefined} ctxWindow={usedFrac !== undefined ? WINDOW : undefined} ctxApprox={!ctxReal} />
 
       {/* hide the composer while an approval is pending — keys answer the card instead */}
       {!pendingApproval ? (

--- a/surfaces/cli/src/views/Chat.tsx
+++ b/surfaces/cli/src/views/Chat.tsx
@@ -23,6 +23,7 @@ import {
   type GoogleLogin,
 } from "@iqlabs-official/agent-sdk";
 import { Select, TextInput } from "@inkjs/ui";
+import open from "open";
 import { chooseStorage } from "../bootstrap.js";
 import { copyToClipboard } from "../clipboard.js";
 import { Message } from "../components/Message.js";
@@ -499,13 +500,19 @@ export function Chat({
       activeSession = session;
       setGdriveUrl(session.url);
       setGoogleSession(session);
+      // Auto-open the browser with the exact URL — the alternative is the user copying a
+      // ~300-char URL that wraps across terminal lines inside the bordered box below, which
+      // terminals routinely mangle on copy (silently truncated scope → Google's own
+      // "Error 400: invalid_scope"). The wrapped text stays visible as a manual/remote-SSH
+      // fallback, but auto-open is the primary path now.
+      void open(session.url).catch(() => { /* no GUI browser available — user falls back to the link/paste below */ });
       session.done.then((ok) => {
         if (cancelled) return;
         if (ok) {
           setShowGdriveConnect(false);
           void finishCloudConnect({ kind: "gdrive" });
         } else {
-          setGdriveErr("Google sign-in was not completed.");
+          setGdriveErr(session.error ?? "Google sign-in was not completed.");
         }
       });
     }).catch((e: unknown) => {
@@ -783,9 +790,10 @@ export function Chat({
           {!gdriveUrl && !gdriveErr && <Text dimColor>starting OAuth flow…</Text>}
           {gdriveUrl && (
             <>
-              <Text>1. open in browser (or copy link):</Text>
+              <Text>opening in your browser… approve access, then this closes on its own.</Text>
+              <Text dimColor>didn't open? copy this link (avoid copying across a wrapped line):</Text>
               <Text color={colors.iqCyan}>{gdriveUrl}</Text>
-              <Text>2. paste the redirected URL or authorization code here:</Text>
+              <Text>no GUI browser here? paste the redirected URL or code instead:</Text>
               <TextInput placeholder="Paste URL or code here" onSubmit={submitGdriveCode} />
             </>
           )}

--- a/surfaces/cli/src/views/Onboarding.tsx
+++ b/surfaces/cli/src/views/Onboarding.tsx
@@ -1,6 +1,7 @@
 import React, { useState, useEffect } from "react";
 import { Box, Text } from "ink";
 import { Select, TextInput } from "@inkjs/ui";
+import open from "open";
 import { STORAGE_OPTIONS, type StorageConfig, type StorageKind, startCodexLogin, markCodexConnected, saveCodexApiKey, startGoogleLogin, type GoogleLogin } from "@iqlabs-official/agent-sdk";
 import type { CliReport, CliStatus } from "@iqlabs-official/agent-sdk";
 import { colors, glyph } from "../theme.js";
@@ -97,12 +98,17 @@ export function Onboarding({
       activeSession = session;
       setGdriveUrl(session.url);
       setGoogleSession(session);
+      // Auto-open the browser with the exact URL — copying it manually means copying a
+      // ~300-char string that wraps across terminal lines below, which terminals routinely
+      // mangle (silently truncated scope → Google's own "Error 400: invalid_scope"). The
+      // wrapped text stays visible as a remote/SSH fallback, but auto-open is now primary.
+      void open(session.url).catch(() => { /* no GUI browser available — falls back to the link/paste below */ });
       session.done.then((ok) => {
         if (cancelled) return;
         if (ok) {
           onDone(engine, { kind: "gdrive" });
         } else {
-          setGdriveErr("Google sign-in was not completed.");
+          setGdriveErr(session.error ?? "Google sign-in was not completed.");
         }
       });
     }).catch((e: unknown) => {
@@ -223,9 +229,10 @@ export function Onboarding({
           {!gdriveUrl && !gdriveErr && <Text dimColor>starting OAuth flow…</Text>}
           {gdriveUrl && (
             <>
-              <Text>1. open in browser (or copy link):</Text>
+              <Text>opening in your browser… approve access, then this closes on its own.</Text>
+              <Text dimColor>didn't open? copy this link (avoid copying across a wrapped line):</Text>
               <Text color={colors.iqCyan}>{gdriveUrl}</Text>
-              <Text>2. paste the redirected URL or authorization code here:</Text>
+              <Text>no GUI browser here? paste the redirected URL or code instead:</Text>
               <TextInput
                 placeholder="Paste URL or code here"
                 onSubmit={submitGdriveCode}

--- a/surfaces/cli/tsup.config.ts
+++ b/surfaces/cli/tsup.config.ts
@@ -16,7 +16,18 @@ export default defineConfig({
   // The inlined core pulls in CJS deps (bs58 → safe-buffer) that call require("buffer")
   // at load time. esbuild's ESM output ships a `__require` shim that THROWS unless a real
   // `require` exists in scope — so we define one via createRequire. (Also the shebang.)
+  // @coral-xyz/anchor's ESM dist also has a bare `exports.workspace = ...`/`exports.Wallet =
+  // ...` (its Node-only "workspace" convenience global, guarded by `if (!isBrowser)`) that
+  // assumes a real CJS `exports` binding — bundled into pure ESM there is none, so it throws
+  // `exports is not defined` the moment anything imports from anchor. Nothing in this CLI
+  // reads that global, so a throwaway module-scope `exports` object is a harmless sink.
+  // A native-addon loader (the `bindings` package, reached from bigint-buffer's fallback
+  // path) also references bare `__filename` to identify its own call site — another CJS
+  // global with no ESM equivalent. Standard esbuild-recommended shim: derive it from
+  // import.meta.url. Approximate (one shared value for the whole bundle, not per-original-
+  // file), but this call site only uses it to fail its native-binding lookup gracefully
+  // (already-tolerated: see the "bigint: Failed to load bindings" warning on every launch).
   banner: {
-    js: "#!/usr/bin/env node\nimport { createRequire as __ar_cr } from 'module';\nconst require = __ar_cr(import.meta.url);",
+    js: "#!/usr/bin/env node\nimport { createRequire as __ar_cr } from 'module';\nimport { fileURLToPath as __ar_ftp } from 'url';\nimport { dirname as __ar_dn } from 'path';\nconst require = __ar_cr(import.meta.url);\nconst exports = {};\nconst __filename = __ar_ftp(import.meta.url);\nconst __dirname = __ar_dn(__filename);",
   },
 });


### PR DESCRIPTION
## Summary
Fixes found while QA-testing the CLI surface (issue #100):

- **Cloud reconnect was a dead end**: `/storage` → gdrive told the user to `rm ~/.config/agentnet` (wrong path — real root is `~/.agentnet`) and never actually reconnected or backfilled local sessions to cloud. Replaced with a real reconnect flow matching vscode/localhost: connects, rebuilds the runtime, and fires a one-shot `syncCloud()` backfill.
- **Cross-engine model leak**: switching claude ↔ codex kept a single shared `lastModel` pref, so codex could receive a claude-only model id (e.g. `sonnet`) and get rejected by the API. Split into per-engine prefs (`lastModelClaude`/`lastModelCodex`) plus a live-catalog validation fallback in `ensureHandle()`.
- **Two ESM/CJS bundling crashes**: `exports is not defined` (from a transitively-bundled CJS global) and `__filename is not defined` (native-addon loader fallback) — both esbuild/tsup banner shims.
- **MCP diagnostic stderr leaking into the terminal UI**: Ink's `render()` defaults to `patchConsole: true`, which re-patches console methods after our own redirect-to-file and forwards them straight to the terminal. Disabled Ink's patching so diagnostics stay in `~/.agentnet/cli-debug.log` (matches vscode/mobile, where this is already invisible).
- **Google sign-in failures were silent**: the loopback landing page always says "connected" before the code exchange even runs, so a dead sign-in looked identical to a successful one. `GoogleLogin` now exposes a real `.error` reason (state mismatch, bad code, exchange failure, timeout) instead of one generic message.
- **`invalid_scope` from Google**: the ~300-char auth URL wrapped across terminal lines inside a bordered box, and copying wrapped terminal text got silently truncated by some terminals. Now auto-opens the browser with the exact URL; manual copy/paste stays as a fallback for headless/SSH use.

## Test plan
- [x] `tsc --noEmit` clean on `packages/core`, `surfaces/cli`, `surfaces/localhost`
- [x] `pnpm --filter agentnet-cli build` succeeds
- [x] `agentnet doctor` sanity check
- [x] Manual QA pass per the CLI test plan (storage reconnect, model picker, oauth flow) — see linked issue