### PR TITLE
Add legacy/modern targetSdk flavors, extract guest-launch seam, fix claude hardlink extraction

### DIFF
--- a/.github/workflows/android-apk.yml
+++ b/.github/workflows/android-apk.yml
@@ -135,9 +135,15 @@ jobs:
           KS_B64: ${{ secrets.ANDROID_DEBUG_KEYSTORE_B64 }}
         run: printf '%s' "$KS_B64" | base64 -d > surfaces/android/agentnet-debug.keystore
 
+      # Ship the `legacy` flavor (targetSdk 28): it keeps the pre-29 W^X exemption that runs
+      # node + the proot guest's binaries from app storage, and is the proven, on-device-tested
+      # variant. The `modern` flavor (targetSdk 35) is validated on hardware but not yet the
+      # public download — build it explicitly here only once it is. Do NOT use bare
+      # `assembleDebug`: with flavors it builds BOTH variants and writes to per-flavor dirs,
+      # so the output path below would no longer resolve.
       - name: Build signed debug APK
         working-directory: surfaces/android
-        run: ./gradlew --no-daemon assembleDebug
+        run: ./gradlew --no-daemon assembleLegacyDebug
 
       # SHA-1 is a public fingerprint (not the key), safe to log — proves the team key signed it.
       - name: Print signing SHA-1
@@ -151,18 +157,21 @@ jobs:
       - uses: actions/upload-artifact@v4
         with:
           name: agentnet-apk-${{ env.ABI }}
-          path: surfaces/android/app/build/outputs/apk/debug/app-debug.apk
+          path: surfaces/android/app/build/outputs/apk/legacy/debug/app-legacy-debug.apk
           retention-days: 7
           if-no-files-found: error
 
       # Publish to the rolling `android-latest` release so the public download link
       # (.../releases/download/android-latest/app-debug.apk) always serves the newest build.
       # arm64 only, so a manual x86_64 build doesn't clobber the shareable arm64 APK.
+      # The flavor split names the file app-legacy-debug.apk, but the public link people already
+      # have points at app-debug.apk — upload it under that display name (gh's `file#name` syntax)
+      # so the shared URL keeps working.
       - name: Update android-latest release
         if: env.ABI == 'arm64'
         run: |
-          APK=surfaces/android/app/build/outputs/apk/debug/app-debug.apk
+          APK=surfaces/android/app/build/outputs/apk/legacy/debug/app-legacy-debug.apk
           gh release view android-latest >/dev/null 2>&1 \
             || gh release create android-latest --title "AgentNet Android (latest)" --latest \
                  --notes "Auto-built from main. Download app-debug.apk and install (allow unknown sources)."
-          gh release upload android-latest "$APK" --clobber
+          gh release upload android-latest "$APK#app-debug.apk" --clobber

--- a/.gitignore
+++ b/.gitignore
@@ -16,3 +16,4 @@ apk/
 
 # internal, local-only design docs (strategy kept out of the public repo)
 plans/raise-targetsdk-exec.md
+surfaces/android/scripts/probe-modern-exec.sh

--- a/.gitignore
+++ b/.gitignore
@@ -17,4 +17,5 @@ apk/
 # internal, local-only design docs (strategy kept out of the public repo)
 plans/raise-targetsdk-exec.md
 plans/modern-rollout-testing.md
+plans/PR-modern-targetsdk.md
 surfaces/android/scripts/probe-modern-exec.sh

--- a/.gitignore
+++ b/.gitignore
@@ -13,3 +13,6 @@ HANDOFF.md
 
 # downloaded APK artifacts (CI / release builds)
 apk/
+
+# internal, local-only design docs (strategy kept out of the public repo)
+plans/raise-targetsdk-exec.md

--- a/.gitignore
+++ b/.gitignore
@@ -16,4 +16,5 @@ apk/
 
 # internal, local-only design docs (strategy kept out of the public repo)
 plans/raise-targetsdk-exec.md
+plans/modern-rollout-testing.md
 surfaces/android/scripts/probe-modern-exec.sh

--- a/surfaces/android/README.md
+++ b/surfaces/android/README.md
@@ -24,7 +24,8 @@ the per-syscall overhead small — fine for the network-bound agent-chat workloa
 surfaces/android/
   settings.gradle.kts, build.gradle.kts, gradle.properties
   app/
-    build.gradle.kts          targetSdk=28 (W^X exemption to exec from app storage)
+    build.gradle.kts          legacy/modern flavors: targetSdk 28 (W^X exemption to exec
+                              from app storage) vs 35 (modern-target bring-up)
     src/main/
       AndroidManifest.xml
       java/com/iqlabs/agentnet/

--- a/surfaces/android/app/build.gradle.kts
+++ b/surfaces/android/app/build.gradle.kts
@@ -34,10 +34,9 @@ android {
     }
 
     // targetSdk is a per-flavor dimension, not a fixed value, so one codebase ships both the
-    // proven legacy engine and the modern-target variant we are bringing up (see
-    // plans/raise-targetsdk-exec.md). applicationId and signing stay IDENTICAL across flavors,
-    // so switching flavor is an in-place upgrade that never wipes the user's rootfs — do not add
-    // an applicationIdSuffix.
+    // proven legacy engine and the modern-target variant we are bringing up. applicationId and
+    // signing stay IDENTICAL across flavors, so switching flavor is an in-place upgrade that
+    // never wipes the user's rootfs — do not add an applicationIdSuffix.
     flavorDimensions += "execTarget"
     productFlavors {
         create("legacy") {
@@ -52,10 +51,11 @@ android {
         }
         create("modern") {
             dimension = "execTarget"
-            // targetSdk 35 gives up the W^X exemption on purpose. This flavor exists to probe what
-            // actually breaks (Module 0) and then route guest exec through /system/bin/linker64
-            // (Module 3, system_linker_exec). Until Module 3 lands, guest binaries are EXPECTED to
-            // fail to exec at runtime here — that failure is the probe signal, not a regression.
+            // targetSdk 35 gives up the W^X exemption on purpose. This flavor is where we bring up
+            // a modern target: guest exec will be routed through /system/bin/linker64 (the
+            // system_linker_exec technique) so app-storage binaries still run. Until that routing
+            // lands, guest binaries are EXPECTED to fail to exec at runtime here — that failure is
+            // the signal we are probing for, not a regression.
             targetSdk = 35
             buildConfigField("String", "EXEC_TARGET", "\"modern\"")
         }

--- a/surfaces/android/app/build.gradle.kts
+++ b/surfaces/android/app/build.gradle.kts
@@ -24,11 +24,6 @@ android {
     defaultConfig {
         applicationId = "com.iqlabs.agentnet"
         minSdk = 24
-        // targetSdk 28 is load-bearing: Android 10+ (target 29+) enforces SELinux W^X,
-        // which blocks executing binaries extracted into app data. We run node + the
-        // proot guest's binaries from app storage, so we need the legacy exemption.
-        // Termux (F-Droid) pins the same target for the same reason.
-        targetSdk = 28
         versionCode = 1
         versionName = "0.1.0"
         buildConfigField(
@@ -36,6 +31,34 @@ android {
             "GOOGLE_OAUTH_CLIENT_ID",
             "\"${googleOAuthClientId.replace("\\", "\\\\").replace("\"", "\\\"")}\""
         )
+    }
+
+    // targetSdk is a per-flavor dimension, not a fixed value, so one codebase ships both the
+    // proven legacy engine and the modern-target variant we are bringing up (see
+    // plans/raise-targetsdk-exec.md). applicationId and signing stay IDENTICAL across flavors,
+    // so switching flavor is an in-place upgrade that never wipes the user's rootfs — do not add
+    // an applicationIdSuffix.
+    flavorDimensions += "execTarget"
+    productFlavors {
+        create("legacy") {
+            dimension = "execTarget"
+            // targetSdk 28 is load-bearing here: Android 10+ (target 29+) enforces SELinux W^X,
+            // which blocks executing binaries extracted into app data. We run node + the proot
+            // guest's binaries from app storage, so the legacy flavor keeps the pre-29 exemption.
+            // Termux (F-Droid) pins the same target for the same reason. This is today's shipping
+            // behavior; keep it unchanged until the modern flavor proves out.
+            targetSdk = 28
+            buildConfigField("String", "EXEC_TARGET", "\"legacy\"")
+        }
+        create("modern") {
+            dimension = "execTarget"
+            // targetSdk 35 gives up the W^X exemption on purpose. This flavor exists to probe what
+            // actually breaks (Module 0) and then route guest exec through /system/bin/linker64
+            // (Module 3, system_linker_exec). Until Module 3 lands, guest binaries are EXPECTED to
+            // fail to exec at runtime here — that failure is the probe signal, not a regression.
+            targetSdk = 35
+            buildConfigField("String", "EXEC_TARGET", "\"modern\"")
+        }
     }
 
     buildFeatures {

--- a/surfaces/android/app/src/main/java/com/iqlabs/agentnet/DirectProotExec.kt
+++ b/surfaces/android/app/src/main/java/com/iqlabs/agentnet/DirectProotExec.kt
@@ -9,7 +9,7 @@ import java.io.File
 // ptrace-remaps the guest's "/lib, /usr, /etc" onto the rootfs in app storage, so
 // node/claude/codex see a normal Linux. This launch execs the guest's own binaries from app
 // storage, so it depends on the targetSdk<=28 W^X exemption — the modern flavor will need
-// the linker-routing strategy from Module 3 (plans/raise-targetsdk-exec.md) instead.
+// a linker-routing strategy (exec via the system linker) instead.
 //
 // Mechanics (ProcessBuilder + host-side proot env) adapted from AnyClaw
 // (friuns2/openclaw-android-assistant, MIT). The OpenClaw/Codex-specific install steps are

--- a/surfaces/android/app/src/main/java/com/iqlabs/agentnet/DirectProotExec.kt
+++ b/surfaces/android/app/src/main/java/com/iqlabs/agentnet/DirectProotExec.kt
@@ -1,0 +1,121 @@
+package com.iqlabs.agentnet
+
+import android.system.Os
+import android.util.Log
+import java.io.File
+
+// The stock proot strategy: enter the Ubuntu guest by exec'ing our bundled proot directly
+// out of nativeLibDir. proot (not the agent) is what makes glibc binaries work here: it
+// ptrace-remaps the guest's "/lib, /usr, /etc" onto the rootfs in app storage, so
+// node/claude/codex see a normal Linux. This launch execs the guest's own binaries from app
+// storage, so it depends on the targetSdk<=28 W^X exemption — the modern flavor will need
+// the linker-routing strategy from Module 3 (plans/raise-targetsdk-exec.md) instead.
+//
+// Mechanics (ProcessBuilder + host-side proot env) adapted from AnyClaw
+// (friuns2/openclaw-android-assistant, MIT). The OpenClaw/Codex-specific install steps are
+// NOT copied — our engine is the official CLIs in the proot guest.
+class DirectProotExec(private val layout: Paths.Layout) : GuestExec {
+    companion object {
+        private const val TAG = "AgentNet/Server"
+    }
+
+    override fun launch(guestEnv: List<String>, guestCommand: String): Process {
+        // prootCommand wraps the launch in `sh -c 'cd <filesDir> && exec proot …'`, so the
+        // host cwd is already pinned to a readable dir before proot runs (see the comment
+        // there). That's what stops the `getcwd() failed → ENOSYS: uv_cwd` crash.
+        val pb = ProcessBuilder(prootCommand(guestEnv, guestCommand))
+
+        // Host-side env for the proot PROCESS (not the guest). These are load-bearing:
+        val env = pb.environment()
+        env["PROOT_LOADER"] = layout.loader        // proot's own ELF loader helper
+        env["PROOT_LOADER_32"] = layout.loader32   // 32-bit loader (guest is 64-bit; set anyway)
+        // proot is the Termux build (process_vm=yes), dynamically linked against
+        // libtalloc.so.2 + libandroid-shmem.so. Those now ship under jniLibs and the OS
+        // extracts them into nativeLibraryDir — so point LD_LIBRARY_PATH there. jniLibs only
+        // packages files named lib*.so, so the versioned libtalloc.so.2 had to ship as
+        // libtalloc.so; but proot's DT_NEEDED still asks for the soname "libtalloc.so.2", so
+        // we hang a symlink with that exact name in a writable dir and put it FIRST on the
+        // search path. (Why this proot: process_vm_readv strips arm64 top-byte pointer tags,
+        // avoiding the PEEKDATA "I/O error" on tagged addresses that broke the sandbox on
+        // tag-enabled devices like the Solana Seeker. Full root cause: AndroidManifest.)
+        val sonameShim = Paths.dir("${layout.filesDir}/proot-soname")
+        val talloc2 = File(sonameShim, "libtalloc.so.2")
+        val tallocTarget = "${layout.nativeLibDir}/libtalloc.so"
+        // nativeLibDir changes on every (re)install, so a symlink left by a PRIOR install points
+        // at a path that no longer exists. File.exists() follows the link → false for that stale
+        // one, yet Os.symlink would then fail EEXIST (the link file is still there) and never get
+        // recreated — leaving proot unable to resolve libtalloc.so.2 and the server stuck on boot
+        // after every reinstall. Recreate whenever the link is missing OR doesn't already point at
+        // the CURRENT target, so a fresh install / upgrade self-heals without manual intervention.
+        val curTarget = runCatching { Os.readlink(talloc2.absolutePath) }.getOrNull()
+        if (curTarget != tallocTarget) {
+            runCatching {
+                talloc2.delete() // drop any stale link/file before relinking
+                Os.symlink(tallocTarget, talloc2.absolutePath)
+            }.onFailure { Log.w(TAG, "could not create libtalloc.so.2 soname symlink", it) }
+        }
+        env["LD_LIBRARY_PATH"] =
+            listOfNotNull(sonameShim.absolutePath, layout.nativeLibDir, env["LD_LIBRARY_PATH"])
+                .joinToString(":")
+        // PROOT_NO_SECCOMP: Android 12+/15 tighten the seccomp filter (e.g. set_robust_list
+        // blocked), which makes glibc/node crash with SIGSYS under proot's seccomp fast
+        // path. Turning seccomp off trades the speed win for "it runs at all" — necessary
+        // on newer Android. (If a target kernel is fine with seccomp, dropping this would
+        // be faster; that's an on-device measurement, see project memory.)
+        // DO NOT set PROOT_NO_SECCOMP. It forces proot to ptrace-intercept and translate
+        // EVERY syscall, including getcwd → readlink("/proc/self/cwd"). In the
+        // untrusted_app SELinux domain /proc/<pid> is restricted, so that readlink fails
+        // and getcwd returns ENOSYS — node then dies with `ENOSYS: uv_cwd` at startup
+        // (the claude SDK calls process.cwd() at import time, before our server loads).
+        // With seccomp acceleration ON (the default), getcwd runs natively in the kernel,
+        // never touches /proc, and the server boots cleanly. Verified on-device: Samsung
+        // SM-F711N (Snapdragon), Android 13 — server reaches HTTP 200, no SIGSYS.
+        // (The earlier belief that newer Android needs NO_SECCOMP for set_robust_list was
+        // wrong for this path; seccomp-on is both correct AND faster.)
+        env["PROOT_TMP_DIR"] = Paths.dir("${layout.rootfs}/tmp").absolutePath
+        env["PROOT_L2S_DIR"] = Paths.dir("${layout.rootfs}/.l2s").absolutePath // stable link2symlink db
+        pb.redirectErrorStream(true)
+
+        return pb.start()
+    }
+
+    // Build the proot invocation that enters the Ubuntu guest and runs `guestCommand` as a
+    // login shell. Flags mirror proot-distro's defaults; --kill-on-exit ties guest
+    // processes to ours so nothing is orphaned, --link2symlink is guest compatibility, and
+    // /dev,/proc,/sys are bound through from Android.
+    // We launch proot through a host /system/bin/sh that first `cd`s into filesDir, then
+    // `exec`s proot. This is load-bearing: an Android app process has cwd = "/", which is
+    // unreadable under SELinux, so proot's startup getcwd() fails ("sh: 0: getcwd()
+    // failed") and a broken cwd propagates into the guest — node then dies with
+    // `ENOSYS: uv_cwd` before our server loads. ProcessBuilder.directory() did NOT fix
+    // this (proot still saw the inherited "/"); doing the chdir in the host shell, right
+    // before exec, makes proot start from a readable cwd. The guest env + args are passed
+    // verbatim to that shell as a single argv.
+    private fun prootCommand(guestEnv: List<String>, guestCommand: String): List<String> {
+        val guestArgv = listOf(
+            layout.proot,
+            "--kill-on-exit",
+            "--link2symlink",           // app storage has no hardlinks; proot fakes them
+            // NOTE: kept to flags the Termux proot build supports. --sysvipc is dropped
+            // (node doesn't need SysV IPC). -L and --kernel-release are likewise omitted as
+            // non-essential (add back only if a specific build is confirmed to accept them).
+            "-r", layout.rootfs,
+            "-0",                       // present as uid 0 inside the guest (fake root)
+            "-b", "/dev",
+            "-b", "/proc",
+            "-b", "/sys",
+            "-b", "${layout.rootfs}/tmp:/dev/shm", // Android has no /dev/shm; bind a guest tmp dir
+            "-w", "/root",
+            "/usr/bin/env", "-i",
+            *guestEnv.toTypedArray(),
+            "/bin/sh", "-lc", guestCommand,
+        )
+        // cd into a readable dir, then exec proot so it never inherits the unreadable "/".
+        val inner = "cd " + shQuote(layout.filesDir) + " && exec " + guestArgv.joinToString(" ") { shQuote(it) }
+        return listOf("/system/bin/sh", "-c", inner)
+    }
+
+    // POSIX single-quote escaping so paths/args with spaces or metacharacters survive the
+    // host shell unmodified ( ' -> '\'' ).
+    private fun shQuote(s: String): String = "'" + s.replace("'", "'\\''") + "'"
+}

--- a/surfaces/android/app/src/main/java/com/iqlabs/agentnet/GuestExec.kt
+++ b/surfaces/android/app/src/main/java/com/iqlabs/agentnet/GuestExec.kt
@@ -6,8 +6,8 @@ package com.iqlabs.agentnet
 //
 // Today there is exactly one strategy, DirectProotExec, which runs the stock proot launch
 // and therefore needs the targetSdk<=28 W^X exemption to exec the guest's binaries out of
-// app storage. Module 3 (plans/raise-targetsdk-exec.md) adds a linker-routing strategy for
-// targetSdk>=29; when it exists the selection point in ServerManager gains a second case.
+// app storage. A linker-routing strategy for targetSdk>=29 (routing exec through the system
+// linker) will add a second case at the selection point in ServerManager.
 interface GuestExec {
     // Launch `guestCommand` inside the guest via its login shell, with `guestEnv` as the
     // guest process environment ("KEY=VALUE" entries). Returns a live host Process with

--- a/surfaces/android/app/src/main/java/com/iqlabs/agentnet/GuestExec.kt
+++ b/surfaces/android/app/src/main/java/com/iqlabs/agentnet/GuestExec.kt
@@ -1,0 +1,17 @@
+package com.iqlabs.agentnet
+
+// The single seam through which the proot guest is launched. A strategy owns HOW guest
+// binaries are exec'd; the caller (ServerManager) expresses only WHAT to run — a guest
+// command plus the guest process environment — and never learns which strategy is active.
+//
+// Today there is exactly one strategy, DirectProotExec, which runs the stock proot launch
+// and therefore needs the targetSdk<=28 W^X exemption to exec the guest's binaries out of
+// app storage. Module 3 (plans/raise-targetsdk-exec.md) adds a linker-routing strategy for
+// targetSdk>=29; when it exists the selection point in ServerManager gains a second case.
+interface GuestExec {
+    // Launch `guestCommand` inside the guest via its login shell, with `guestEnv` as the
+    // guest process environment ("KEY=VALUE" entries). Returns a live host Process with
+    // stdout and stderr merged. The caller owns lifecycle (log draining, stop); the strategy
+    // owns guest entry and all host-side mechanics.
+    fun launch(guestEnv: List<String>, guestCommand: String): Process
+}

--- a/surfaces/android/app/src/main/java/com/iqlabs/agentnet/Installer.kt
+++ b/surfaces/android/app/src/main/java/com/iqlabs/agentnet/Installer.kt
@@ -24,7 +24,13 @@ import java.io.File
 class Installer(private val ctx: Context) {
     companion object {
         private const val TAG = "AgentNet/Installer"
-        private const val MARKER = ".installed-v2"
+        // Bumped v2 -> v3 to force a one-time rootfs re-extraction on existing installs:
+        // the hardlink-extraction fix (guest-absolute symlinks) lives in how the rootfs is
+        // unpacked, so binaries like claude stay broken until the rootfs is laid down again.
+        // The MARKER only re-extracts on a fresh marker, so bumping it is the only way the
+        // fix reaches devices that update in place. Re-extract is from the bundled tar (no
+        // network download).
+        private const val MARKER = ".installed-v3"
         // Server bundle is small and changes every app build; its marker holds the app's
         // versionCode so an APK update re-extracts ONLY the server bundle (the heavy
         // rootfs is left alone). Without this, the idempotent MARKER froze the server

--- a/surfaces/android/app/src/main/java/com/iqlabs/agentnet/ServerManager.kt
+++ b/surfaces/android/app/src/main/java/com/iqlabs/agentnet/ServerManager.kt
@@ -17,7 +17,7 @@ import java.net.URL
 // ServerManager owns WHAT runs (the node server command + its guest environment) and the
 // process lifecycle (log draining, readiness poll, stop). HOW the guest is entered — the
 // proot invocation, loader, seccomp policy, pointer-tag-safe libs — lives behind GuestExec
-// (DirectProotExec today; a linker-routing strategy for modern targetSdk in Module 3).
+// (DirectProotExec today; a linker-routing strategy for modern targetSdk later).
 class ServerManager(private val ctx: Context) {
     companion object {
         private const val TAG = "AgentNet/Server"
@@ -73,8 +73,8 @@ class ServerManager(private val ctx: Context) {
         val layout = Paths.layout(ctx)
         // `node` resolves from the guest PATH; the bundle is at /root/agentnet-server.
         val cmd = "exec node /root/agentnet-server/index.js"
-        // One guest-launch seam. DirectProotExec is the only strategy today; Module 3 adds
-        // the modern-targetSdk selection here (plans/raise-targetsdk-exec.md).
+        // One guest-launch seam. DirectProotExec is the only strategy today; a modern-targetSdk
+        // strategy will add its selection here.
         val proc = DirectProotExec(layout).launch(buildGuestEnv(), cmd)
         process = proc
 

--- a/surfaces/android/app/src/main/java/com/iqlabs/agentnet/ServerManager.kt
+++ b/surfaces/android/app/src/main/java/com/iqlabs/agentnet/ServerManager.kt
@@ -2,7 +2,6 @@ package com.iqlabs.agentnet
 
 import android.content.Context
 import android.os.Build
-import android.system.Os
 import android.util.Log
 import java.io.BufferedReader
 import java.io.File
@@ -12,18 +11,13 @@ import java.net.URL
 
 // Runs our localhost node server INSIDE a proot-distro Ubuntu guest, then waits for it
 // to answer on 127.0.0.1. This is the Android form of vscode's extension host: same
-// node bundle, same HTTP-RPC + SSE transport, just launched through proot so the glibc
+// node bundle, same HTTP-RPC + SSE transport, just launched through the guest so the glibc
 // node + official claude/codex binaries run on Android.
 //
-// proot (not the agent) is what makes glibc binaries work here: it ptrace-remaps the
-// guest's "/lib, /usr, /etc" onto the rootfs in app storage, so node/claude/codex see
-// a normal Linux. seccomp acceleration is LEFT ON (we never set PROOT_NO_SECCOMP) —
-// that keeps the per-syscall overhead small, which is why an agent's network-bound
-// chat workload feels fine despite proot.
-//
-// Mechanics (ProcessBuilder + bg log thread + HTTP readiness poll) adapted from
-// AnyClaw (friuns2/openclaw-android-assistant, MIT). The OpenClaw/Codex-specific
-// install steps are NOT copied — our engine is the official CLIs in the proot guest.
+// ServerManager owns WHAT runs (the node server command + its guest environment) and the
+// process lifecycle (log draining, readiness poll, stop). HOW the guest is entered — the
+// proot invocation, loader, seccomp policy, pointer-tag-safe libs — lives behind GuestExec
+// (DirectProotExec today; a linker-routing strategy for modern targetSdk in Module 3).
 class ServerManager(private val ctx: Context) {
     companion object {
         private const val TAG = "AgentNet/Server"
@@ -32,19 +26,9 @@ class ServerManager(private val ctx: Context) {
     @Volatile private var process: Process? = null
     val isRunning: Boolean get() = process?.isAlive == true
 
-    // Build the proot invocation that enters the Ubuntu guest and runs `cmd` as a
-    // login shell. Flags mirror proot-distro's defaults; --kill-on-exit ties guest
-    // processes to ours so nothing is orphaned, --link2symlink/--sysvipc are guest
-    // compatibility, and /dev,/proc,/sys are bound through from Android.
-    // We launch proot through a host /system/bin/sh that first `cd`s into filesDir, then
-    // `exec`s proot. This is load-bearing: an Android app process has cwd = "/", which is
-    // unreadable under SELinux, so proot's startup getcwd() fails ("sh: 0: getcwd()
-    // failed") and a broken cwd propagates into the guest — node then dies with
-    // `ENOSYS: uv_cwd` before our server loads. ProcessBuilder.directory() did NOT fix
-    // this (proot still saw the inherited "/"); doing the chdir in the host shell, right
-    // before exec, makes proot start from a readable cwd. The guest args are passed
-    // verbatim to that shell as a single argv.
-    private fun prootCommand(p: Paths.Layout, cmd: String): List<String> {
+    // The guest process environment passed to `env -i` inside the guest. This is the node
+    // server's runtime config, independent of how the guest is entered.
+    private fun buildGuestEnv(): List<String> {
         val googleClientIdEnv =
             if (BuildConfig.GOOGLE_OAUTH_CLIENT_ID.isBlank()) emptyList()
             else listOf("GOOGLE_CLIENT_ID=${BuildConfig.GOOGLE_OAUTH_CLIENT_ID}")
@@ -53,21 +37,7 @@ class ServerManager(private val ctx: Context) {
             "GOOGLE_ACCESS_TOKEN_URL=http://127.0.0.1:${Paths.GOOGLE_AUTH_PORT}/google-drive/token",
             "GOOGLE_AUTH_STATUS_URL=http://127.0.0.1:${Paths.GOOGLE_AUTH_PORT}/google-drive/status",
         )
-        val guestArgv = listOf(
-            p.proot,
-            "--kill-on-exit",
-            "--link2symlink",           // app storage has no hardlinks; proot fakes them
-            // NOTE: kept to flags the Termux proot build supports. --sysvipc is dropped
-            // (node doesn't need SysV IPC). -L and --kernel-release are likewise omitted as
-            // non-essential (add back only if a specific build is confirmed to accept them).
-            "-r", p.rootfs,
-            "-0",                       // present as uid 0 inside the guest (fake root)
-            "-b", "/dev",
-            "-b", "/proc",
-            "-b", "/sys",
-            "-b", "${p.rootfs}/tmp:/dev/shm", // Android has no /dev/shm; bind a guest tmp dir
-            "-w", "/root",
-            "/usr/bin/env", "-i",
+        return listOf(
             "HOME=/root",
             "USER=root",
             "PATH=/usr/local/sbin:/usr/local/bin:/usr/sbin:/usr/bin:/sbin:/bin:/usr/local/games:/usr/games",
@@ -90,18 +60,8 @@ class ServerManager(private val ctx: Context) {
             // this only disables the Codex "plugins" feature for the Android app-server.
             "AGENTNET_CODEX_DISABLE_PLUGINS=1",
             "AGENTNET_DEVICE_LABEL=${Build.MANUFACTURER} ${Build.MODEL} (Android)",
-            *googleClientIdEnv.toTypedArray(),
-            *googleNativeAuthEnv.toTypedArray(),
-            "/bin/sh", "-lc", cmd,
-        )
-        // cd into a readable dir, then exec proot so it never inherits the unreadable "/".
-        val inner = "cd " + shQuote(p.filesDir) + " && exec " + guestArgv.joinToString(" ") { shQuote(it) }
-        return listOf("/system/bin/sh", "-c", inner)
+        ) + googleClientIdEnv + googleNativeAuthEnv
     }
-
-    // POSIX single-quote escaping so paths/args with spaces or metacharacters survive the
-    // host shell unmodified ( ' -> '\'' ).
-    private fun shQuote(s: String): String = "'" + s.replace("'", "'\\''") + "'"
 
     // Start node on our localhost bundle inside the guest. Returns once the process is
     // spawned; call waitForServer() to block until it actually serves.
@@ -110,66 +70,12 @@ class ServerManager(private val ctx: Context) {
             Log.i(TAG, "server already running")
             return true
         }
-        val p = Paths.layout(ctx)
+        val layout = Paths.layout(ctx)
         // `node` resolves from the guest PATH; the bundle is at /root/agentnet-server.
         val cmd = "exec node /root/agentnet-server/index.js"
-        // prootCommand wraps the launch in `sh -c 'cd <filesDir> && exec proot …'`, so the
-        // host cwd is already pinned to a readable dir before proot runs (see the comment
-        // there). That's what stops the `getcwd() failed → ENOSYS: uv_cwd` crash.
-        val pb = ProcessBuilder(prootCommand(p, cmd))
-
-        // Host-side env for the proot PROCESS (not the guest). These are load-bearing:
-        val env = pb.environment()
-        env["PROOT_LOADER"] = p.loader            // proot's own ELF loader helper
-        env["PROOT_LOADER_32"] = p.loader32       // 32-bit loader (guest is 64-bit; set anyway)
-        // proot is the Termux build (process_vm=yes), dynamically linked against
-        // libtalloc.so.2 + libandroid-shmem.so. Those now ship under jniLibs and the OS
-        // extracts them into nativeLibraryDir — so point LD_LIBRARY_PATH there. jniLibs only
-        // packages files named lib*.so, so the versioned libtalloc.so.2 had to ship as
-        // libtalloc.so; but proot's DT_NEEDED still asks for the soname "libtalloc.so.2", so
-        // we hang a symlink with that exact name in a writable dir and put it FIRST on the
-        // search path. (Why this proot: process_vm_readv strips arm64 top-byte pointer tags,
-        // avoiding the PEEKDATA "I/O error" on tagged addresses that broke the sandbox on
-        // tag-enabled devices like the Solana Seeker. Full root cause: AndroidManifest.)
-        val sonameShim = Paths.dir("${p.filesDir}/proot-soname")
-        val talloc2 = File(sonameShim, "libtalloc.so.2")
-        val tallocTarget = "${p.nativeLibDir}/libtalloc.so"
-        // nativeLibDir changes on every (re)install, so a symlink left by a PRIOR install points
-        // at a path that no longer exists. File.exists() follows the link → false for that stale
-        // one, yet Os.symlink would then fail EEXIST (the link file is still there) and never get
-        // recreated — leaving proot unable to resolve libtalloc.so.2 and the server stuck on boot
-        // after every reinstall. Recreate whenever the link is missing OR doesn't already point at
-        // the CURRENT target, so a fresh install / upgrade self-heals without manual intervention.
-        val curTarget = runCatching { Os.readlink(talloc2.absolutePath) }.getOrNull()
-        if (curTarget != tallocTarget) {
-            runCatching {
-                talloc2.delete() // drop any stale link/file before relinking
-                Os.symlink(tallocTarget, talloc2.absolutePath)
-            }.onFailure { Log.w(TAG, "could not create libtalloc.so.2 soname symlink", it) }
-        }
-        env["LD_LIBRARY_PATH"] =
-            listOfNotNull(sonameShim.absolutePath, p.nativeLibDir, env["LD_LIBRARY_PATH"])
-                .joinToString(":")
-        // PROOT_NO_SECCOMP: Android 12+/15 tighten the seccomp filter (e.g. set_robust_list
-        // blocked), which makes glibc/node crash with SIGSYS under proot's seccomp fast
-        // path. Turning seccomp off trades the speed win for "it runs at all" — necessary
-        // on newer Android. (If a target kernel is fine with seccomp, dropping this would
-        // be faster; that's an on-device measurement, see project memory.)
-        // DO NOT set PROOT_NO_SECCOMP. It forces proot to ptrace-intercept and translate
-        // EVERY syscall, including getcwd → readlink("/proc/self/cwd"). In the
-        // untrusted_app SELinux domain /proc/<pid> is restricted, so that readlink fails
-        // and getcwd returns ENOSYS — node then dies with `ENOSYS: uv_cwd` at startup
-        // (the claude SDK calls process.cwd() at import time, before our server loads).
-        // With seccomp acceleration ON (the default), getcwd runs natively in the kernel,
-        // never touches /proc, and the server boots cleanly. Verified on-device: Samsung
-        // SM-F711N (Snapdragon), Android 13 — server reaches HTTP 200, no SIGSYS.
-        // (The earlier belief that newer Android needs NO_SECCOMP for set_robust_list was
-        // wrong for this path; seccomp-on is both correct AND faster.)
-        env["PROOT_TMP_DIR"] = Paths.dir("${p.rootfs}/tmp").absolutePath
-        env["PROOT_L2S_DIR"] = Paths.dir("${p.rootfs}/.l2s").absolutePath // stable link2symlink db
-        pb.redirectErrorStream(true)
-
-        val proc = pb.start()
+        // One guest-launch seam. DirectProotExec is the only strategy today; Module 3 adds
+        // the modern-targetSdk selection here (plans/raise-targetsdk-exec.md).
+        val proc = DirectProotExec(layout).launch(buildGuestEnv(), cmd)
         process = proc
 
         // Drain stdout/stderr to logcat so server errors are visible (otherwise a

--- a/surfaces/android/app/src/main/java/com/iqlabs/agentnet/TarExtractor.kt
+++ b/surfaces/android/app/src/main/java/com/iqlabs/agentnet/TarExtractor.kt
@@ -70,10 +70,17 @@ object TarExtractor {
                         clobber(target) // a dir/file may already sit here; remove it first
                         runCatching { Os.symlink(linkName, target.absolutePath) }
                     }
-                    '1' -> { // hardlink: fall back to a symlink into the same rootfs
+                    '1' -> { // hardlink: app storage has no hardlinks, so emulate with a symlink.
+                        // The tar stores the link target relative to the rootfs ROOT (e.g.
+                        // "./usr/bin/x"), so point the symlink at the GUEST-absolute path ("/usr/bin/x")
+                        // — that is what resolves inside proot's remapped root. The host-absolute path
+                        // (dest + linkName, e.g. /data/.../rootfs/usr/bin/x) resolves on the host but
+                        // DANGLES inside the guest, which is what broke `claude` (a hardlink to its
+                        // native binary) with spawn ENOENT.
                         ensureDirectory(target.parentFile)
                         clobber(target)
-                        runCatching { Os.symlink(File(dest, linkName).absolutePath, target.absolutePath) }
+                        val guestTarget = "/" + linkName.removePrefix("./").removePrefix("/")
+                        runCatching { Os.symlink(guestTarget, target.absolutePath) }
                     }
                     '0', ' ' -> { // regular file
                         ensureDirectory(target.parentFile)


### PR DESCRIPTION
## Summary

Prepares the Android surface for a modern `targetSdk` (Play eligibility) **without changing
the shipping build**, and fixes a pre-existing bug that left `claude` unrunnable in the guest.

- **Build flavors** `legacy` (targetSdk 28) and `modern` (targetSdk 35). `legacy` stays the
  public default and is byte-for-byte the previous config plus one `BuildConfig` field.
- **GuestExec seam** — a pure refactor that isolates *how* a guest process is launched
  (proot flags/loader/seccomp) from *what* is launched (node command + guest env). Generated
  proot argv and host env are identical to before.
- **Hardlink extraction fix** — tar hardlinks were materialized as **host-absolute** symlinks
  that dangle inside the proot guest, so `claude` failed with `spawn ENOENT`. Now they resolve
  to **guest-absolute** paths. Install marker bumped `v2 → v3` to force a one-time rootfs
  re-extraction so the fix reaches in-place updates (from the bundled tar, no network download).
- **CI** builds the proven `legacy` flavor and re-uploads under the existing `app-debug.apk`
  name so the public download link keeps working after the flavor split.

`modern` is validated on hardware (Solana Seeker, Android 16) but is **not** the public
download yet — it ships behind the flavor until a broader device pass completes.

## Guest-launch path and where each change sits

```mermaid
flowchart TD
    UI["WebView UI"] -->|"localhost HTTP 200"| SM["ServerManager<br/>(guest env + lifecycle)"]
    SM -->|"delegates launch"| GE{{"GuestExec"}}
    GE --> DPE["DirectProotExec<br/>(proot flags / loader / seccomp)"]
    DPE --> PROOT["proot — libproot.so<br/>from nativeLibDir"]
    PROOT -->|"loads guest via its own loader mmap"| NODE["node"]
    NODE --> CODEX["codex"]
    NODE --> CLAUDE["claude"]

    N1["NEW: GuestExec seam (pure refactor)"]:::new -.-> GE
    N2["NEW: legacy/modern targetSdk flavors"]:::new -.-> SM
    FX["FIX: hardlink -> guest-abs symlink + marker v3"]:::fix -.-> CLAUDE

    classDef new fill:#e6f0ff,stroke:#3b82f6,color:#111;
    classDef fix fill:#ffe9e6,stroke:#ef4444,color:#111;
```

## Why the targetSdk bump is safe (risk model)

```mermaid
flowchart LR
    A["targetSdk 28 -> 35"] --> B{"App-storage exec<br/>blocked by W^X?"}
    B -->|"we never direct-execve<br/>guest binaries"| C["N/A"]
    B -->|"proot loads the guest via<br/>its own loader mmap"| D{"mmap survives<br/>targetSdk 35 SELinux?"}
    D -->|"Seeker A16 + pointer tagging:<br/>HTTP 200, node/codex/claude run"| E["PASS — Track A<br/>(no exec-rewrite code needed)"]
    D -->|"other vendors / versions"| F["pending device matrix<br/>(Pixel, Samsung, A13/14)"]
```

## Change set

| Area | File | Note |
|---|---|---|
| Flavors | `app/build.gradle.kts` | `legacy(28)` / `modern(35)`, `EXEC_TARGET`; same appId + signing |
| Seam | `GuestExec.kt`, `DirectProotExec.kt` (new), `ServerManager.kt` (−113) | behavior-preserving |
| Fix | `TarExtractor.kt` | hardlink -> guest-absolute symlink |
| Fix reach | `Installer.kt` | marker `v2 -> v3` (one-time re-extract) |
| CI | `.github/workflows/android-apk.yml` | build `legacy`, keep `app-debug.apk` name |
| Docs | `surfaces/android/README.md` | flavor note |

## Validation

- Solana Seeker (MediaTek MT6878, Android 16, `modern`/targetSdk 35): server HTTP 200; node,
  codex, and claude all run under proot; no exec/mmap SELinux denials for our binaries.
- Both flavors build; merged manifest confirms targetSdk 28/35; `legacy` config unchanged.
- claude fix confirmed on device: after re-extract, `claude.exe` resolves to a guest-absolute
  path (was host-absolute -> dangling).

## Not in this PR

- Flipping `modern` to the public default (needs the device matrix above).
- Any exec-rewrite / linker-shim / nativeLibDir migration — the probe showed Track A needs none.
