### PR TITLE
Adopt targetSdk 35 as standard + Play release AAB pipeline

### DIFF
--- a/.github/workflows/android-apk.yml
+++ b/.github/workflows/android-apk.yml
@@ -135,15 +135,12 @@ jobs:
           KS_B64: ${{ secrets.ANDROID_DEBUG_KEYSTORE_B64 }}
         run: printf '%s' "$KS_B64" | base64 -d > surfaces/android/agentnet-debug.keystore
 
-      # Ship the `legacy` flavor (targetSdk 28): it keeps the pre-29 W^X exemption that runs
-      # node + the proot guest's binaries from app storage, and is the proven, on-device-tested
-      # variant. The `modern` flavor (targetSdk 35) is validated on hardware but not yet the
-      # public download — build it explicitly here only once it is. Do NOT use bare
-      # `assembleDebug`: with flavors it builds BOTH variants and writes to per-flavor dirs,
-      # so the output path below would no longer resolve.
+      # Single variant now: the app targets SDK 35 (our standard). proot loads the guest binaries
+      # via its own loader mmap, which survives the targetSdk 35 SELinux W^X policy (verified on
+      # device), so there is no separate legacy target to build.
       - name: Build signed debug APK
         working-directory: surfaces/android
-        run: ./gradlew --no-daemon assembleLegacyDebug
+        run: ./gradlew --no-daemon assembleDebug
 
       # SHA-1 is a public fingerprint (not the key), safe to log — proves the team key signed it.
       - name: Print signing SHA-1
@@ -157,22 +154,19 @@ jobs:
       - uses: actions/upload-artifact@v4
         with:
           name: agentnet-apk-${{ env.ABI }}
-          path: surfaces/android/app/build/outputs/apk/legacy/debug/app-legacy-debug.apk
+          path: surfaces/android/app/build/outputs/apk/debug/app-debug.apk
           retention-days: 7
           if-no-files-found: error
 
       # Publish to the rolling `android-latest` release so the public download link
       # (.../releases/download/android-latest/app-debug.apk) always serves the newest build.
-      # arm64 only, so a manual x86_64 build doesn't clobber the shareable arm64 APK.
-      # The flavor split names the file app-legacy-debug.apk, but the public download URL is keyed
-      # by the asset NAME, which must stay app-debug.apk. gh's `file#label` syntax only sets the
-      # label (not the name), so copy the file to app-debug.apk and upload that — then --clobber
-      # replaces the existing asset in place and the shared URL keeps working.
+      # arm64 only, so a manual x86_64 build doesn't clobber the shareable arm64 APK. The build now
+      # outputs app-debug.apk directly (single variant), so the asset NAME the public URL is keyed
+      # by is already correct — upload it as-is and --clobber replaces the asset in place.
       - name: Update android-latest release
         if: env.ABI == 'arm64'
         run: |
-          cp surfaces/android/app/build/outputs/apk/legacy/debug/app-legacy-debug.apk app-debug.apk
           gh release view android-latest >/dev/null 2>&1 \
             || gh release create android-latest --title "AgentNet Android (latest)" --latest \
                  --notes "Auto-built from main. Download app-debug.apk and install (allow unknown sources)."
-          gh release upload android-latest app-debug.apk --clobber
+          gh release upload android-latest surfaces/android/app/build/outputs/apk/debug/app-debug.apk --clobber

--- a/.github/workflows/android-release.yml
+++ b/.github/workflows/android-release.yml
@@ -1,0 +1,162 @@
+# Build a SIGNED release AAB (Android App Bundle) for Google Play closed/production testing.
+#
+# This is DELIBERATELY separate from android-apk.yml:
+#   - android-apk.yml  -> debug-signed APK, auto-built on every main push, for sideload sharing.
+#   - android-release.yml (this) -> release-signed AAB, MANUAL only, for uploading to Play.
+# Play requires an AAB (not APK), a recent targetSdk, and a real release key — none of which the
+# debug pipeline produces. The app targets SDK 35 (our standard) so it clears Play's minimum-target
+# bar. The AAB is uploaded ONLY as a workflow artifact — never to
+# the public android-latest release (an AAB is not directly installable, and Play uploads are a
+# deliberate human step, not an automatic push).
+#
+# Required repo secrets (the UPLOAD key — Google re-signs with the Play-managed app key on top):
+#   ANDROID_RELEASE_KEYSTORE_B64    base64 of the upload keystore (`base64 -i upload.jks`)
+#   ANDROID_RELEASE_STORE_PASSWORD  keystore password
+#   ANDROID_RELEASE_KEY_ALIAS       key alias inside the keystore
+#   ANDROID_RELEASE_KEY_PASSWORD    key password
+# The uploaded AAB carries only the public cert + signature, so the artifact is safe to download.
+# Manual trigger only, so these secrets are never exposed to untrusted (fork PR) code.
+
+name: android-release
+
+on:
+  workflow_dispatch:
+    inputs:
+      abi:
+        description: "Target ABI (arm64 = real phones; x86_64 = emulator only)"
+        type: choice
+        options: ["arm64", "x86_64"]
+        default: "arm64"
+      version_code:
+        description: "Play versionCode (must increase every upload; blank = use run number)"
+        required: false
+        default: ""
+      version_name:
+        description: "User-visible version name (blank = keep gradle default)"
+        required: false
+        default: ""
+      assets_run_id:
+        description: "android-assets run id to reuse (blank = latest successful)"
+        required: false
+        default: ""
+
+permissions:
+  contents: read
+  actions: read
+
+jobs:
+  build:
+    runs-on: ubuntu-latest
+    env:
+      ABI: ${{ github.event.inputs.abi || 'arm64' }}
+      GH_TOKEN: ${{ github.token }}
+    steps:
+      - uses: actions/checkout@v4
+
+      # Fail fast if the release signing secrets are missing — otherwise gradle would produce an
+      # UNSIGNED AAB (signingConfig resolves to null), which Play rejects with a confusing error.
+      - name: Require release signing secrets
+        env:
+          KS_B64: ${{ secrets.ANDROID_RELEASE_KEYSTORE_B64 }}
+          STORE_PW: ${{ secrets.ANDROID_RELEASE_STORE_PASSWORD }}
+          KEY_ALIAS: ${{ secrets.ANDROID_RELEASE_KEY_ALIAS }}
+          KEY_PW: ${{ secrets.ANDROID_RELEASE_KEY_PASSWORD }}
+        run: |
+          missing=""
+          [ -z "$KS_B64" ]   && missing="$missing ANDROID_RELEASE_KEYSTORE_B64"
+          [ -z "$STORE_PW" ] && missing="$missing ANDROID_RELEASE_STORE_PASSWORD"
+          [ -z "$KEY_ALIAS" ] && missing="$missing ANDROID_RELEASE_KEY_ALIAS"
+          [ -z "$KEY_PW" ]   && missing="$missing ANDROID_RELEASE_KEY_PASSWORD"
+          if [ -n "$missing" ]; then
+            echo "::error::Missing release signing secrets:$missing (see android-release.yml header)"
+            exit 1
+          fi
+
+      # Lightweight, arch-independent JS — rebuilt every run so the AAB carries the latest UI.
+      - uses: pnpm/action-setup@v4
+        with: { version: 9 }
+      - uses: actions/setup-node@v4
+        with: { node-version: 22, cache: pnpm }
+      - run: pnpm install --frozen-lockfile
+      - run: pnpm --filter agentnet-localhost build
+      - run: pnpm --filter agentnet-webview build
+
+      # Reuse the rootfs + jniLibs from the latest android-assets run (no QEMU rebuild). Same
+      # resolution logic as android-apk.yml: walk recent successful runs, take the first whose
+      # per-ABI artifact hasn't expired.
+      - name: Resolve android-assets run
+        id: assets
+        run: |
+          ID="${{ github.event.inputs.assets_run_id }}"
+          if [ -z "$ID" ]; then
+            for cand in $(gh run list --workflow=android-assets.yml --status success -L 15 \
+                            --json databaseId -q '.[].databaseId' || true); do
+              live=$(gh api "repos/${{ github.repository }}/actions/runs/$cand/artifacts" \
+                       -q ".artifacts[] | select(.name==\"android-assets-${ABI}\" and .expired==false) | .id" \
+                       2>/dev/null | head -1 || true)
+              if [ -n "$live" ]; then ID="$cand"; break; fi
+            done
+          fi
+          if [ -z "$ID" ]; then
+            echo "::error::No android-assets run with a live android-assets-${ABI} artifact. Run android-assets first."
+            exit 1
+          fi
+          echo "Using android-assets run $ID"
+          echo "id=$ID" >> "$GITHUB_OUTPUT"
+
+      - name: Download rootfs + jniLibs
+        run: gh run download "${{ steps.assets.outputs.id }}" -n "android-assets-${ABI}" -D ci-assets
+
+      - name: Stage assets into the source tree
+        run: |
+          set -e
+          mkdir -p surfaces/android/app/src/main/assets
+          rm -rf surfaces/android/app/src/main/jniLibs
+          cp -R ci-assets/jniLibs surfaces/android/app/src/main/jniLibs
+          cp ci-assets/assets/rootfs-*.tar surfaces/android/app/src/main/assets/
+          STAGE="$(mktemp -d)/server-bundle"
+          mkdir -p "$STAGE/webview"
+          cp -R surfaces/localhost/dist/. "$STAGE/"
+          cp -R surfaces/webview/dist/. "$STAGE/webview/"
+          tar -cf surfaces/android/app/src/main/assets/agentnet-server.tar -C "$STAGE" .
+          ls -lh surfaces/android/app/src/main/assets/
+
+      - uses: actions/setup-java@v4
+        with: { distribution: temurin, java-version: 17 }
+
+      # Decode the upload keystore into a path gradle reads via ANDROID_RELEASE_KEYSTORE. Removed at
+      # job end; GitHub-hosted runners are ephemeral and isolated.
+      - name: Install release keystore
+        env:
+          KS_B64: ${{ secrets.ANDROID_RELEASE_KEYSTORE_B64 }}
+        run: printf '%s' "$KS_B64" | base64 -d > surfaces/android/agentnet-upload.keystore
+
+      - name: Build signed release AAB (targetSdk 35)
+        working-directory: surfaces/android
+        env:
+          ANDROID_RELEASE_KEYSTORE: agentnet-upload.keystore
+          ANDROID_RELEASE_STORE_PASSWORD: ${{ secrets.ANDROID_RELEASE_STORE_PASSWORD }}
+          ANDROID_RELEASE_KEY_ALIAS: ${{ secrets.ANDROID_RELEASE_KEY_ALIAS }}
+          ANDROID_RELEASE_KEY_PASSWORD: ${{ secrets.ANDROID_RELEASE_KEY_PASSWORD }}
+          ANDROID_VERSION_CODE: ${{ github.event.inputs.version_code || github.run_number }}
+          ANDROID_VERSION_NAME: ${{ github.event.inputs.version_name }}
+        run: ./gradlew --no-daemon bundleRelease
+
+      - name: Remove keystore
+        if: always()
+        run: rm -f surfaces/android/agentnet-upload.keystore
+
+      # Confirm the AAB really is signed before handing it off (catches a silently-unsigned build).
+      - name: Verify AAB is signed
+        run: |
+          AAB=surfaces/android/app/build/outputs/bundle/release/app-release.aab
+          ls -lh "$AAB"
+          unzip -l "$AAB" | grep -E "META-INF/.*\.(RSA|EC|DSA)" \
+            || { echo "::error::AAB has no signature block — check the release secrets"; exit 1; }
+
+      - uses: actions/upload-artifact@v4
+        with:
+          name: agentnet-aab-${{ env.ABI }}
+          path: surfaces/android/app/build/outputs/bundle/release/app-release.aab
+          retention-days: 30
+          if-no-files-found: error

--- a/.gitignore
+++ b/.gitignore
@@ -18,4 +18,5 @@ apk/
 plans/raise-targetsdk-exec.md
 plans/modern-rollout-testing.md
 plans/PR-modern-targetsdk.md
+plans/play-release-setup.md
 surfaces/android/scripts/probe-modern-exec.sh

--- a/surfaces/android/README.md
+++ b/surfaces/android/README.md
@@ -24,8 +24,8 @@ the per-syscall overhead small — fine for the network-bound agent-chat workloa
 surfaces/android/
   settings.gradle.kts, build.gradle.kts, gradle.properties
   app/
-    build.gradle.kts          legacy/modern flavors: targetSdk 28 (W^X exemption to exec
-                              from app storage) vs 35 (modern-target bring-up)
+    build.gradle.kts          targetSdk 35; guest runs under proot (its loader mmap
+                              survives the W^X policy, verified on device)
     src/main/
       AndroidManifest.xml
       java/com/iqlabs/agentnet/

--- a/surfaces/android/app/build.gradle.kts
+++ b/surfaces/android/app/build.gradle.kts
@@ -24,41 +24,25 @@ android {
     defaultConfig {
         applicationId = "com.iqlabs.agentnet"
         minSdk = 24
-        versionCode = 1
-        versionName = "0.1.0"
+        // targetSdk 35 is our standard. We never direct-execve guest binaries; proot loads them via
+        // its own loader mmap, which survives the targetSdk 35 SELinux W^X policy. Verified on device
+        // (Seeker / Android 16 + pointer tagging, a worst-case target): node, codex and claude all
+        // ran with no exec/mmap denials, so no linker-exec routing is needed. This is the same
+        // approach Play-Store Termux uses to run a proot-distro glibc userland at target 29+. minSdk
+        // stays 24 so older phones still install; appId + signing are unchanged, so shipping this is
+        // an in-place upgrade over the older targetSdk-28 build and never wipes the user's rootfs.
+        targetSdk = 35
+        // Play requires a strictly increasing versionCode for every upload to a track. CI passes
+        // the next number via ANDROID_VERSION_CODE; local/debug builds fall back to 1 unchanged.
+        versionCode = (providers.environmentVariable("ANDROID_VERSION_CODE").orNull
+            ?: localProperties.getProperty("versionCode"))?.toInt() ?: 1
+        versionName = providers.environmentVariable("ANDROID_VERSION_NAME").orNull
+            ?: localProperties.getProperty("versionName", "0.1.0")
         buildConfigField(
             "String",
             "GOOGLE_OAUTH_CLIENT_ID",
             "\"${googleOAuthClientId.replace("\\", "\\\\").replace("\"", "\\\"")}\""
         )
-    }
-
-    // targetSdk is a per-flavor dimension, not a fixed value, so one codebase ships both the
-    // proven legacy engine and the modern-target variant we are bringing up. applicationId and
-    // signing stay IDENTICAL across flavors, so switching flavor is an in-place upgrade that
-    // never wipes the user's rootfs — do not add an applicationIdSuffix.
-    flavorDimensions += "execTarget"
-    productFlavors {
-        create("legacy") {
-            dimension = "execTarget"
-            // targetSdk 28 is load-bearing here: Android 10+ (target 29+) enforces SELinux W^X,
-            // which blocks executing binaries extracted into app data. We run node + the proot
-            // guest's binaries from app storage, so the legacy flavor keeps the pre-29 exemption.
-            // Termux (F-Droid) pins the same target for the same reason. This is today's shipping
-            // behavior; keep it unchanged until the modern flavor proves out.
-            targetSdk = 28
-            buildConfigField("String", "EXEC_TARGET", "\"legacy\"")
-        }
-        create("modern") {
-            dimension = "execTarget"
-            // targetSdk 35 gives up the W^X exemption on purpose. This flavor is where we bring up
-            // a modern target: guest exec will be routed through /system/bin/linker64 (the
-            // system_linker_exec technique) so app-storage binaries still run. Until that routing
-            // lands, guest binaries are EXPECTED to fail to exec at runtime here — that failure is
-            // the signal we are probing for, not a regression.
-            targetSdk = 35
-            buildConfigField("String", "EXEC_TARGET", "\"modern\"")
-        }
     }
 
     buildFeatures {
@@ -84,6 +68,29 @@ android {
         }
     }
 
+    // Release signing = the Play "upload key". Fully env-driven so the private key NEVER lives in
+    // this public repo: CI decodes the keystore from a secret and exports these vars; locally you
+    // can put the same values in local.properties. Unlike the debug keystore, the passwords ARE
+    // secrets, so there is no hardcoded fallback. When none of this is set (every normal build),
+    // no release signing config is created and a release build stays unsigned — nothing else
+    // changes. Google re-signs the uploaded AAB with the Play-managed app key (Play App Signing),
+    // so this upload key can be rotated without breaking installs.
+    val releaseStoreFile = (providers.environmentVariable("ANDROID_RELEASE_KEYSTORE").orNull
+        ?: localProperties.getProperty("releaseKeystore"))?.let { rootProject.file(it) }
+    if (releaseStoreFile != null && releaseStoreFile.exists()) {
+        signingConfigs {
+            create("release") {
+                storeFile = releaseStoreFile
+                storePassword = providers.environmentVariable("ANDROID_RELEASE_STORE_PASSWORD").orNull
+                    ?: localProperties.getProperty("releaseStorePassword")
+                keyAlias = providers.environmentVariable("ANDROID_RELEASE_KEY_ALIAS").orNull
+                    ?: localProperties.getProperty("releaseKeyAlias")
+                keyPassword = providers.environmentVariable("ANDROID_RELEASE_KEY_PASSWORD").orNull
+                    ?: localProperties.getProperty("releaseKeyPassword")
+            }
+        }
+    }
+
     buildTypes {
         release {
             isMinifyEnabled = false
@@ -91,6 +98,9 @@ android {
                 getDefaultProguardFile("proguard-android-optimize.txt"),
                 "proguard-rules.pro"
             )
+            // Signed only when the release upload key is configured (CI/Play builds); otherwise
+            // findByName returns null and the release build stays unsigned, same as before.
+            signingConfig = signingConfigs.findByName("release")
         }
     }
 


### PR DESCRIPTION
## Summary

Adopt **targetSdk 35 as the single standard** and add a **signed release AAB pipeline** for Google Play closed testing.

On-device testing (Seeker, Android 16 + pointer tagging, a worst-case target) confirmed the guest runs under proot at targetSdk 35 with no exec/mmap denials: proot loads guest binaries via its own loader mmap, which survives the W^X policy, so no linker-exec routing is needed. This is the same mechanism Play-Store Termux uses to run a proot-distro glibc userland at target 29+. Given that, the legacy (targetSdk 28) flavor is no longer worth co-maintaining.

## Changes

- **Drop the legacy/modern flavor split** -> single `defaultConfig.targetSdk = 35`. appId + signing unchanged (in-place upgrade, never wipes the user's rootfs); minSdk stays 24 so older phones still install.
- **`android-apk.yml`** (public sideload pipeline): `assembleDebug` again, output `apk/debug/app-debug.apk`. The public `android-latest` download name is unchanged.
- **`android-release.yml`** (new, manual dispatch): builds a signed release AAB (`bundleRelease`) for Play. Env-driven release signing (upload key never in the repo), overridable versionCode, AAB uploaded as a workflow artifact only.

## Outward-facing note

Merging flips the public sideload `app-debug.apk` from targetSdk 28 to 35. This is an in-place upgrade (rootfs preserved). Cross-vendor safety is backed by the Play Termux fleet evidence and is further gated by Play closed testing (12-16 varied devices for 14 days) before any production release.

## Verification

- `assembleDebug` builds locally and outputs `apk/debug/app-debug.apk` at targetSdk 35 (merged manifest confirmed).
- No source references the removed `EXEC_TARGET`/flavors.
- Both workflow YAMLs validate.
- Full signed-AAB build is first proven when the release secrets are set and the workflow runs.
