### PR TITLE
Keep agent turns running while the phone is locked

### DIFF
--- a/surfaces/android/app/src/main/java/com/iqlabs/agentnet/MainActivity.kt
+++ b/surfaces/android/app/src/main/java/com/iqlabs/agentnet/MainActivity.kt
@@ -12,6 +12,7 @@ import android.content.pm.PackageManager
 import android.net.Uri
 import android.os.Build
 import android.os.Bundle
+import android.os.PowerManager
 import android.util.Log
 import android.webkit.ConsoleMessage
 import android.webkit.WebChromeClient
@@ -45,8 +46,10 @@ class MainActivity : AppCompatActivity() {
         private const val IDENTITY_NAME = "AgentNet"
         private const val IDENTITY_URI = "https://agentnet.iqlabs.com"
         private const val IDENTITY_ICON = "favicon.ico" // relative to IDENTITY_URI
-        private const val APPROVAL_CHANNEL = "agentnet_approval"
+        private const val APPROVAL_CHANNEL = "agentnet_approval_locked_v2"
+        private const val COMPLETION_CHANNEL = "agentnet_completion_locked_v1"
         private const val APPROVAL_NOTIF_ID = 2
+        private const val COMPLETION_NOTIF_ID = 3
         private const val REQ_POST_NOTIFICATIONS = 101
         // Intent extra: which chat to deep-link to when an approval notification is tapped.
         const val EXTRA_OPEN_SESSION = "agentnet.openSession"
@@ -262,7 +265,10 @@ class MainActivity : AppCompatActivity() {
         super.onResume()
         inForeground = true
         // Returning to the app clears any pending approval alert — the WebView shows it now.
-        getSystemService(NotificationManager::class.java)?.cancel(APPROVAL_NOTIF_ID)
+        getSystemService(NotificationManager::class.java)?.let {
+            it.cancel(APPROVAL_NOTIF_ID)
+            it.cancel(COMPLETION_NOTIF_ID)
+        }
     }
 
     override fun onPause() {
@@ -303,8 +309,10 @@ class MainActivity : AppCompatActivity() {
     // Promote/demote the foreground service that keeps this process (and the node runtime)
     // alive while backgrounded. The web UI calls this with `active && backgroundExecEnabled`.
     // `clientId` rides along so the notification's Stop action can reach /rpc.
-    fun setAgentActive(active: Boolean, clientId: String) {
-        val svc = Intent(this, ServerService::class.java).putExtra(ServerService.EXTRA_CLIENT, clientId)
+    fun setAgentActive(active: Boolean, clientId: String, keepWhileLocked: Boolean) {
+        val svc = Intent(this, ServerService::class.java)
+            .putExtra(ServerService.EXTRA_CLIENT, clientId)
+            .putExtra(ServerService.EXTRA_KEEP_WHILE_LOCKED, keepWhileLocked)
         if (active) {
             if (Build.VERSION.SDK_INT >= Build.VERSION_CODES.O) startForegroundService(svc)
             else startService(svc)
@@ -339,9 +347,16 @@ class MainActivity : AppCompatActivity() {
         if (inForeground && !force) return
         val mgr = getSystemService(NotificationManager::class.java) ?: return
         if (Build.VERSION.SDK_INT >= Build.VERSION_CODES.O) {
-            mgr.createNotificationChannel(
-                NotificationChannel(APPROVAL_CHANNEL, "AgentNet approvals", NotificationManager.IMPORTANCE_HIGH)
-            )
+            mgr.createNotificationChannel(NotificationChannel(
+                APPROVAL_CHANNEL,
+                "AgentNet approvals",
+                NotificationManager.IMPORTANCE_HIGH,
+            ).apply {
+                description = "Approval requests from active agent turns"
+                enableVibration(true)
+                vibrationPattern = longArrayOf(0, 220, 140, 220)
+                lockscreenVisibility = Notification.VISIBILITY_PUBLIC
+            })
         }
         // Tap carries the sessionId so the WebView can jump to that chat. A distinct request
         // code per session keeps FLAG_UPDATE_CURRENT from collapsing different chats' extras;
@@ -372,14 +387,67 @@ class MainActivity : AppCompatActivity() {
             .setLargeIcon(Icon.createWithResource(this, R.drawable.iq_logo_green))
             .setContentIntent(tap)
             .setAutoCancel(true)
+            .setCategory(Notification.CATEGORY_REMINDER)
+            .setVisibility(Notification.VISIBILITY_PUBLIC)
+        if (Build.VERSION.SDK_INT < Build.VERSION_CODES.O) {
+            builder.setPriority(Notification.PRIORITY_HIGH).setVibrate(longArrayOf(0, 220, 140, 220))
+        }
         // Only a yes/no approval gets Approve/Reject buttons. A question is answered by picking
         // an option in-app, so the notification just deep-links there on tap (no actions).
         if (!isQuestion) {
             builder
                 .addAction(android.R.drawable.ic_menu_revert, "Reject", approvalAction("reject", id, clientId, 2))
-                .addAction(android.R.drawable.ic_menu_send, "Approve", approvalAction("approve", id, clientId, 3))
+                // Approval from a locked phone must route through device unlock into the
+                // in-app approval dock rather than execute from the lock screen.
+                .addAction(android.R.drawable.ic_menu_send, "Approve", tap)
         }
         mgr.notify(APPROVAL_NOTIF_ID, builder.build())
+    }
+
+    // Alert only while the display is off. The WebView calls this on a real typing -> idle
+    // transition and only when the user opted into screen-off execution.
+    fun notifyTurnComplete(sessionId: String) {
+        val power = getSystemService(PowerManager::class.java) ?: return
+        if (power.isInteractive) return
+        val mgr = getSystemService(NotificationManager::class.java) ?: return
+        if (Build.VERSION.SDK_INT >= Build.VERSION_CODES.O) {
+            mgr.createNotificationChannel(NotificationChannel(
+                COMPLETION_CHANNEL,
+                "AgentNet completions",
+                NotificationManager.IMPORTANCE_HIGH,
+            ).apply {
+                description = "Completed agent turns"
+                enableVibration(true)
+                vibrationPattern = longArrayOf(0, 180)
+                lockscreenVisibility = Notification.VISIBILITY_PUBLIC
+            })
+        }
+        val tap = PendingIntent.getActivity(
+            this,
+            sessionId.hashCode(),
+            Intent(this, MainActivity::class.java)
+                .addFlags(Intent.FLAG_ACTIVITY_REORDER_TO_FRONT or Intent.FLAG_ACTIVITY_SINGLE_TOP)
+                .putExtra(EXTRA_OPEN_SESSION, sessionId),
+            PendingIntent.FLAG_UPDATE_CURRENT or PendingIntent.FLAG_IMMUTABLE,
+        )
+        val builder = if (Build.VERSION.SDK_INT >= Build.VERSION_CODES.O) {
+            Notification.Builder(this, COMPLETION_CHANNEL)
+        } else {
+            @Suppress("DEPRECATION") Notification.Builder(this)
+        }
+        builder
+            .setContentTitle("Agent finished")
+            .setContentText("Your agent turn is complete.")
+            .setSmallIcon(R.drawable.iq_logo_green)
+            .setLargeIcon(Icon.createWithResource(this, R.drawable.iq_logo_green))
+            .setContentIntent(tap)
+            .setAutoCancel(true)
+            .setCategory(Notification.CATEGORY_STATUS)
+            .setVisibility(Notification.VISIBILITY_PUBLIC)
+        if (Build.VERSION.SDK_INT < Build.VERSION_CODES.O) {
+            builder.setPriority(Notification.PRIORITY_HIGH).setVibrate(longArrayOf(0, 180))
+        }
+        mgr.notify(COMPLETION_NOTIF_ID, builder.build())
     }
 
     // Drop the approval notification — called when the WebView reports the user is now

--- a/surfaces/android/app/src/main/java/com/iqlabs/agentnet/ServerService.kt
+++ b/surfaces/android/app/src/main/java/com/iqlabs/agentnet/ServerService.kt
@@ -5,10 +5,14 @@ import android.app.NotificationChannel
 import android.app.NotificationManager
 import android.app.PendingIntent
 import android.app.Service
+import android.content.BroadcastReceiver
+import android.content.Context
 import android.content.Intent
+import android.content.IntentFilter
 import android.graphics.drawable.Icon
 import android.os.Build
 import android.os.IBinder
+import android.os.PowerManager
 
 // Foreground service that keeps the node server (and the running agent turn) alive when the
 // app is backgrounded. Android aggressively kills background processes; a foreground service
@@ -21,7 +25,19 @@ class ServerService : Service() {
     companion object {
         private const val CHANNEL = "agentnet_server"
         private const val NOTIF_ID = 1
+        private const val WAKE_LOCK_TIMEOUT_MS = 6 * 60 * 60 * 1000L
         const val EXTRA_CLIENT = "client" // SSE client id, so Stop can reach /rpc
+        const val EXTRA_KEEP_WHILE_LOCKED = "keepWhileLocked"
+    }
+
+    private var keepWhileLocked = false
+    private var wakeLock: PowerManager.WakeLock? = null
+    private val screenReceiver = object : BroadcastReceiver() {
+        override fun onReceive(context: Context?, intent: Intent?) {
+            when (intent?.action) {
+                Intent.ACTION_SCREEN_OFF, Intent.ACTION_SCREEN_ON -> updateWakeLock()
+            }
+        }
     }
 
     override fun onCreate() {
@@ -31,6 +47,15 @@ class ServerService : Service() {
                 NotificationChannel(CHANNEL, "AgentNet", NotificationManager.IMPORTANCE_LOW)
             )
         }
+        val filter = IntentFilter().apply {
+            addAction(Intent.ACTION_SCREEN_OFF)
+            addAction(Intent.ACTION_SCREEN_ON)
+        }
+        if (Build.VERSION.SDK_INT >= Build.VERSION_CODES.TIRAMISU) {
+            registerReceiver(screenReceiver, filter, RECEIVER_NOT_EXPORTED)
+        } else {
+            @Suppress("DEPRECATION") registerReceiver(screenReceiver, filter)
+        }
         startForeground(NOTIF_ID, notification(""))
     }
 
@@ -39,11 +64,41 @@ class ServerService : Service() {
     // it we don't want it auto-resurrected with no work to do; the next turn restarts it.
     override fun onStartCommand(intent: Intent?, flags: Int, startId: Int): Int {
         val client = intent?.getStringExtra(EXTRA_CLIENT) ?: ""
+        keepWhileLocked = intent?.getBooleanExtra(EXTRA_KEEP_WHILE_LOCKED, false) == true
         startForeground(NOTIF_ID, notification(client))
+        updateWakeLock()
         return START_NOT_STICKY
     }
 
     override fun onBind(intent: Intent?): IBinder? = null
+
+    // A partial wakelock keeps the CPU and node runtime alive without lighting the display.
+    // It is held only while this active-turn service is alive, the user opted in, and the
+    // display is off. The timeout is a final leak guard; every normal lifecycle path releases.
+    private fun updateWakeLock() {
+        val power = getSystemService(PowerManager::class.java) ?: return
+        if (keepWhileLocked && !power.isInteractive) {
+            val lock = wakeLock ?: power.newWakeLock(
+                PowerManager.PARTIAL_WAKE_LOCK,
+                "$packageName:agent-turn",
+            ).apply { setReferenceCounted(false) }.also { wakeLock = it }
+            if (!lock.isHeld) lock.acquire(WAKE_LOCK_TIMEOUT_MS)
+        } else {
+            releaseWakeLock()
+        }
+    }
+
+    private fun releaseWakeLock() {
+        wakeLock?.let { if (it.isHeld) runCatching { it.release() } }
+        wakeLock = null
+    }
+
+    override fun onDestroy() {
+        keepWhileLocked = false
+        releaseWakeLock()
+        runCatching { unregisterReceiver(screenReceiver) }
+        super.onDestroy()
+    }
 
     private fun notification(client: String): Notification {
         val builder = if (Build.VERSION.SDK_INT >= Build.VERSION_CODES.O) {

--- a/surfaces/android/app/src/main/java/com/iqlabs/agentnet/ShellBridge.kt
+++ b/surfaces/android/app/src/main/java/com/iqlabs/agentnet/ShellBridge.kt
@@ -19,8 +19,8 @@ class ShellBridge(private val activity: MainActivity) {
 
     // #53: turn started/ended → promote/demote the background foreground service.
     @JavascriptInterface
-    fun setAgentActive(active: Boolean, clientId: String) {
-        activity.runOnUiThread { runCatching { activity.setAgentActive(active, clientId) } }
+    fun setAgentActive(active: Boolean, clientId: String, keepWhileLocked: Boolean) {
+        activity.runOnUiThread { runCatching { activity.setAgentActive(active, clientId, keepWhileLocked) } }
     }
 
     // #53: a turn is waiting on approval → raise a notification. `sessionId` lets a tap
@@ -42,5 +42,11 @@ class ShellBridge(private val activity: MainActivity) {
     @JavascriptInterface
     fun onBackgroundEnabled() {
         activity.runOnUiThread { runCatching { activity.onBackgroundEnabled() } }
+    }
+
+    // A completed turn gets a softer lock-screen alert when screen-off execution is enabled.
+    @JavascriptInterface
+    fun notifyTurnComplete(sessionId: String) {
+        activity.runOnUiThread { runCatching { activity.notifyTurnComplete(sessionId) } }
     }
 }

--- a/surfaces/webview/src/App.tsx
+++ b/surfaces/webview/src/App.tsx
@@ -14,7 +14,7 @@ import { TabBar } from "./shell/TabBar";
 import { Toast } from "./Toast";
 import { useVisualViewportVars, useKeyboardChrome } from "./layoutEffects";
 import { useEffect, useRef, useState, type PointerEvent } from "react";
-import { syncAgentService, notifyApproval, clearApprovalNotice, ensureBackgroundConsent } from "./platform/agentService";
+import { syncAgentService, notifyApproval, clearApprovalNotice, ensureBackgroundConsent, notifyTurnComplete } from "./platform/agentService";
 import { haptics } from "./haptics";
 
 // Phase router:
@@ -35,6 +35,16 @@ export function App() {
   // enabled background exec; demote otherwise. No-op off the Android shell.
   const agentActive = state.typing || state.approvals.length > 0;
   useEffect(() => { syncAgentService(agentActive, getClientId()); }, [agentActive, getClientId]);
+
+  // A real active -> idle transition means the turn ended. Native checks that the display is
+  // still off before posting, and the helper checks the user's screen-off opt-in.
+  const wasTyping = useRef(false);
+  useEffect(() => {
+    if (wasTyping.current && !state.typing && state.approvals.length === 0) {
+      notifyTurnComplete(state.activeSessionId ?? "");
+    }
+    wasTyping.current = state.typing;
+  }, [state.typing, state.approvals.length, state.activeSessionId]);
 
   // Default-on background exec: prompt once for battery-optimization exemption on launch.
   useEffect(() => { ensureBackgroundConsent(); }, []);
@@ -344,4 +354,3 @@ function MarketPage({ marketTab, active }: { marketTab: "skills" | "profile" | "
     </div>
   );
 }
-

--- a/surfaces/webview/src/chat/Sessions.tsx
+++ b/surfaces/webview/src/chat/Sessions.tsx
@@ -24,7 +24,13 @@ import { openExternalUrl } from "../platform/openExternalUrl";
 import { useAutoOpenExternalUrl } from "../platform/useAutoOpenExternalUrl";
 import { HeliusKeyForm } from "../settings/HeliusKeyForm";
 import { ConnectGithub } from "../onboarding/ConnectGithub";
-import { hasAgentService, backgroundExecEnabled, setBackgroundExecEnabled } from "../platform/agentService";
+import {
+  hasAgentService,
+  backgroundExecEnabled,
+  screenOffExecEnabled,
+  setBackgroundExecEnabled,
+  setScreenOffExecEnabled,
+} from "../platform/agentService";
 
 // Chat list drawer — the mobile answer to vscode's multi-panel "new tab": instead of
 // splitting the screen, the ☰ menu slides this in and you pick ONE chat to show. Telegram
@@ -91,6 +97,7 @@ export function Sessions({ onClose, embedded = false, onOpenAgent }: { onClose: 
   const [copied, setCopied] = useState(false);
   const [busy, setBusy] = useState(false);
   const [bgExec, setBgExec] = useState(backgroundExecEnabled());
+  const [screenOffExec, setScreenOffExec] = useState(screenOffExecEnabled());
   const [showManualCode, setShowManualCode] = useState(false);
 
   // Long-press a chat row to reveal a delete menu (replaces the always-on per-row x).
@@ -337,9 +344,12 @@ export function Sessions({ onClose, embedded = false, onOpenAgent }: { onClose: 
                     onClick={() => {
                       const v = !bgExec;
                       setBgExec(v);
-                      setBackgroundExecEnabled(v, getClientId());
-                      if (!v && state.typing) notify("Background off — task keeps running while the app is open.");
+                      if (!v) setScreenOffExec(false);
+                      setBackgroundExecEnabled(v, state.typing || state.approvals.length > 0, getClientId());
+                      if (!v && state.typing) notify("Background off: task keeps running while the app is open.");
                     }}
+                    role="switch"
+                    aria-checked={bgExec}
                     className="flex w-full items-center gap-3.5 rounded-2xl px-2.5 py-3 text-left transition active:bg-[color:var(--an-bg-2)]"
                   >
                     <span className="flex h-7 w-7 shrink-0 items-center justify-center" style={{ color: bgExec ? "var(--an-green)" : "var(--an-fg-dim)" }}>
@@ -358,6 +368,35 @@ export function Sessions({ onClose, embedded = false, onOpenAgent }: { onClose: 
                       Uses more battery while a task runs in the background. No task = nothing runs.
                     </p>
                   )}
+                  <button
+                    onClick={() => {
+                      if (!bgExec) return;
+                      const v = !screenOffExec;
+                      setScreenOffExec(v);
+                      setScreenOffExecEnabled(v, state.typing || state.approvals.length > 0, getClientId());
+                    }}
+                    disabled={!bgExec}
+                    role="switch"
+                    aria-checked={screenOffExec}
+                    aria-describedby="screen-off-exec-note"
+                    className="flex w-full items-center gap-3.5 rounded-2xl px-2.5 py-3 text-left transition enabled:active:bg-[color:var(--an-bg-2)] disabled:cursor-not-allowed disabled:opacity-50"
+                  >
+                    <span className="flex h-7 w-7 shrink-0 items-center justify-center" style={{ color: screenOffExec ? "var(--an-green)" : "var(--an-fg-dim)" }}>
+                      <svg width="22" height="22" viewBox="0 0 22 22" fill="none" stroke="currentColor" strokeWidth="1.55" strokeLinecap="round" strokeLinejoin="round" aria-hidden="true"><path d="M16.8 14.6A7 7 0 0 1 7.4 5.2 7 7 0 1 0 16.8 14.6Z" /><path d="M14.8 5.2v2.6M13.5 6.5h2.6" /></svg>
+                    </span>
+                    <span className="min-w-0 flex-1">
+                      <span className="block text-[1.12rem] font-semibold leading-tight" style={{ color: "var(--an-fg)" }}>Keep working while locked</span>
+                      <span className="block text-[0.72rem] leading-tight" style={{ color: "var(--an-fg-mute)" }}>
+                        {!bgExec ? "Turn on background execution first" : screenOffExec ? "Keeps active tasks running with the screen off" : "Pauses may occur after the screen turns off"}
+                      </span>
+                    </span>
+                    <span className="relative h-[1.35rem] w-[2.4rem] shrink-0 rounded-full transition" style={{ background: screenOffExec ? "var(--an-green)" : "var(--an-bg-2)" }}>
+                      <span className="absolute top-[0.15rem] h-[1.05rem] w-[1.05rem] rounded-full bg-white transition-all" style={{ left: screenOffExec ? "1.2rem" : "0.15rem" }} />
+                    </span>
+                  </button>
+                  <p id="screen-off-exec-note" className="px-2.5 pb-1 text-[0.68rem] leading-snug" style={{ color: "var(--an-fg-mute)" }}>
+                    Uses more battery during active tasks. Approval requests and completed turns vibrate on the lock screen.
+                  </p>
                 </>
               )}
             </div>

--- a/surfaces/webview/src/platform/agentService.ts
+++ b/surfaces/webview/src/platform/agentService.ts
@@ -12,7 +12,7 @@ declare global {
       openUrl?(url: string): void;
       // Promote (true) / demote (false) the foreground service. `clientId` lets the
       // persistent notification's Stop action reach /rpc.
-      setAgentActive?(active: boolean, clientId: string): void;
+      setAgentActive?(active: boolean, clientId: string, keepWhileLocked: boolean): void;
       // Raise an approval notification. `sessionId` lets a tap deep-link to that chat.
       // `force` = notify even in foreground (the request is for a session the user isn't
       // viewing — chat-app style ping). When force is false the shell still no-ops in
@@ -26,11 +26,14 @@ declare global {
       // First time the user enables background exec: prompt for battery-optimization
       // exemption so Android doesn't reap a long task. Guarded native-side against nagging.
       onBackgroundEnabled?(): void;
+      // Raise a softer completion alert when the display is off.
+      notifyTurnComplete?(sessionId: string): void;
     };
   }
 }
 
 const KEY = "agentnet.backgroundExec";
+const LOCKED_KEY = "agentnet.keepWorkingLocked";
 
 // Only true inside the Android shell — gates the settings toggle's visibility.
 export function hasAgentService(): boolean {
@@ -44,6 +47,12 @@ export function backgroundExecEnabled(): boolean {
   return localStorage.getItem(KEY) !== "0";
 }
 
+// Screen-off execution is deliberately opt-in and cannot outlive its background-execution
+// dependency. Missing storage means OFF.
+export function screenOffExecEnabled(): boolean {
+  return backgroundExecEnabled() && localStorage.getItem(LOCKED_KEY) === "1";
+}
+
 // Default-on means the user never taps the toggle, so the one-time battery-exemption prompt
 // (normally fired on enable) wouldn't show. Call this once on launch so a default-on user
 // still gets it. The shell guards against nagging, so repeat calls are safe no-ops.
@@ -51,16 +60,36 @@ export function ensureBackgroundConsent(): void {
   if (backgroundExecEnabled()) window.AgentNetShell?.onBackgroundEnabled?.();
 }
 
-export function setBackgroundExecEnabled(on: boolean, clientId: string | null): void {
+export function setBackgroundExecEnabled(on: boolean, active: boolean, clientId: string | null): void {
   localStorage.setItem(KEY, on ? "1" : "0");
-  if (on) window.AgentNetShell?.onBackgroundEnabled?.();
-  else window.AgentNetShell?.setAgentActive?.(false, clientId ?? ""); // demote at once when off
+  if (on) {
+    window.AgentNetShell?.onBackgroundEnabled?.();
+    window.AgentNetShell?.setAgentActive?.(active, clientId ?? "", screenOffExecEnabled());
+  } else {
+    localStorage.setItem(LOCKED_KEY, "0");
+    window.AgentNetShell?.setAgentActive?.(false, clientId ?? "", false); // demote at once when off
+  }
+}
+
+export function setScreenOffExecEnabled(on: boolean, active: boolean, clientId: string | null): void {
+  const enabled = on && backgroundExecEnabled();
+  localStorage.setItem(LOCKED_KEY, enabled ? "1" : "0");
+  if (enabled) window.AgentNetShell?.onBackgroundEnabled?.();
+  window.AgentNetShell?.setAgentActive?.(active && backgroundExecEnabled(), clientId ?? "", enabled);
 }
 
 // Reflect agent activity to the shell. Promotes only when background exec is enabled AND a
 // turn is active; otherwise demotes so the idle process can be reclaimed.
 export function syncAgentService(active: boolean, clientId: string | null): void {
-  window.AgentNetShell?.setAgentActive?.(active && backgroundExecEnabled(), clientId ?? "");
+  window.AgentNetShell?.setAgentActive?.(
+    active && backgroundExecEnabled(),
+    clientId ?? "",
+    screenOffExecEnabled(),
+  );
+}
+
+export function notifyTurnComplete(sessionId: string): void {
+  if (screenOffExecEnabled()) window.AgentNetShell?.notifyTurnComplete?.(sessionId);
 }
 
 // Ask the shell to surface a pending approval. `force` makes it notify even in foreground


### PR DESCRIPTION
## Summary
- add an opt-in partial wakelock that follows the active-turn foreground-service lifecycle and releases on screen-on, turn end, or service destruction
- add a dependent Keep working while locked setting that is off by default and reuses the battery-optimization consent flow
- add high-importance lock-screen approval and completion notifications with distinct vibration patterns
- route locked-device approval through unlock into the in-app approval dock

## Safety
- wakelock acquisition requires an active turn, enabled background execution, enabled screen-off execution, and a non-interactive display
- every normal stop path releases the lock, with a six-hour timeout as a final safety ceiling

## Validation
- pnpm --filter agentnet-webview build
- ANDROID_HOME=/Users/parthagrawal99/Library/Android/sdk ./gradlew :app:compileDebugKotlin
- git diff --check

Closes #119