### PR TITLE
Skill and workflow publishing now share one JSON builder, so their published shape can't drift

### DIFF
--- a/packages/core/src/nft/buildItemJson.spec.ts
+++ b/packages/core/src/nft/buildItemJson.spec.ts
@@ -1,0 +1,77 @@
+import { describe, it, expect } from "vitest";
+import { buildItemJson } from "./skill.js";
+
+// buildItemJson is the shared standard-NFT-JSON shape for BOTH publish paths. These
+// tests pin the exact bytes each path used to produce independently, so the shared
+// builder is a provable no-op refactor and the skill/workflow shapes can't drift.
+describe("nft/buildItemJson — shared skill+workflow JSON shape", () => {
+  it("skill shape: name/description/attributes/skillText, image omitted when absent", () => {
+    const json = buildItemJson({
+      name: "iq-onchain-db",
+      description: "store data on solana",
+      text: "# body",
+      category: "solana",
+      hashtags: ["solana", "iqlabs"],
+    });
+    // exactly what publishSkill's inline builder emitted before extraction
+    expect(json).toBe(
+      JSON.stringify({
+        name: "iq-onchain-db",
+        description: "store data on solana",
+        attributes: [
+          { trait_type: "category", value: "solana" },
+          { trait_type: "skill", value: "solana" },
+          { trait_type: "skill", value: "iqlabs" },
+        ],
+        skillText: "# body",
+      }),
+    );
+    expect(json).not.toContain("image");
+    expect(json).not.toContain("requiredSkill");
+  });
+
+  it("skill shape: image is included, in position, when present", () => {
+    const json = buildItemJson({
+      name: "s",
+      description: "d",
+      text: "b",
+      image: "https://x.png",
+    });
+    expect(json).toBe(
+      JSON.stringify({ name: "s", description: "d", image: "https://x.png", attributes: [], skillText: "b" }),
+    );
+  });
+
+  it("workflow shape: requiredSkill traits appended after hashtags, no image", () => {
+    const json = buildItemJson({
+      name: "create-new-db",
+      description: "creates a db",
+      text: "# recipe",
+      category: "developer",
+      hashtags: ["solana"],
+      requiredSkills: ["MintAAA", "MintBBB"],
+    });
+    // exactly what publishWorkflow's inline builder emitted before extraction
+    expect(json).toBe(
+      JSON.stringify({
+        name: "create-new-db",
+        description: "creates a db",
+        attributes: [
+          { trait_type: "category", value: "developer" },
+          { trait_type: "skill", value: "solana" },
+          { trait_type: "requiredSkill", value: "MintAAA" },
+          { trait_type: "requiredSkill", value: "MintBBB" },
+        ],
+        skillText: "# recipe",
+      }),
+    );
+  });
+
+  it("a workflow always carries its description (regression: it must never be blank)", () => {
+    const parsed = JSON.parse(
+      buildItemJson({ name: "w", description: "real description", text: "steps", requiredSkills: ["M"] }),
+    );
+    expect(parsed.description).toBe("real description");
+    expect(parsed.attributes).toContainEqual({ trait_type: "requiredSkill", value: "M" });
+  });
+});

--- a/packages/core/src/nft/skill.ts
+++ b/packages/core/src/nft/skill.ts
@@ -162,6 +162,38 @@ export interface PublishSkillInput {
 }
 
 /**
+ * Build the standard NFT JSON that gets code-in'd for BOTH a skill and a workflow
+ * (skill-nft-json.md §2/§4/§4b) — the single source of truth for that shape, so the
+ * two publish paths cannot drift. Attribute order is fixed: `category` once, then each
+ * hashtag as a repeated `skill` trait, then each prerequisite as a `requiredSkill`
+ * trait (workflows only). `image` is emitted only when present, and required-skill
+ * traits only when supplied, so a skill (no image → omitted, no requiredSkills → none)
+ * and a workflow (image omitted) each serialize byte-for-byte as they did before this
+ * was extracted. Built before the first tx so the signature total stays predictable.
+ */
+export function buildItemJson(item: {
+  name: string;
+  description: string;
+  text: string;
+  image?: string;
+  category?: string;
+  hashtags?: string[];
+  requiredSkills?: string[];
+}): string {
+  const attributes: { trait_type: string; value: string }[] = [];
+  if (item.category) attributes.push({ trait_type: "category", value: item.category });
+  for (const tag of item.hashtags ?? []) attributes.push({ trait_type: "skill", value: tag });
+  for (const mint of item.requiredSkills ?? []) attributes.push({ trait_type: "requiredSkill", value: mint });
+  return JSON.stringify({
+    name: item.name,
+    description: item.description,
+    ...(item.image ? { image: item.image } : {}), // §3 — omit when absent
+    attributes,
+    skillText: item.text,
+  });
+}
+
+/**
  * Publish a skill. The skill mint's authority is the gate program's mint-auth PDA
  * (so only buy_item can mint it), and its config (price, empty required_skills) is
  * registered on-chain via publish_item.
@@ -192,17 +224,15 @@ export async function publishSkill(
   // code-in the standard NFT JSON (skill-nft-json.md §2): name/description +
   // standard `attributes` (category once, each hashtag as a repeated "skill"
   // trait, §4) + the SKILL.md body in `skillText`. One inscription holds
-  // everything search/detail needs — traits do NOT go on the mint. Built before
-  // the first tx so the signature total can be predicted from the JSON size.
-  const attributes: { trait_type: string; value: string }[] = [];
-  if (input.category) attributes.push({ trait_type: "category", value: input.category });
-  for (const tag of input.hashtags ?? []) attributes.push({ trait_type: "skill", value: tag });
-  const skillJson = JSON.stringify({
+  // everything search/detail needs — traits do NOT go on the mint. buildItemJson
+  // is the shared shape used by the workflow path too, so they can't drift.
+  const skillJson = buildItemJson({
     name: input.name,
     description: input.description,
-    ...(input.image ? { image: input.image } : {}), // §3 — omit when absent
-    attributes,
-    skillText: input.text,
+    text: input.text,
+    image: input.image,
+    category: input.category,
+    hashtags: input.hashtags,
   });
 
   // Wrap the signer so each wallet signature advances the publish gauge. `phase` is

--- a/packages/core/src/nft/workflow.ts
+++ b/packages/core/src/nft/workflow.ts
@@ -14,7 +14,7 @@ import type { SignerInput } from "@iqlabs-official/solana-sdk/utils";
 
 import { codeIn, signerAddress, ensureDbRoot, itemMetadataUri } from "../core/chain.js";
 import { getWorkflowsCollectionMint } from "../core/seed.js";
-import { trackSignatures, estimatePublishSigns, type PublishProgress } from "./skill.js";
+import { trackSignatures, estimatePublishSigns, buildItemJson, type PublishProgress } from "./skill.js";
 import { createSkillMint } from "./token2022.js";
 import { checkWorkflowFormat, FormatError } from "./checkFormat.js";
 import {
@@ -52,17 +52,15 @@ export async function publishWorkflow(
   // code-in the standard NFT JSON (skill-nft-json.md §2, §4b): same shape as a
   // skill — category once, each hashtag a repeated "skill" trait — plus one
   // "requiredSkill" trait per prerequisite (valued by the skill's mint id, §4b).
-  // The body (recipe) goes in skillText. Traits live here, not on the mint.
-  // Built before the first tx so the signature total can be predicted.
-  const attributes: { trait_type: string; value: string }[] = [];
-  if (input.category) attributes.push({ trait_type: "category", value: input.category });
-  for (const tag of input.hashtags ?? []) attributes.push({ trait_type: "skill", value: tag });
-  for (const mint of input.requiredSkills) attributes.push({ trait_type: "requiredSkill", value: mint });
-  const workflowJson = JSON.stringify({
+  // The body (recipe) goes in skillText. buildItemJson is shared with the skill
+  // path so description + attributes can't silently diverge between the two.
+  const workflowJson = buildItemJson({
     name: input.name,
     description: input.description,
-    attributes,
-    skillText: input.text,
+    text: input.text,
+    category: input.category,
+    hashtags: input.hashtags,
+    requiredSkills: input.requiredSkills,
   });
 
   // Same signature-counting gauge as publishSkill, tagged "workflow" so the UI tints it


### PR DESCRIPTION
# Skill and workflow publishing now share one JSON builder, so their published shape can't drift

`publishSkill` and `publishWorkflow` each hand-built the same standard item JSON inline. Two copies of one shape drift over time — exactly the class of bug where a workflow ships a blank description or loses its `requiredSkill` traits. This extracts a single `buildItemJson()` that both paths call, with a spec pinning the exact bytes each path produced before the extraction. Pure deduplication; no behavior change.

- `packages/core/src/nft/skill.ts` — new exported `buildItemJson()`: `name`/`description`, then `image` only when present, then `attributes` in fixed order (`category` once → each hashtag as a repeated `skill` trait → each prerequisite as a `requiredSkill` trait), then the body as `skillText`. The doc comment spells out the ordering and cites `skill-nft-json.md` §2/§4/§4b.
- `publishSkill` drops its inline builder and calls `buildItemJson(...)` with the same inputs.
- `packages/core/src/nft/workflow.ts` — `publishWorkflow` does the same, importing the builder from `./skill.js` on the import line it already uses for `trackSignatures`/`estimatePublishSigns`.
- `packages/core/src/nft/buildItemJson.spec.ts` (new) — four tests that pin the exact serialized output of both shapes: skill with and without `image` (including its position when present), workflow trait ordering with `requiredSkill` values, and a regression check that a workflow's description is never blank.

Verified: core `tsc --noEmit` is clean, and the new spec passes 4/4 — its expected strings are the byte-for-byte output the two inline builders produced before extraction.

## Relates to

The publish paths in `packages/core/src/nft/` (`publishSkill` / `publishWorkflow`) and the standard item JSON they emit per `skill-nft-json.md` §2/§4/§4b. No linked issue — proactive dedup of a drift-prone duplicate.

## Risks

**Low.** Pure extraction, no behavior change: the new spec pins the byte-for-byte pre-extraction output of both paths, so any accidental shape change fails 4/4. Blast radius is limited to item-JSON assembly; publish orchestration (transactions, signature gauge) is untouched.

## Background — what & why

Two hand-rolled copies of the same JSON shape lived in `skill.ts` and `workflow.ts`. Duplicated shapes drift silently — blank workflow descriptions, dropped `requiredSkill` traits — and nothing caught it. One shared `buildItemJson()` plus a byte-pinning spec removes that whole bug class.

## Testing — where a reviewer starts + steps

Start at `packages/core/src/nft/buildItemJson.spec.ts` — its expected strings are the exact bytes each inline builder produced before extraction, so the tests alone prove no shape changed.

1. `cd packages/core`
2. `npx vitest run src/nft/buildItemJson.spec.ts` → 4/4 pass
3. `npx tsc --noEmit` → clean

### Code quality

Held to five rules — each verified against this diff, not asserted:

1. **No meaningless wrappers with identical input/output** — ✅ `buildItemJson()` is no pass-through: it owns the attribute assembly, the conditional `image` spread, and the field ordering that two call sites previously duplicated by hand.
2. **Scan existing functions first and reuse; never two functions with the same purpose** — ✅ this PR is that rule applied: two inline builders with one purpose collapse into one function, and `workflow.ts` reuses it via the `./skill.js` import it already had rather than growing a new module.
3. **No type variables that won't be reused; inline them** — ✅ no new named types: the parameter is an inline object literal on the signature, and the `attributes` array is typed inline as `{ trait_type: string; value: string }[]`.
4. **No non-essential parameters** — ✅ all seven fields serialize into the output; the optionals (`image`, `category`, `hashtags`, `requiredSkills`) sit exactly where the two shapes legitimately differ. Nothing configurable that isn't emitted.
5. **Keep responsibilities separated; if the design feels wrong, say so** — ✅ shape-building is now one responsibility in one place, while publish orchestration (transactions, signature gauge) stays untouched in both callers. Placement note: the builder lives in `skill.ts` beside the shared publish helpers `workflow.ts` already imports; if that shared surface keeps growing, splitting it into its own module is the next honest step.

`tsc --noEmit` clean · new spec 4/4 · no regressions — the 8 failing vitest specs (rpc/seed/dasSource/skillSource/session) are pre-existing on main and env-dependent. Merges cleanly into main, independent of the other fix branches.

## Evidence

| Row | Artifact |
|---|---|
| Before/After screenshots | N/A - backend-only, no UI surface; see test logs |
| Video walkthrough (MP4) | N/A - backend-only, no UI flow to record |
| Backend logs | `packages/core/src/nft/buildItemJson.spec.ts` run — 4/4 pass, covering both publish paths end-to-end through the shared builder |
| Frontend logs | N/A - backend-only; no client request/response or UI state involved |
| Real-LLM trajectory | N/A - no agent, model, or prompt changes; pure JSON-builder deduplication |
| Domain artifacts | The spec pins byte-identical JSON for both publish paths — its expected strings are the pre-extraction output of each inline builder, so the generated item JSON is provably unchanged |
