### PR TITLE
Docs a new dev can trust: every id and link now matches the shipped code, and the Drive sync error is explained

### DIFF
--- a/README.md
+++ b/README.md
@@ -12,7 +12,7 @@ Underneath that, the chain is what makes the agent yours:
 - **Skills are soulbound NFTs on Solana.** A published skill lives on the chain rather than on a hosting server, so it does not disappear when a host shuts down. Reviews are written to the chain as well and cannot be removed. When a priced skill is bought, the same transaction that mints it to the buyer also transfers the payment to the creator, so the payout is enforced by the program rather than by a platform's policy.
 - **Sessions follow the wallet.** Conversation history is encrypted with a key derived from the wallet, so only the owner can read it. Skills, memory, and reputation are keyed to the same wallet, which means connecting the secret key on a new device restores the same agent.
 
-A longer walkthrough of this reasoning, in thread form: [plans/thread.md](plans/thread.md).
+A longer walkthrough of this reasoning lives in the design notes: [plans/00-overview.md](plans/00-overview.md).
 
 
 ## Install & run
@@ -417,7 +417,7 @@ Exploration shows **~90% already exists in IQLabs / the SDKs.** Most is a clone 
 | skill text on-chain | code-in (≤700B inline) → the NFT mint's `uri` | ✅ exists (code-in) |
 | `.sol` human name | wide-web SNS resolution | ✅ exists |
 | search · sort | filter by NFT traits, sort by `supply` | ✅ built (`search/`) |
-| **soulbound skill ownership** | **Token-2022 `NonTransferable` mint** per skill, minted via the gate program so it can't be forged | ✅ built (`nft/token2022.ts` + gate program, devnet) |
+| **soulbound skill ownership** | **Token-2022 `NonTransferable` mint** per skill, minted via the gate program so it can't be forged | ✅ built (`nft/token2022.ts` + gate program, mainnet) |
 | **star = soulbound buy = payment = equip (atomic)** | `buy_skill`: `SystemProgram.transfer` + mint 1 token in one tx (free = price-0) | ✅ built (`nft/skill.ts` + `skill-market/` MCP tools) |
 | **reputation (comments, git-link attachable)** | `reviews:[collection]:[skillNFT]` + `reviews:agent:[agentWallet]` tables, holder-gated | ✅ built (`notes/`) |
 | **skill validation + security audit** | buyer-side gate: `scanSkillText` + `verify_skill` (`VERIFY_RUBRIC`) + `VerifyGuard`; periodic/official audits later | ✅ built (gate) / 🔨 audits |
@@ -425,7 +425,7 @@ Exploration shows **~90% already exists in IQLabs / the SDKs.** Most is a clone 
 | **iqfetch / publish (address convention)** | core protocol functions (git-sdk's sibling) | ✅ built (`publishSkill` / `searchSkills` / `getSkillText`; `iq://` URI form still open) |
 
 **Reference code:**
-- Skill/workflow mint gate program (Anchor): `IQCoreTeam/agent-workflow-nft` (private) — devnet `3ptXj4yuaQG51WTA3SZZ37jGvYFgMhgXnSKWJLASJNkt`
+- Skill/workflow mint gate program (Anchor): `IQCoreTeam/agent-workflow-nft` (private) — mainnet `8YmcHuCx323RtqC8mzTJ5CH4oVT8mPKJ7xarcPKbdgof` (`core/seed.ts::WORKFLOW_GATE_PROGRAM_ID`; earlier devnet build `3ptXj4yuaQG51WTA3SZZ37jGvYFgMhgXnSKWJLASJNkt`)
 - Contract: `IQCoreTeam/IQLabsContract` (private)
 - Solana SDK: [IQCoreTeam/iqlabs-solana-sdk](https://github.com/IQCoreTeam/iqlabs-solana-sdk)
 - git SDK (the pattern to clone): [IQCoreTeam/iqlabs-git-sdk](https://github.com/IQCoreTeam/iqlabs-git-sdk)

--- a/install-guide/vscode.md
+++ b/install-guide/vscode.md
@@ -113,6 +113,23 @@ In VS Code (Marketplace install) or the Extension Development Host window (sourc
 
 ---
 
+## Optional — cloud session sync
+
+Sessions are stored locally by default. To sync them across devices you can connect a
+cloud backend from the chat's storage settings:
+
+- **iCloud** (Mac) — no setup; pick it and you're done.
+- **Google Drive** — desktop surfaces use a native-app OAuth flow that needs **your own**
+  Google OAuth client (the app can't ship a shared one). Create an OAuth client in the
+  Google Cloud Console, then either set `GOOGLE_CLIENT_ID` (and, for client types that
+  require it, `GOOGLE_CLIENT_SECRET`) in the environment, or add
+  `"google_client_id"` / `"google_client_secret"` to `~/.agentnet/config.json`. The same
+  client-ID setup is described for the phone build in [android.md](android.md#optional--configure-google-drive-oauth-for-testing).
+  Without this you'll see *"Cloud connect failed: Google client id missing"* — that's
+  expected, not a bug; use iCloud or local storage if you don't want to set up Drive.
+
+---
+
 ## Troubleshooting
 
 - **F5 launches but no AgentNet command appears:** run `pnpm build:vscode` (the extension

--- a/packages/core/src/core/seed.ts
+++ b/packages/core/src/core/seed.ts
@@ -43,17 +43,17 @@ export function reviewsAgentHint(agentWallet: string): string {
 
 // ===== On-chain program / collection ids (one place — easy to swap) =====
 //
-// Current values are the DEVNET test deployment. Override any of them with the
+// Current values are the MAINNET deployment. Override any of them with the
 // matching env var when you point at a different network / collection. To move
-// to mainnet, change NETWORK below + these three (and the program's constants.rs
-// collection).
+// to another network, change NETWORK below + these three (and the program's
+// constants.rs collection).
 
 export type Network = "devnet" | "mainnet";
 
 /**
  * The single network switch. Everything network-shaped (the default RPC, the Helius
  * endpoint, the UI badge) derives from this — flip it here (or AGENTNET_NETWORK) and
- * the whole app retargets. We're on devnet for testing.
+ * the whole app retargets. Currently set to mainnet.
  */
 export const NETWORK: Network = "mainnet";
 
@@ -153,7 +153,7 @@ export const FEE_BPS = 690; // 6.9%
 
 /**
  * The TokenGroup mint skills are enrolled into. Env override wins; otherwise the
- * configured devnet test collection.
+ * configured mainnet collection.
  */
 export function getSkillsCollectionMint(): string | null {
   return process.env.AGENTNET_SKILLS_COLLECTION_PUBKEY || SKILLS_COLLECTION_MINT;
@@ -161,7 +161,7 @@ export function getSkillsCollectionMint(): string | null {
 
 /**
  * The TokenGroup mint workflows are enrolled into. Env override wins; otherwise
- * the configured devnet test collection.
+ * the configured mainnet collection.
  */
 export function getWorkflowsCollectionMint(): string | null {
   return process.env.AGENTNET_WORKFLOWS_COLLECTION_PUBKEY || WORKFLOWS_COLLECTION_MINT;

--- a/plans/workflow-nft.md
+++ b/plans/workflow-nft.md
@@ -109,9 +109,9 @@ with a populated list.
 > workflows behind this single PDA-mint program; only the `requiredSkills` list differs.
 
 - Repo: **[IQCoreTeam/agent-workflow-nft](https://github.com/IQCoreTeam/agent-workflow-nft)** (Anchor 0.32.1).
-- Devnet program: `3ptXj4yuaQG51WTA3SZZ37jGvYFgMhgXnSKWJLASJNkt`.
-- Official skills collection it checks against: `4exdqNEcXixiMzenEBts2cE7qLmMvcVtHCjsZUGBm4Gt`
-  (`constants.rs::OFFICIAL_SKILLS_COLLECTION` — swap before mainnet).
+- Program: mainnet `8YmcHuCx323RtqC8mzTJ5CH4oVT8mPKJ7xarcPKbdgof` (`core/seed.ts::WORKFLOW_GATE_PROGRAM_ID`); the earlier devnet build was `3ptXj4yuaQG51WTA3SZZ37jGvYFgMhgXnSKWJLASJNkt`.
+- Official skills collection it checks against: mainnet `BUGHnCh2Pf93tgcxAEfhjd6tUjbY56JrSZdCRXyt7uS5`
+  (`constants.rs::OFFICIAL_SKILLS_COLLECTION`, mirrored by `core/seed.ts::SKILLS_COLLECTION_MINT`); the earlier devnet build was `4exdqNEcXixiMzenEBts2cE7qLmMvcVtHCjsZUGBm4Gt`.
 
 ```mermaid
 flowchart TB


### PR DESCRIPTION
# Docs a new dev can trust: every id and link now matches the shipped code, and the Drive sync error is explained

Docs-and-comments-only pass. The README and plans still described the devnet test deployment even though the code ships `NETWORK = "mainnet"`, one README link pointed at a file that doesn't exist, and the VS Code guide never explained the Google Drive error users hit on first cloud sync. Anyone following the docs now lands on the deployment that actually exists. No code paths change.

- **README**: repointed the design-notes link from `plans/thread.md` (file doesn't exist in the tree) to `plans/00-overview.md`.
- **README (×2)**: the capability-table row for soulbound skill ownership now says the gate-program path is built on **mainnet** (was "devnet"), and the reference-code line carries the real mainnet program id `8YmcHuCx…` sourced from `core/seed.ts::WORKFLOW_GATE_PROGRAM_ID`, with the old devnet id `3ptXj4…` kept only as explicitly labeled history.
- **`plans/workflow-nft.md`**: same reconciliation for both ids — mainnet program `8YmcHuCx…`, and the official skills collection updated from the devnet `4exdqNE…` to mainnet `BUGHnCh2…` (`constants.rs::OFFICIAL_SKILLS_COLLECTION`, mirrored by `core/seed.ts::SKILLS_COLLECTION_MINT`); earlier devnet ids labeled as such rather than deleted.
- **`packages/core/src/core/seed.ts`** (comments only): the doc comments said "DEVNET test deployment" while the constant beneath them reads `NETWORK: Network = "mainnet"` — they now describe the code they sit next to.
- **`install-guide/vscode.md`**: new optional "cloud session sync" section — documents that Google Drive on desktop needs your own OAuth client (`GOOGLE_CLIENT_ID` env var, or `google_client_id` in `~/.agentnet/config.json`), links the matching Android instructions, and states plainly that *"Cloud connect failed: Google client id missing"* is expected configuration, not a bug.

Verified: every id in the diff was checked against this branch's `packages/core/src/core/seed.ts` (`WORKFLOW_GATE_PROGRAM_ID = 8YmcHuCx…`, `SKILLS_COLLECTION_MINT = BUGHnCh2…`), the new link target `plans/00-overview.md` confirmed to exist (and `plans/thread.md` confirmed absent), and core `tsc --noEmit` run clean.

## Relates to

Documentation accuracy across README, `plans/`, `install-guide/vscode.md`, and `core/seed.ts` comments — the docs still described the retired devnet deployment. No tracked issue; found while onboarding against the docs.

## Risks

**Low.** Docs and code comments only — zero executable lines change (`tsc --noEmit` clean, no tests added or modified). Worst case is a wrong id in prose, and every id in the diff is checked against its source constant in `seed.ts` (see Evidence).

## Background — what & why

The code moved to mainnet but the docs never followed: README and plans still pointed readers at devnet ids, one README link targeted a file that doesn't exist, and the first-run Google Drive error was undocumented. A new dev following the docs ended up on a deployment that no longer exists. This PR reconciles every id, link, and comment with the shipped code — full file-by-file detail in the description above.

## Testing — where a reviewer starts + steps

Start at `packages/core/src/core/seed.ts` — the single source of truth the docs now cite.

1. Confirm the constants: `NETWORK = "mainnet"`, `WORKFLOW_GATE_PROGRAM_ID` begins `8YmcHuCx`, `SKILLS_COLLECTION_MINT` begins `BUGHnCh2`.
2. Grep the diffed docs (README, `plans/workflow-nft.md`) for those two ids — every occurrence matches the constants; old devnet ids (`3ptXj4…`, `4exdqNE…`) appear only under explicit "earlier devnet build" labels.
3. Check the README link fix: `plans/00-overview.md` exists in the tree; `plans/thread.md` (the old target) does not.
4. In `seed.ts`, confirm the changed lines are comments only — the doc comment now says mainnet, matching the constant directly beneath it.
5. Optional: run `tsc --noEmit` in `packages/core` — clean.

### Code quality
Held to a strict bar — each rule checked against this diff, not asserted:

1. **No meaningless wrappers with identical input/output** — zero functions added or changed; the only `.ts` file touched (`seed.ts`) changes comments exclusively. ✅
2. **Scan existing functions first and reuse; never two functions with the same purpose** — instead of restating ids as bare strings, the docs now cite the one existing source of truth by symbol (`core/seed.ts::WORKFLOW_GATE_PROGRAM_ID` / `SKILLS_COLLECTION_MINT`), so the ids keep exactly one home. ✅
3. **No type variables that won't be reused; inline them** — no types introduced anywhere in the diff. ✅
4. **No non-essential parameters** — no signatures touched; the Drive note documents the existing `GOOGLE_CLIENT_ID` / `config.json` knobs rather than inventing new configuration surface. ✅
5. **Keep responsibilities separated; if the design feels wrong, say so** — `seed.ts` stays the owner of deployment ids and the docs reference it; where old devnet ids still matter, they're labeled "earlier devnet build" instead of being deleted or left ambiguous. ✅

`tsc --noEmit` clean. No regressions: the 8 failing vitest specs (rpc/seed/dasSource/skillSource/session) are pre-existing on main and env-dependent; this branch is docs/comments-only and adds no tests. Merges cleanly into main with no conflicts.

## Evidence

| Evidence | Reference |
| --- | --- |
| Before/After screenshots | N/A - docs-only change, no UI surface |
| Video walkthrough (MP4) | N/A - docs-only change, nothing to demonstrate on screen |
| Backend logs | Verification record in lieu of runtime logs (no code path exists to fire): every id in the diff checked against this branch's `packages/core/src/core/seed.ts` — `WORKFLOW_GATE_PROGRAM_ID = 8YmcHuCx…`, `SKILLS_COLLECTION_MINT = BUGHnCh2…` — and link targets confirmed on disk: `plans/00-overview.md` exists, `plans/thread.md` absent. Reproducible via Testing steps 1–3 above. |
| Frontend logs | N/A - no frontend code touched, no request/response or state to capture |
| Real-LLM trajectory | N/A - no agent, model, or prompt changes |
| Domain artifacts | N/A - docs/comments only, no behavior change; produces no DB rows, memories, on-chain output, or generated files. `tsc --noEmit` clean is the only machine-checked result. |
