### PR TITLE
Your chat history survives a wallet switch: `migrateSessions` re-keys sessions between wallets

### DIFF
--- a/packages/core/src/account/migrate.spec.ts
+++ b/packages/core/src/account/migrate.spec.ts
@@ -1,0 +1,209 @@
+import { describe, it, expect, beforeEach, afterEach } from "vitest";
+import { mkdtempSync, rmSync, readdirSync, readFileSync, writeFileSync } from "node:fs";
+import { tmpdir } from "node:os";
+import { join } from "node:path";
+import { migrateSessions } from "./migrate.js";
+import { SessionStore, PAGE_SIZE } from "./store.js";
+import { manualStorage } from "./storage/manual.js";
+import { testWallet } from "./keypairWallet.js";
+import type { CanonicalSession, ChatMessage, Wallet } from "../runtime/contract.js";
+
+// Deterministic fixtures: the dedupe compares messages by JSON.stringify, so the
+// same builder must produce byte-identical JSON on both sides.
+const msg = (i: number): ChatMessage => ({
+  role: i % 2 === 0 ? "user" : "assistant",
+  text: `message ${i}`,
+  ts: 1_700_000_000_000 + i,
+});
+
+function meta(
+  sessionId: string,
+  title: string,
+  ts: number,
+  lastDevice?: { id: string; label: string },
+): Omit<CanonicalSession, "messages"> {
+  return { sessionId, cli: "claude", title, ts, ...(lastDevice ? { lastDevice } : {}) };
+}
+
+async function seed(
+  store: SessionStore,
+  m: Omit<CanonicalSession, "messages">,
+  count: number,
+): Promise<void> {
+  for (let i = 0; i < count; i++) await store.appendMessage(m, msg(i));
+}
+
+// Snapshot a wallet's session dir: filename -> raw bytes (hex), for byte-identity checks.
+function snapshotDir(dir: string): Record<string, string> {
+  const out: Record<string, string> = {};
+  for (const f of readdirSync(dir)) out[f] = Buffer.from(readFileSync(join(dir, f))).toString("hex");
+  return out;
+}
+
+describe("account/migrate — session re-key between wallets", () => {
+  let home: string;
+  const origEnv = { ...process.env };
+  const walletA = testWallet(1);
+  const walletB = testWallet(2);
+  // Fresh store per call: proves reads come from disk, not another instance's caches.
+  const storeFor = (w: Wallet) => new SessionStore(w, manualStorage(w.address));
+  const dirFor = (w: Wallet) => join(home, "sessions", w.address);
+
+  beforeEach(() => {
+    home = mkdtempSync(join(tmpdir(), "agentnet-migrate-"));
+    process.env.AGENTNET_HOME = home;
+  });
+
+  afterEach(() => {
+    process.env = { ...origEnv };
+    rmSync(home, { recursive: true, force: true });
+  });
+
+  it("re-keys every session: B decrypts and lists what A wrote, across page boundaries", async () => {
+    const over = PAGE_SIZE + 5; // forces a page rollover in both source and destination
+    const m1 = meta("s1", "long session", 2000, { id: "device-A", label: "Device A" });
+    const m2 = meta("s2", "short session", 1000);
+    const src = storeFor(walletA);
+    await seed(src, m1, over);
+    await seed(src, m2, 3);
+
+    const report = await migrateSessions(storeFor(walletA), storeFor(walletB));
+    expect(report).toEqual({ copied: 2, skipped: 0, messages: over + 3 });
+
+    // A fresh store under B reads everything back — identity fields and full transcript.
+    const dst = storeFor(walletB);
+    const listed = await dst.listMine();
+    expect(listed.map((s) => s.sessionId)).toEqual(["s1", "s2"]); // ts-desc order
+    expect(listed[0]).toMatchObject({ title: "long session", cli: "claude", ts: 2000, lastDevice: { id: "device-A", label: "Device A" } });
+    expect(listed[1]).toMatchObject({ title: "short session", cli: "claude", ts: 1000 });
+
+    const srcS1 = await storeFor(walletA).load("s1");
+    const dstS1 = await dst.load("s1");
+    expect(dstS1).toEqual(srcS1);
+    expect(dstS1?.messages).toHaveLength(over);
+    expect(await dst.load("s2")).toEqual(await storeFor(walletA).load("s2"));
+
+    // The destination really paged: the copy is stored as p0 + p1, like a typed-in session.
+    const bFiles = readdirSync(dirFor(walletB)).sort();
+    expect(bFiles).toContain("s1__p0.log");
+    expect(bFiles).toContain("s1__p1.log");
+  });
+
+  it("destination pages are truly re-encrypted: A's key cannot read B's copies", async () => {
+    await seed(storeFor(walletA), meta("s1", "t", 1000), 2);
+    await migrateSessions(storeFor(walletA), storeFor(walletB));
+
+    // Wallet A's key over B's folder: undecryptable — listMine omits, load throws.
+    const wrongKey = new SessionStore(walletA, manualStorage(walletB.address));
+    expect(await wrongKey.listMine()).toEqual([]);
+    await expect(wrongKey.load("s1")).rejects.toThrow();
+  });
+
+  it("is non-destructive: the source dir is byte-identical and still loads under A", async () => {
+    const src = storeFor(walletA);
+    await seed(src, meta("s1", "t1", 1000), PAGE_SIZE + 5);
+    await src.recordMeta(meta("s-empty", "e", 500));
+    const before = snapshotDir(dirFor(walletA));
+
+    await migrateSessions(storeFor(walletA), storeFor(walletB));
+
+    expect(snapshotDir(dirFor(walletA))).toEqual(before); // same files, same bytes
+    const after = await storeFor(walletA).load("s1");
+    expect(after?.messages).toHaveLength(PAGE_SIZE + 5);
+  });
+
+  it("is idempotent: a second run copies nothing and duplicates nothing", async () => {
+    const src = storeFor(walletA);
+    await seed(src, meta("s1", "t1", 2000), PAGE_SIZE + 5);
+    await seed(src, meta("s2", "t2", 1000), 3);
+
+    const first = await migrateSessions(storeFor(walletA), storeFor(walletB));
+    expect(first.copied).toBe(2);
+
+    const second = await migrateSessions(storeFor(walletA), storeFor(walletB));
+    expect(second).toEqual({ copied: 0, skipped: 2, messages: 0 });
+
+    const dst = storeFor(walletB);
+    expect((await dst.load("s1"))?.messages).toHaveLength(PAGE_SIZE + 5);
+    expect((await dst.load("s2"))?.messages).toHaveLength(3);
+  });
+
+  it("resumes an interrupted copy: only the missing tail is appended", async () => {
+    const total = 10;
+    const k = 4;
+    const m = meta("s1", "t", 1000);
+    await seed(storeFor(walletA), m, total);
+    await seed(storeFor(walletB), m, k); // as if an earlier run stopped after k messages
+
+    const report = await migrateSessions(storeFor(walletA), storeFor(walletB));
+    expect(report).toEqual({ copied: 1, skipped: 0, messages: total - k });
+
+    const dstS1 = await storeFor(walletB).load("s1");
+    expect(dstS1).toEqual(await storeFor(walletA).load("s1")); // no gaps, no duplicates
+    expect(dstS1?.messages).toHaveLength(total);
+  });
+
+  it("skips a divergent same-id session and leaves the destination untouched", async () => {
+    const m = meta("s1", "t", 1000);
+    await seed(storeFor(walletA), m, 3);
+    const other: ChatMessage = { role: "user", text: "a different history", ts: 42 };
+    await storeFor(walletB).appendMessage(m, other);
+
+    const report = await migrateSessions(storeFor(walletA), storeFor(walletB));
+    expect(report).toEqual({ copied: 0, skipped: 1, messages: 0 });
+    expect((await storeFor(walletB).load("s1"))?.messages).toEqual([other]);
+  });
+
+  it("migrates a meta-only session via recordMeta", async () => {
+    await storeFor(walletA).recordMeta(meta("s-empty", "just a title", 777));
+
+    const report = await migrateSessions(storeFor(walletA), storeFor(walletB));
+    expect(report).toEqual({ copied: 1, skipped: 0, messages: 0 });
+
+    const listed = await storeFor(walletB).listMine();
+    expect(listed).toHaveLength(1);
+    expect(listed[0]).toMatchObject({ sessionId: "s-empty", title: "just a title", ts: 777 });
+
+    // And a re-run treats it as already present.
+    const again = await migrateSessions(storeFor(walletA), storeFor(walletB));
+    expect(again).toEqual({ copied: 0, skipped: 1, messages: 0 });
+  });
+
+  it("isolates faults: a corrupt source session is counted skipped, healthy ones copy", async () => {
+    const src = storeFor(walletA);
+    await seed(src, meta("s-ok", "healthy", 2000), 3);
+    await seed(src, meta("s-bad", "broken", 1000), PAGE_SIZE + 5); // 2 pages
+    // Corrupt the OLDER page: listMine (newest page only) still lists the session,
+    // so the migration attempts it and must fail per-session, not abort the run.
+    writeFileSync(join(dirFor(walletA), "s-bad__p0.log"), "not an encrypted record\n");
+
+    const report = await migrateSessions(storeFor(walletA), storeFor(walletB));
+    expect(report.copied).toBe(1);
+    expect(report.skipped).toBe(1);
+    expect(report.messages).toBe(3);
+
+    const listed = await storeFor(walletB).listMine();
+    expect(listed.map((s) => s.sessionId)).toEqual(["s-ok"]);
+    expect((await storeFor(walletB).load("s-ok"))?.messages).toHaveLength(3);
+  });
+
+  it("covers the guest-unlock shape: a signMessage-only device wallet migrates into a real wallet", async () => {
+    // Mirror of the surface's deviceGuestWallet: session-key signing works, chain signing
+    // fails closed. Migration must only ever need signMessage.
+    const guest: Wallet = {
+      ...testWallet(3),
+      async signTransaction() {
+        throw new Error("Connect a wallet to use on-chain actions.");
+      },
+      async signAllTransactions() {
+        throw new Error("Connect a wallet to use on-chain actions.");
+      },
+    } as Wallet;
+    await seed(storeFor(guest), meta("g1", "guest chat", 1234), 2);
+
+    const report = await migrateSessions(storeFor(guest), storeFor(walletB));
+    expect(report).toEqual({ copied: 1, skipped: 0, messages: 2 });
+    expect((await storeFor(walletB).load("g1"))?.messages).toHaveLength(2);
+    expect((await storeFor(guest).load("g1"))?.messages).toHaveLength(2); // guest copy intact
+  });
+});

--- a/packages/core/src/account/migrate.ts
+++ b/packages/core/src/account/migrate.ts
@@ -1,0 +1,69 @@
+// Re-key migration: copy every session from one wallet's store into another's.
+// Reads decrypt under the SOURCE wallet's key (load), writes re-encrypt under the
+// DESTINATION's (appendMessage/recordMeta) — the crypto is entirely inherited from
+// SessionStore; none happens here. Non-destructive by construction: the source is
+// only ever read, so its pages stay intact (and readable by the old wallet).
+//
+// The two composed stores ARE the parameters: the guest-unlock flow passes
+// device-key → real-wallet stores, a wallet switch passes SessionStore(A) →
+// SessionStore(B). Meta (sessionId/cli/title/ts/lastDevice) is written verbatim
+// into each destination page, so identity and ordering survive the copy.
+//
+// Idempotent: sessions already complete in the destination are skipped; a partial
+// copy (an interrupted earlier run) resumes — only the missing tail is appended,
+// matched by JSON prefix; a same-id session with DIFFERENT content is never touched.
+
+import type { SessionStore } from "./store.js";
+
+export interface MigrationReport {
+  copied: number; // sessions that landed new content (full copy, resumed tail, or meta-only)
+  skipped: number; // already complete, divergent same-id, or unreadable in the source
+  messages: number; // messages appended to the destination across all sessions
+}
+
+export async function migrateSessions(
+  source: SessionStore,
+  destination: SessionStore,
+): Promise<MigrationReport> {
+  const report: MigrationReport = { copied: 0, skipped: 0, messages: 0 };
+  const existing = new Set((await destination.listMine()).map((s) => s.sessionId));
+  for (const meta of await source.listMine()) {
+    // Per-session tolerance (mirrors listMine's): one undecryptable/corrupt session
+    // must not abort the run — count it and keep copying the healthy ones.
+    try {
+      const session = await source.load(meta.sessionId);
+      if (!session) {
+        report.skipped += 1;
+        continue;
+      }
+      let start = 0;
+      if (existing.has(meta.sessionId)) {
+        const current = await destination.load(meta.sessionId);
+        if (!current || current.messages.length >= session.messages.length) {
+          report.skipped += 1; // destination already complete (or ahead)
+          continue;
+        }
+        const samePrefix = current.messages.every(
+          (m, i) => JSON.stringify(m) === JSON.stringify(session.messages[i]),
+        );
+        if (!samePrefix) {
+          report.skipped += 1; // divergent history — never overwrite
+          continue;
+        }
+        start = current.messages.length; // resume: append only the missing tail
+      }
+      if (session.messages.length === 0) {
+        await destination.recordMeta(meta); // meta-only session still shows up in lists
+      } else {
+        for (const m of session.messages.slice(start)) {
+          await destination.appendMessage(meta, m);
+          report.messages += 1;
+        }
+      }
+      report.copied += 1;
+    } catch {
+      report.skipped += 1;
+    }
+  }
+  return report;
+}

--- a/packages/core/src/index.ts
+++ b/packages/core/src/index.ts
@@ -157,6 +157,9 @@ export {
 export { STORAGE_OPTIONS } from "./account/storage/adapter.js";
 export type { StorageConfig, StorageKind } from "./account/storage/adapter.js";
 export { manualStorage } from "./account/storage/manual.js";
+// re-key migration: copy sessions between two wallets' stores (guest unlock, wallet switch)
+export { migrateSessions } from "./account/migrate.js";
+export type { MigrationReport } from "./account/migrate.js";
 // session-key lifetime policy: ephemeral (memory, default) vs persisted (KeyVault).
 // A surface picks one to enable "local storage mode"; default stays ephemeral.
 export { ephemeralKey, persistedKey } from "./account/keyPolicy.js";

--- a/surfaces/localhost/src/index.ts
+++ b/surfaces/localhost/src/index.ts
@@ -75,6 +75,7 @@ import {
   manualStorage,
 } from "@iqlabs-official/agent-sdk";
 import { SessionStore } from "@iqlabs-official/agent-sdk/account/store";
+import { migrateSessions } from "@iqlabs-official/agent-sdk/account/migrate";
 
 const PORT = Number(process.env.AGENTNET_PORT ?? 4317);
 const GOOGLE_AUTHORIZE_URL = process.env.GOOGLE_AUTHORIZE_URL || "";
@@ -199,31 +200,20 @@ async function ensureGuestRuntime(): Promise<AgentRuntime> {
 }
 
 // Preserve the value-first conversation when the user unlocks. Guest pages are decrypted
-// with the device key and appended into the real wallet's local store, which re-encrypts
-// them with the wallet-derived key. Existing destination sessions are never duplicated.
+// with the device key and re-encrypted into the real wallet's local store; the copy loop
+// (dedupe/resume/fault tolerance) lives in core's migrateSessions — this owns the surface
+// part only: which wallets and stores are involved.
 async function migrateGuestSessions(realWallet: Wallet): Promise<void> {
   const guest = await deviceGuestWallet();
-  const source = new SessionStore(guest, manualStorage(guest.address));
-  const destination = new SessionStore(realWallet, manualStorage(realWallet.address));
-  const existing = new Set((await destination.listMine()).map((s) => s.sessionId));
-  for (const meta of await source.listMine()) {
-    const session = await source.load(meta.sessionId);
-    if (!session) continue;
-    let start = 0;
-    if (existing.has(meta.sessionId)) {
-      const current = await destination.load(meta.sessionId);
-      if (!current || current.messages.length >= session.messages.length) continue;
-      const samePrefix = current.messages.every((message, index) =>
-        JSON.stringify(message) === JSON.stringify(session.messages[index]),
-      );
-      if (!samePrefix) continue;
-      start = current.messages.length;
-    }
-    if (session.messages.length === 0) {
-      await destination.recordMeta(meta);
-      continue;
-    }
-    for (const message of session.messages.slice(start)) await destination.appendMessage(meta, message);
+  const report = await migrateSessions(
+    new SessionStore(guest, manualStorage(guest.address)),
+    new SessionStore(realWallet, manualStorage(realWallet.address)),
+  );
+  if (report.copied || report.skipped) {
+    console.log(
+      `[wallet] guest migration: ${report.copied} session(s) copied ` +
+        `(${report.messages} messages), ${report.skipped} skipped`,
+    );
   }
 }
 


### PR DESCRIPTION
# Your chat history survives a wallet switch: `migrateSessions` re-keys sessions between wallets

Sessions are encrypted per wallet (the key derives from the wallet signature), so switching wallets today permanently orphans your chat history — there is no path to carry it over. This adds the general re-key to core: `migrateSessions(source, destination)` reads each session decrypted under wallet A's store and appends it re-encrypted under wallet B's, so the history simply follows you.

- **New: `packages/core/src/account/migrate.ts`** — `migrateSessions(source, destination)` walks the source's sessions via `listMine`/`load` and writes them through the destination's `appendMessage`/`recordMeta`, returning a `MigrationReport` (`copied`/`skipped`/`messages`). Meta (id, title, timestamps, `lastDevice`) is written verbatim, so identity and ordering survive the copy.
- **Non-destructive by construction** — the source store is only ever read; its pages stay byte-identical and remain readable by the old wallet.
- **Idempotent and resumable** — already-complete sessions are skipped; an interrupted copy resumes by appending only the missing tail (prefix-matched message by message); a same-id session with *different* content is never overwritten.
- **Fault-isolated per session** — one corrupt or undecryptable source session is counted `skipped` and the healthy ones still copy; the run never aborts.
- **Zero new crypto** — every encrypt/decrypt happens inside `SessionStore`; `migrate.ts` contains none.
- **Surface refactor** — `surfaces/localhost/src/index.ts`'s `migrateGuestSessions` drops its inline dedupe/resume loop and delegates to core's `migrateSessions`, keeping only what belongs to the surface: which wallets and stores are involved, plus a one-line report log.
- **Exported** from the package index: `migrateSessions` and `MigrationReport`.
- **9 unit tests** (`migrate.spec.ts`): full re-key across a page boundary (destination really pages into `p0`+`p1`), true re-encryption (the source key cannot read the destination's copies), byte-identical source after migration, idempotent re-run, resume-after-interrupt with no gaps or duplicates, divergent-history skip, meta-only sessions, fault isolation with a corrupted page, and the guest-unlock shape (a signMessage-only device wallet migrating into a real wallet).

Verified: core `tsc --noEmit` and the branch's 9-spec vitest suite; the guest-unlock path exercises the same behavior it did before, now through core.

This PR ships the primitive and moves the existing guest migration onto it; wiring it into the wallet-switch flow is left as a follow-up — that one's a product call, not something to presume in a drive-by PR. If you'd rather see a different shape for any of this, happy to rework it. The branch merges cleanly into main and is independent of the other open branches.

---

### Code quality

Held to a strict bar — verified against the diff, not asserted:

1. **No meaningless wrappers with identical input/output** — the one new function does real work (dedupe, prefix-matched resume, per-session fault isolation), and the slimmed `migrateGuestSessions` is not a pass-through either: it resolves the device guest wallet, composes both stores, and logs the report. ✅
2. **Scan existing functions first and reuse; never two functions with the same purpose** — the copy loop already existed inline in the surface; this PR moves it into core and deletes the surface copy, reusing `listMine`/`load`/`appendMessage`/`recordMeta` so the dedupe/resume logic exists in exactly one place. ✅
3. **No type variables that won't be reused; inline them** — the only named type added is `MigrationReport`, and it earns the name: it is the exported public return type, consumed by the surface's log line and asserted against in the tests; everything else uses the existing `runtime/contract` types. ✅
4. **No non-essential parameters** — `migrateSessions(source, destination)` takes exactly the two stores and nothing else; no options bag, no flags — the composed stores already carry wallet, key, and storage location. ✅
5. **Keep responsibilities separated; if the design feels wrong, say so** — crypto stays in `SessionStore`, copy policy in `migrate.ts`, wallet/store selection and logging in the surface; the one sharp edge (resume matches messages by `JSON.stringify` prefix, so both sides must serialize identically) is called out in comments in both the module and the spec rather than hidden. ✅

`tsc --noEmit` clean; all 9 new specs pass; no regressions — the 8 failing specs (rpc/seed/dasSource/skillSource/session) are pre-existing on main and environment-dependent.

---

## Relates to

No open issue. Area: core session encryption / wallet identity — chat history is orphaned on wallet switch because sessions are encrypted per wallet with no re-key path.

## Risks

**Low.** Additive core module plus a refactor of the existing guest migration onto it. The source store is read-only by construction (asserted byte-identical in tests), no new crypto is introduced, no storage schema changes, and the wallet-switch product flow is deliberately *not* wired up here — nothing existing changes behavior except `migrateGuestSessions`, which is covered by a dedicated spec.

## Background — what & why

**What:** a core `migrateSessions(source, destination)` primitive that copies every session from one wallet's encrypted store into another's, re-encrypted under the destination key, idempotently and resumably; the localhost surface's guest-unlock migration is moved onto it.

**Why:** the per-wallet encryption key means switching wallets silently loses all chat history today. This ships the safe, reusable re-key so the guest-unlock path stops carrying its own copy loop and the future wallet-switch flow has a tested primitive to call.

## Testing — where a reviewer starts + steps

Start at `packages/core/src/account/migrate.spec.ts` — the 9 specs are the executable walkthrough of every claim above.

1. `cd packages/core && npx vitest run src/account/migrate.spec.ts` → 9/9 pass.
2. `npx tsc --noEmit` → clean.
3. Read the "byte-identical source" and "resume-after-interrupt" specs to confirm non-destructiveness and resumability are asserted, not claimed.
4. In `surfaces/localhost/src/index.ts`, confirm `migrateGuestSessions` now only composes stores and logs the `MigrationReport` — the copy loop lives solely in core.

## Evidence

| Row | Artifact |
|---|---|
| Before/After screenshots | N/A - backend-only (core library + surface internals), no UI surface; see backend test logs below |
| Video walkthrough (MP4) | N/A - backend-only, nothing on screen to record; behavior is demonstrated end-to-end by the spec run |
| Backend logs | `packages/core/src/account/migrate.spec.ts` — 9/9 pass via `npx vitest run src/account/migrate.spec.ts`, exercising the real code path end-to-end: full re-key across a page boundary (destination pages into `p0`+`p1`), resume-after-interrupt with no gaps or duplicates, and fault isolation past a corrupted source page |
| Frontend logs | N/A - no frontend code touched; no requests or client state involved |
| Real-LLM trajectory | N/A - no agent, model, or prompt changes; pure storage/crypto plumbing |
| Domain artifacts | `MigrationReport { copied, skipped, messages }` returned by every run and asserted against in the specs; source store pages verified **byte-identical** after migration (the non-destructive guarantee, asserted byte-for-byte in the spec, not inferred) |

A reviewer can confirm the feature works from the spec run alone: the tests construct two wallet-keyed stores, migrate between them, and assert re-encryption, source integrity, idempotency, resume, and fault isolation without any manual setup.
