### PR TITLE
Model picker now shows the exact model you're choosing — real versioned names, no opaque "Default"

### DIFF
--- a/packages/core/src/chat/modelOptions.ts
+++ b/packages/core/src/chat/modelOptions.ts
@@ -11,20 +11,20 @@ export type ChatModelOption = {
 // `value` (passed as the CLI/app-server model override); surfaces use the richer
 // labels/descriptions so the picker is understandable instead of exposing bare aliases.
 // No bare "default" pseudo-entry: the first real model is the sensible default, and the
-// picker shows its actual name (e.g. "Opus 4.8") instead of an opaque "default" chip.
+// picker shows its actual name (e.g. "Opus 5") instead of an opaque "default" chip.
 // This is only the offline/fallback baseline — surfaces upgrade to the CLI's live list.
 export const CHAT_MODEL_OPTIONS: Record<EngineKey, ChatModelOption[]> = {
   claude: [
     {
       value: "opus",
-      chipLabel: "Opus 4.8",
-      label: "Opus 4.8",
+      chipLabel: "Opus 5",
+      label: "Opus 5",
       description: "Most capable · Claude alias: opus",
     },
     {
       value: "sonnet",
-      chipLabel: "Sonnet 4.6",
-      label: "Sonnet 4.6",
+      chipLabel: "Sonnet 5",
+      label: "Sonnet 5",
       description: "Balanced · Claude alias: sonnet",
     },
     {

--- a/packages/core/src/runtime/claudeModels.ts
+++ b/packages/core/src/runtime/claudeModels.ts
@@ -24,14 +24,24 @@ function modelToOption(model: ModelInfo): ChatModelOption {
   // distinct label like "Opus (1M context)" is left as-is.
   const lead = desc?.split(" · ")[0]?.trim(); // "Fable 5" or "Opus 5 with 1M context"
   if (model.value === "default" && lead) {
-    // The CLI's "Default (recommended)" hides the real model name in its description, and
-    // supportedModels() doesn't return it standalone — relabel it with the actual model name.
+    // The CLI's "Default (recommended)" hides the real model name in its description.
+    // Keep the "Default" identity (this entry auto-follows the CLI's recommendation) but
+    // reveal the model it currently resolves to — "Default · Opus 5". Without the "Default ·"
+    // prefix the chip reads as a bare "Opus 5", which collides with the separate explicit
+    // "Opus (1M context)" entry (the same underlying model) and looks like a duplicate.
     full = lead;
-    chip = lead.split(" with ")[0].trim(); // "Opus 5"
-  } else if (lead && lead.toLowerCase().startsWith(displayName.toLowerCase()) && lead.length > displayName.length) {
-    const versioned = lead.split(" with ")[0].trim(); // drop any "with 1M context" for the chip
-    chip = versioned;
-    full = versioned;
+    chip = `Default · ${lead.split(" with ")[0].trim()}`; // "Default · Opus 5"
+  } else if (lead && lead.toLowerCase().startsWith(displayName.toLowerCase())) {
+    // Relabel ONLY when the lead is "<family> <version>" — a version token being digits with
+    // optional dotted minors ("Fable" → "Fable 5", "Haiku" → "Haiku 4.5"). Anything else after
+    // the family — "Opus (1M context)", a "Sonnet Reasoning" variant — has no version token, so
+    // we leave the chip as the bare family and don't invent a versioned name.
+    const version = lead.slice(displayName.length).match(/^\s+(\d+(?:\.\d+)*)\b/);
+    if (version) {
+      const versioned = `${lead.slice(0, displayName.length)} ${version[1]}`; // family (orig case) + version
+      chip = versioned;
+      full = versioned;
+    }
   }
   const extra = `Claude alias: ${model.value}`;
   return {

--- a/packages/core/src/runtime/claudeModels.ts
+++ b/packages/core/src/runtime/claudeModels.ts
@@ -14,18 +14,24 @@ import { resolveExecutable } from "./resolveExecutable.js";
 
 function modelToOption(model: ModelInfo): ChatModelOption {
   const desc = model.description?.trim();
-  let chip = model.displayName?.trim() || model.value;
-  let full = chip;
-  // The CLI's default entry is named "Default (recommended)" and hides the real model
-  // name in its description ("Opus 4.8 with 1M context · ..."). supportedModels() does not
-  // return that model as a standalone entry, so relabel the default with its actual model
-  // name instead of showing an opaque "Default" on the chip.
-  if (model.value === "default" && desc) {
-    const lead = desc.split(" · ")[0]?.trim(); // "Opus 4.8 with 1M context"
-    if (lead) {
-      full = lead;
-      chip = lead.split(" with ")[0].trim(); // "Opus 4.8"
-    }
+  const displayName = model.displayName?.trim() || model.value;
+  let chip = displayName;
+  let full = displayName;
+  // The version number lives in the DESCRIPTION ("Fable 5 · …", "Opus 5 with 1M context · …")
+  // while displayName is often the bare family ("Fable", "Sonnet", "Haiku"). Prefer the
+  // description's lead so the chip shows the real versioned name (Fable 5, Sonnet 5, Haiku 4.5),
+  // matching the CLI's own picker — but only when it's clearly "<displayName> <version>", so a
+  // distinct label like "Opus (1M context)" is left as-is.
+  const lead = desc?.split(" · ")[0]?.trim(); // "Fable 5" or "Opus 5 with 1M context"
+  if (model.value === "default" && lead) {
+    // The CLI's "Default (recommended)" hides the real model name in its description, and
+    // supportedModels() doesn't return it standalone — relabel it with the actual model name.
+    full = lead;
+    chip = lead.split(" with ")[0].trim(); // "Opus 5"
+  } else if (lead && lead.toLowerCase().startsWith(displayName.toLowerCase()) && lead.length > displayName.length) {
+    const versioned = lead.split(" with ")[0].trim(); // drop any "with 1M context" for the chip
+    chip = versioned;
+    full = versioned;
   }
   const extra = `Claude alias: ${model.value}`;
   return {


### PR DESCRIPTION
# Model picker now shows the exact model you're choosing — real versioned names, and "Default · Opus 5" reveals what Default resolves to

The picker gets its model list live from the installed Claude CLI (`supportedModels()`), but the labels derived from that list dropped information: chips showed the bare family ("Fable", "Sonnet", "Haiku") because the CLI keeps the version in the *description*, and the offline fallback still named last generation's models. Both are fixed, conservatively:

- **Chips take the versioned name from the description lead** — "Fable 5", "Sonnet 5", "Haiku 4.5" — matching the CLI's own picker (`packages/core/src/runtime/claudeModels.ts`).
- **Relabel only on a real version token.** The chip is rewritten only when the lead is `<displayName> <version>` — digits with optional dotted minors ("5", "4.5"). A distinct label like **"Opus (1M context)"** has no version token, so it is left exactly as-is instead of being mangled (the review fix, `08f63e9`).
- **The "Default (recommended)" entry now reads "Default · Opus 5"** (refined during review). An earlier iteration relabelled it to a bare "Opus 5", which collided visually with the separate explicit **"Opus (1M context)"** entry — the same underlying model — so the picker looked like it listed two Opus 5s. The `model.value === "default"` branch now builds `` chip = `Default · ${lead.split(" with ")[0].trim()}` ``: the chip keeps its "Default" identity (this entry auto-follows the CLI's recommendation as it changes) while revealing the model it currently resolves to, so it no longer reads as a duplicate.
- **Stale offline fallback refreshed**: "Opus 4.8" → "Opus 5", "Sonnet 4.6" → "Sonnet 5" (`packages/core/src/chat/modelOptions.ts`). This baseline only shows if the live probe fails; the Codex fallback is untouched — the live probe is authoritative there.

**Verified:** on-device — the picker chips read **Default · Opus 5 | Opus (1M context) | Fable 5 | Sonnet 5 | Haiku 4.5**, with the non-versioned "Opus (1M context)" label correctly left intact and the default entry clearly distinct from it.

### Code quality
Held to a strict bar — verified against this diff, not asserted:
1. **No meaningless wrappers with identical input/output** — ✅ no new functions; the change refines the existing `modelToOption` in place.
2. **Scan existing functions first and reuse; never two functions with the same purpose** — ✅ the description-lead parsing that already existed for the "default" entry is generalized to cover all entries in the same block, not duplicated into a parallel path; the "Default · " prefix is one template literal in the existing `model.value === "default"` branch.
3. **No type variables that won't be reused; inline them** — ✅ no types added or changed; `ChatModelOption` and `ModelInfo` are reused as-is.
4. **No non-essential parameters** — ✅ `modelToOption(model)` keeps its one-parameter signature; the version guard derives everything from `model` itself.
5. **Keep responsibilities separated; if the design feels wrong, say so** — ✅ the live CLI probe stays the single source of truth for *which* models exist; this branch only corrects derived display labels and a stale offline baseline, and the code comments state exactly when relabeling is refused.

Core `tsc --noEmit` is clean; no test regressions — the 8 failing vitest specs (rpc/seed/dasSource/skillSource/session) are pre-existing on main and env-dependent. Merges cleanly into main with no conflicts.

## Relates to

No open issue — UI-accuracy follow-up in the chat composer's model picker (`packages/core/src/runtime/claudeModels.ts`, `packages/core/src/chat/modelOptions.ts`), completing the catalog review that produced fix `08f63e9`.

## Risks

**Low.** Display labels only — the `value` sent to the CLI is untouched, so model selection behavior cannot change. Worst case is a mislabeled chip, and the guard refuses to relabel anything without a `<displayName> <version>` lead; the "Default · " prefix is likewise display-only, derived from the same description lead. The refreshed offline fallback is only visible when the live probe fails; the Codex catalog is untouched.

## Background — what & why

The picker's model list is live and correct, but the derived chip text dropped the version ("Fable" instead of "Fable 5") and the offline baseline still named last generation's models — so users couldn't tell which model they were actually choosing. The default entry had the inverse problem: an opaque "Default" hid its model, and a bare "Opus 5" relabel looked like a duplicate of the explicit "Opus (1M context)" entry (the same underlying model). This branch fixes the label derivation conservatively (details in the description above) without touching which models exist or how they're selected.

## Testing — where a reviewer starts + steps

Start in the app's chat screen with Claude connected (any chat).

1. Tap the **AUTO EDIT** controls disclosure next to the CLAUDE/CODEX tabs — the panel opens with the **MODEL** row.
2. Confirm the chips read **Default · Opus 5 | Opus (1M context) | Fable 5 | Sonnet 5 | Haiku 4.5** — versioned names, no bare "Fable"/"Sonnet"/"Haiku", and the default entry shows both its "Default" role and the model it resolves to.
3. Confirm **"Opus (1M context)"** is left exactly as-is (no version token in its lead, so the relabel guard refuses it) — and that "Default · Opus 5" reads as a distinct entry, not a second Opus 5.
4. Cross-check against the CLI itself: the attached probe log runs the branch's heuristic over every entry the installed Claude CLI returns from `supportedModels()` — compare its `CHIP` column to the chips on screen.

## Evidence

| Gate item | Evidence |
|---|---|
| Before/After screenshots | **After (real, on-device, re-captured with the refinement):** `evidence/12-model-picker-after.png` — embedded below; the MODEL row shows **DEFAULT · OPUS 5**. **Before:** N/A - the pre-fix build is no longer installed on the device; the pre-fix chip text is the `displayName` column in the probe log below (`Fable`, `Sonnet`, `Haiku`, `Default (recommended)`). |
| Video walkthrough (MP4) | N/A - one static picker surface; the screenshot plus the live probe log show the entire change. |
| Backend logs | **Real:** `evidence/12-supportedModels-probe.log` — live `supportedModels()` probe against the installed Claude CLI (2026-08-12), running the branch's chip heuristic over every real entry; embedded below. |
| Frontend logs | N/A - no request/response path; the picker renders the same in-process catalog captured in the backend probe log. |
| Real-LLM trajectory | N/A - label derivation from `supportedModels()` metadata, not a model call. |
| Domain artifacts | **Live chip data** (the probe log): relabel fires only on a real `<family> <version>` token — `Fable`→`Fable 5`, `Sonnet`→`Sonnet 5`, `Haiku`→`Haiku 4.5`, `default`→`Default · Opus 5`, and **`Opus (1M context)` is left intact** because its lead has no version token for its displayName. |

![Model picker on-device: versioned chips, "Default · Opus 5" for the default entry, and the non-versioned "Opus (1M context)" left intact](https://github.com/RemilioNubilio/AgentNet/releases/download/pr-evidence/12-model-picker-after.png)

*The picker open on-device (branch build): chips read Default · Opus 5 | Opus (1M context) | Fable 5 | Sonnet 5 | Haiku 4.5, with the selected model's full description underneath.*

Live probe log (`evidence/12-supportedModels-probe.log`, 2026-08-12 — `displayName` is the pre-fix chip, `CHIP` is what this branch renders):

```
# live supportedModels() probe against the installed Claude CLI — 2026-08-12 14:08 PDT
# script: probe-models.mjs — calls the SDK's supportedModels() live, then applies the branch chip heuristic verbatim
# columns: value | displayName (pre-fix chip) | description | CHIP (this branch renders) | FULL
{"value":"default","displayName":"Default (recommended)","description":"Opus 5 with 1M context · Best for everyday, complex tasks","CHIP":"Default · Opus 5","FULL":"Opus 5 with 1M context"}
{"value":"opus[1m]","displayName":"Opus (1M context)","description":"Opus 5 with 1M context · Best for everyday, complex tasks","CHIP":"Opus (1M context)","FULL":"Opus (1M context)"}
{"value":"claude-fable-5[1m]","displayName":"Fable","description":"Fable 5 · Most capable for your hardest and longest-running tasks","CHIP":"Fable 5","FULL":"Fable 5"}
{"value":"sonnet","displayName":"Sonnet","description":"Sonnet 5 · Efficient for routine tasks","CHIP":"Sonnet 5","FULL":"Sonnet 5"}
{"value":"haiku","displayName":"Haiku","description":"Haiku 4.5 · Fastest for quick answers","CHIP":"Haiku 4.5","FULL":"Haiku 4.5"}
```
