### PR TITLE
Make the permission-mode chips real: working Codex modes and a Claude Bypass chip

### DIFF
--- a/packages/core/src/chat/ui/webview.ts
+++ b/packages/core/src/chat/ui/webview.ts
@@ -2476,6 +2476,7 @@ export function chatHtml(): string {
       { value: 'default',     label: 'Ask edits',    title: 'Ask before each file edit (default)' },
       { value: 'acceptEdits', label: 'Auto edit',    title: 'Auto-accept file edits; still ask for other tools' },
       { value: 'plan',        label: 'Plan',         title: 'Plan mode: read-only until you approve the plan' },
+      { value: 'bypassPermissions', label: 'YOLO', title: 'Skip every approval — auto-runs all commands, edits, and on-chain spends. Use with care.' },
     ],
     codex: [
       { value: 'readonly', label: 'Read only',   title: 'Read-only sandbox; ask before edits, commands, network' },

--- a/packages/core/src/chat/ui/webview.ts
+++ b/packages/core/src/chat/ui/webview.ts
@@ -2476,7 +2476,7 @@ export function chatHtml(): string {
       { value: 'default',     label: 'Ask edits',    title: 'Ask before each file edit (default)' },
       { value: 'acceptEdits', label: 'Auto edit',    title: 'Auto-accept file edits; still ask for other tools' },
       { value: 'plan',        label: 'Plan',         title: 'Plan mode: read-only until you approve the plan' },
-      { value: 'bypassPermissions', label: 'YOLO', title: 'Skip every approval — auto-runs all commands, edits, and on-chain spends. Use with care.' },
+      { value: 'bypassPermissions', label: 'Bypass', title: 'Bypass all permission prompts (--dangerously-skip-permissions) — auto-runs every command, edit, and on-chain spend. Use with care.' },
     ],
     codex: [
       { value: 'readonly', label: 'Read only',   title: 'Read-only sandbox; ask before edits, commands, network' },

--- a/packages/core/src/chat/ui/webview.ts
+++ b/packages/core/src/chat/ui/webview.ts
@@ -2476,7 +2476,7 @@ export function chatHtml(): string {
       { value: 'default',     label: 'Ask edits',    title: 'Ask before each file edit (default)' },
       { value: 'acceptEdits', label: 'Auto edit',    title: 'Auto-accept file edits; still ask for other tools' },
       { value: 'plan',        label: 'Plan',         title: 'Plan mode: read-only until you approve the plan' },
-      { value: 'bypassPermissions', label: 'Bypass', title: 'Bypass all permission prompts (--dangerously-skip-permissions) — auto-runs every command, edit, and on-chain spend. Use with care.' },
+      { value: 'bypassPermissions', label: 'Bypass', title: 'Bypass all permission prompts (--dangerously-skip-permissions). Auto-runs every command, edit, and on-chain spend. Use with care.' },
     ],
     codex: [
       { value: 'readonly', label: 'Read only',   title: 'Read-only sandbox; ask before edits, commands, network' },

--- a/packages/core/src/runtime/spawn.ts
+++ b/packages/core/src/runtime/spawn.ts
@@ -384,7 +384,10 @@ function claudeEngine(opts: SpawnOpts): Engine {
     ...process.env,
     ...(opts.githubToken ? gitCredentialEnv(opts.githubToken) : {}),
   };
-  if (opts.mode === "bypassPermissions" && process.getuid?.() === 0) {
+  // AGENTNET_CODEX_SANDBOX is set only by the Android launcher (ServerManager) → it marks the
+  // proot guest. Require it so IS_SANDBOX is set ONLY inside that genuinely-sandboxed guest, not
+  // on any random root host (a desktop running as root would otherwise get an unguarded bypass).
+  if (opts.mode === "bypassPermissions" && process.getuid?.() === 0 && process.env.AGENTNET_CODEX_SANDBOX) {
     claudeEnv.IS_SANDBOX = "1";
   }
 
@@ -522,7 +525,13 @@ function codexEngine(opts: SpawnOpts): Engine {
   const sandbox = process.env.AGENTNET_CODEX_SANDBOX || undefined;
   // Make the codex mode chips real: derive the approval policy + sandbox from opts.mode.
   // A mode change restages the session (session.ts), so the next spawn picks these up.
-  const codexApproval = codexApprovalPolicy(opts.mode);
+  // When the OS sandbox is FORCED by env (Android proot can't run bubblewrap → danger-full-access),
+  // a non-"full" mode must NOT weaken to on-failure: the sandbox isn't really constraining there, so
+  // the approval gate is the only real control and must keep asking. Only "full" opts out. Desktop
+  // (no env override) uses the mode's own policy.
+  const codexApproval = sandbox
+    ? (opts.mode === "full" ? "never" : "on-request")
+    : codexApprovalPolicy(opts.mode);
   const effectiveSandbox = codexSandbox(opts.mode, sandbox);
   const childEnv = { ...process.env, ...gitCredentialEnv(opts.githubToken) };
   if (opts.apiKey) {

--- a/packages/core/src/runtime/spawn.ts
+++ b/packages/core/src/runtime/spawn.ts
@@ -375,6 +375,19 @@ function claudeEngine(opts: SpawnOpts): Engine {
     return { behavior: "allow" as const, updatedInput: decision.updatedInput ?? input };
   };
 
+  // The SDK `env` REPLACES the subprocess environment, so start from process.env (keeps
+  // PATH / ANTHROPIC creds) and layer the git token on top when present. Claude Code refuses
+  // --dangerously-skip-permissions (bypassPermissions) when running as root "for security
+  // reasons"; the proot guest IS root AND sandboxed (Android app sandbox + proot), so signal
+  // IS_SANDBOX to let YOLO actually work on-device. Guarded to root + bypass — a no-op elsewhere.
+  const claudeEnv: NodeJS.ProcessEnv = {
+    ...process.env,
+    ...(opts.githubToken ? gitCredentialEnv(opts.githubToken) : {}),
+  };
+  if (opts.mode === "bypassPermissions" && process.getuid?.() === 0) {
+    claudeEnv.IS_SANDBOX = "1";
+  }
+
   const q = query({
     prompt: prompts(),
     options: {
@@ -408,7 +421,7 @@ function claudeEngine(opts: SpawnOpts): Engine {
       ...(opts.enabledSkills?.length ? { skills: opts.enabledSkills } : {}),
       // Give the agent's git the configured GitHub token. The SDK `env` REPLACES the
       // subprocess environment, so spread process.env to keep PATH / ANTHROPIC creds / etc.
-      ...(opts.githubToken ? { env: { ...process.env, ...gitCredentialEnv(opts.githubToken) } } : {}),
+      env: claudeEnv,
       // NOTE: settingSources is deliberately omitted — the SDK then loads ALL sources
       // (user/project/local), which is what lets skills in the user dir (~/.claude/skills,
       // where owned NFTs + the passive workflow are installed) be discovered. Passing

--- a/packages/core/src/runtime/spawn.ts
+++ b/packages/core/src/runtime/spawn.ts
@@ -142,6 +142,27 @@ function claudePermissionMode(
     : "default";
 }
 
+// Codex approval policy per UI mode. The picker sends "auto" | "readonly" | "full"; the
+// codex app-server takes an approvalPolicy. (Sandbox is a separate axis — see codexSandbox.)
+// Previously the app hardcoded "on-request" and ignored the mode, so the codex chips did
+// nothing; this makes them real.
+function codexApprovalPolicy(mode?: string): "on-request" | "on-failure" | "never" {
+  if (mode === "full") return "never"; // full access, never ask
+  if (mode === "auto") return "on-failure"; // auto-run in the workspace; ask only on failure/escalation
+  return "on-request"; // readonly + default: ask before edits, commands, network
+}
+
+// Codex OS sandbox per UI mode. AGENTNET_CODEX_SANDBOX wins when set (Android forces
+// danger-full-access because bubblewrap can't run under proot — there the approvalPolicy
+// above is the real control); otherwise derive the sandbox from the mode.
+function codexSandbox(mode: string | undefined, envSandbox: string | undefined): string | undefined {
+  if (envSandbox) return envSandbox;
+  if (mode === "full") return "danger-full-access";
+  if (mode === "readonly") return "read-only";
+  if (mode === "auto") return "workspace-write";
+  return undefined; // codex default
+}
+
 export function spawnCli(opts: SpawnOpts): Engine {
   return opts.cli === "claude" ? claudeEngine(opts) : codexEngine(opts);
 }
@@ -486,6 +507,10 @@ function codexEngine(opts: SpawnOpts): Engine {
   // AGENTNET_CODEX_SANDBOX=danger-full-access so Codex skips its own sandbox and relies on
   // proot + the app sandbox + our approval gate. Desktop leaves it unset → Codex's default.
   const sandbox = process.env.AGENTNET_CODEX_SANDBOX || undefined;
+  // Make the codex mode chips real: derive the approval policy + sandbox from opts.mode.
+  // A mode change restages the session (session.ts), so the next spawn picks these up.
+  const codexApproval = codexApprovalPolicy(opts.mode);
+  const effectiveSandbox = codexSandbox(opts.mode, sandbox);
   const childEnv = { ...process.env, ...gitCredentialEnv(opts.githubToken) };
   if (opts.apiKey) {
     childEnv.OPENAI_API_KEY = opts.apiKey;
@@ -876,9 +901,9 @@ function codexEngine(opts: SpawnOpts): Engine {
           threadId: opts.sessionId,
           model: opts.model,
           cwd: opts.cwd,
-          approvalPolicy: "on-request",
+          approvalPolicy: codexApproval,
           approvalsReviewer: "user",
-          ...(sandbox ? { sandbox } : {}),
+          ...(effectiveSandbox ? { sandbox: effectiveSandbox } : {}),
           ...(opts.effort ? { reasoning_effort: opts.effort } : {}),
         });
         cb.emitSid(opts.sessionId);
@@ -886,9 +911,9 @@ function codexEngine(opts: SpawnOpts): Engine {
         const res = await sendRequest("thread/start", {
           model: opts.model,
           cwd: opts.cwd,
-          approvalPolicy: "on-request",
+          approvalPolicy: codexApproval,
           approvalsReviewer: "user",
-          ...(sandbox ? { sandbox } : {}),
+          ...(effectiveSandbox ? { sandbox: effectiveSandbox } : {}),
           ...(opts.effort ? { reasoning_effort: opts.effort } : {}),
         });
         const threadId = res?.thread?.id;

--- a/surfaces/webview/src/chat/Composer.tsx
+++ b/surfaces/webview/src/chat/Composer.tsx
@@ -67,7 +67,7 @@ const MODES: Record<Cli, { value: string; label: string; title: string }[]> = {
     { value: "default",     label: "Ask edits",  title: "Ask before each file edit (default)" },
     { value: "acceptEdits", label: "Auto edit",  title: "Auto-accept file edits; still ask for other tools" },
     { value: "plan",        label: "Plan",        title: "Plan mode: read-only until you approve the plan" },
-    { value: "bypassPermissions", label: "YOLO", title: "Skip every approval — auto-runs all commands, edits, and on-chain spends. Use with care." },
+    { value: "bypassPermissions", label: "Bypass", title: "Bypass all permission prompts (--dangerously-skip-permissions) — auto-runs every command, edit, and on-chain spend. Use with care." },
   ],
   codex: [
     { value: "readonly", label: "Read only",   title: "Read-only sandbox; ask before edits, commands, network" },

--- a/surfaces/webview/src/chat/Composer.tsx
+++ b/surfaces/webview/src/chat/Composer.tsx
@@ -65,6 +65,7 @@ const MODES: Record<Cli, { value: string; label: string; title: string }[]> = {
     { value: "acceptEdits", label: "Auto edit",  title: "Auto-accept file edits; still ask for other tools" },
     { value: "default",     label: "Ask edits",  title: "Ask before each file edit (default)" },
     { value: "plan",        label: "Plan",        title: "Plan mode: read-only until you approve the plan" },
+    { value: "bypassPermissions", label: "YOLO", title: "Skip every approval — auto-runs all commands, edits, and on-chain spends. Use with care." },
   ],
   codex: [
     { value: "auto",     label: "Auto accept", title: "Auto-accept edits + run inside the workspace (default)" },

--- a/surfaces/webview/src/chat/Composer.tsx
+++ b/surfaces/webview/src/chat/Composer.tsx
@@ -67,7 +67,7 @@ const MODES: Record<Cli, { value: string; label: string; title: string }[]> = {
     { value: "default",     label: "Ask edits",  title: "Ask before each file edit (default)" },
     { value: "acceptEdits", label: "Auto edit",  title: "Auto-accept file edits; still ask for other tools" },
     { value: "plan",        label: "Plan",        title: "Plan mode: read-only until you approve the plan" },
-    { value: "bypassPermissions", label: "Bypass", title: "Bypass all permission prompts (--dangerously-skip-permissions) — auto-runs every command, edit, and on-chain spend. Use with care." },
+    { value: "bypassPermissions", label: "Bypass", title: "Bypass all permission prompts (--dangerously-skip-permissions). Auto-runs every command, edit, and on-chain spend. Use with care." },
   ],
   codex: [
     { value: "readonly", label: "Read only",   title: "Read-only sandbox; ask before edits, commands, network" },

--- a/surfaces/webview/src/chat/Composer.tsx
+++ b/surfaces/webview/src/chat/Composer.tsx
@@ -61,15 +61,17 @@ const EFFORTS = [
 ];
 
 const MODES: Record<Cli, { value: string; label: string; title: string }[]> = {
+  // Kept in the SAME order + wording as the VSCode surface (webview.ts) so the modes read
+  // identically everywhere. Ordered by increasing autonomy.
   claude: [
-    { value: "acceptEdits", label: "Auto edit",  title: "Auto-accept file edits; still ask for other tools" },
     { value: "default",     label: "Ask edits",  title: "Ask before each file edit (default)" },
+    { value: "acceptEdits", label: "Auto edit",  title: "Auto-accept file edits; still ask for other tools" },
     { value: "plan",        label: "Plan",        title: "Plan mode: read-only until you approve the plan" },
     { value: "bypassPermissions", label: "YOLO", title: "Skip every approval — auto-runs all commands, edits, and on-chain spends. Use with care." },
   ],
   codex: [
-    { value: "auto",     label: "Auto accept", title: "Auto-accept edits + run inside the workspace (default)" },
     { value: "readonly", label: "Read only",   title: "Read-only sandbox; ask before edits, commands, network" },
+    { value: "auto",     label: "Auto accept", title: "Auto-accept edits + run inside the workspace; approve on failure (default)" },
     { value: "full",     label: "Full access", title: "Full disk + network access, never ask (use with care)" },
   ],
 };

--- a/surfaces/webview/src/chat/Composer.tsx
+++ b/surfaces/webview/src/chat/Composer.tsx
@@ -62,7 +62,7 @@ const EFFORTS = [
 
 const MODES: Record<Cli, { value: string; label: string; title: string }[]> = {
   // Kept in the SAME order + wording as the VSCode surface (webview.ts) so the modes read
-  // identically everywhere. Ordered by increasing autonomy.
+  // identically everywhere — the SDK's native permission-mode order.
   claude: [
     { value: "default",     label: "Ask edits",  title: "Ask before each file edit (default)" },
     { value: "acceptEdits", label: "Auto edit",  title: "Auto-accept file edits; still ask for other tools" },


### PR DESCRIPTION
# Make the permission-mode chips real: working Codex modes and a Claude Bypass chip

The mode picker looked complete, but picking a mode didn't always change anything. The Codex chips were cosmetic - `thread/start` / `thread/resume` hardcoded `approvalPolicy: "on-request"` and ignored `opts.mode` - and Claude's `bypassPermissions` was already plumbed through but never offered in the UI. This wires every chip to real behavior, with identical wording on both surfaces.

- **Codex modes now drive both real axes** (`packages/core/src/runtime/spawn.ts`): `full → never + danger-full-access`, `auto → on-failure + workspace-write`, `readonly → on-request + read-only`, via two small pure functions (`codexApprovalPolicy`, `codexSandbox`) shared by `thread/start` and `thread/resume`. A mode change already restages the session, so the next spawn applies it.
- **Forced-sandbox safety rule**: when `AGENTNET_CODEX_SANDBOX` forces the OS sandbox (Android proot can't run bubblewrap → `danger-full-access`), the sandbox isn't really constraining, so a non-`full` mode must not weaken the approval gate to `on-failure` - it stays `on-request` and keeps asking. Only an explicit "Full access" opts out.
- **Claude gets a "Bypass" chip** (`Composer.tsx` + `webview.ts`): the SDK's `bypassPermissions` (the `--dangerously-skip-permissions` equivalent), named accurately and labeled honestly - "auto-runs every command, edit, and on-chain spend. Use with care."
- **On-device enabler for Bypass**: Claude Code refuses `--dangerously-skip-permissions` when `euid == 0`, and the proot guest runs as root. The claude subprocess env now sets `IS_SANDBOX=1` - but only when all three hold: mode is `bypassPermissions`, the process is root, and the `AGENTNET_CODEX_SANDBOX` guest marker is present. That marker is set only by the Android launcher, so the escalation can never fire on a random root host.
- **Consistent surfaces**: `Composer.tsx` now lists the modes in the same order and wording as the VSCode surface (`webview.ts`).

Review fixes folded into this pass: the forced-sandbox approval rule above [12], the guest-marker guard on `IS_SANDBOX` [13], and a corrected comment [16].

**Verified**: on-device tonight - Bypass ran tools with zero approval prompts, and the `AGENTNET_CODEX_SANDBOX` guest marker was confirmed present in the running server env.

The Bypass chip is the real judgment call in here - even guarded and labeled, it's a deliberate foot-gun, and whether to offer it at all is your call. The Codex wiring and the wording cleanup stand on their own, so happy to split this, or drop the chip entirely, if you'd rather not expose it.

## Relates to

Permission-mode picker / runtime spawn area (`packages/core/src/runtime/spawn.ts`, `Composer.tsx`, `webview.ts`). Folds in review findings [12] (forced-sandbox approval rule), [13] (guest-marker guard on `IS_SANDBOX`), and [16] (corrected comment). No open issue number.

## Risks

**Medium.** The Bypass chip auto-runs every command, edit, and on-chain spend - a deliberate, honestly-labeled foot-gun, and the maintainer call flagged above. Its root enabler (`IS_SANDBOX=1`) is triple-guarded (mode + root + Android guest marker) so it cannot fire on a random root host. The Codex wiring itself is low risk: two pure mapping functions on the existing restage-on-mode-change path.

## Background - what & why

Users picked modes that silently did nothing: Codex spawns ignored `opts.mode`, and Claude's most permissive mode existed in the runtime with no way to select it. This makes every chip mean what it says - each Codex mode maps to a real approval-policy + sandbox pair, Bypass becomes selectable with honest labeling, and the two safety rules (forced-sandbox keeps prompting; triple-guarded root enabler) make that safe to ship.

## Testing - where a reviewer starts + steps

Start at the composer mode picker (webview or VSCode surface - order and wording are now identical).

1. Pick each Codex chip and start a thread - the spawn must carry the mapped pair: `full → never + danger-full-access`, `auto → on-failure + workspace-write`, `readonly → on-request + read-only`. Change mode mid-session; the restage means the next spawn applies it.
2. With `AGENTNET_CODEX_SANDBOX` set (forced `danger-full-access`), pick a non-full mode - approvals must stay `on-request` (still prompting), not drop to `on-failure`.
3. Pick **Bypass** on a Claude thread and ask for a file write plus a shell command - expect zero approval prompts end-to-end.
4. Negative check on the enabler: on a root host *without* the guest marker, confirm `IS_SANDBOX` is absent from the claude subprocess env.

### Code quality

Held to a strict bar - each point checked against the diff, not asserted:

1. **No meaningless wrappers with identical input/output** - `codexApprovalPolicy` and `codexSandbox` are real mappings (mode → policy / sandbox, with the env override winning), not pass-throughs. ✅
2. **Scan existing functions first and reuse; never two functions with the same purpose** - reuses `claudePermissionMode` (it already accepted `bypassPermissions` on main), the existing restage-on-mode-change path, and the existing `gitCredentialEnv` plumbing; `thread/start` and `thread/resume` share the same two mapping functions instead of duplicating tables. ✅
3. **No type variables that won't be reused; inline them** - the `"on-request" | "on-failure" | "never"` return union is inline on the signature; no single-use type aliases added. ✅
4. **No non-essential parameters** - `codexSandbox(mode, envSandbox)`: both parameters carry a decision (the env override must win); nothing decorative. ✅
5. **Keep responsibilities separated; if the design feels wrong, say so** - approval policy and OS sandbox are Codex's two distinct axes and stay two separate pure functions; the `IS_SANDBOX` escalation is one narrow, triple-guarded block with a comment explaining exactly why it exists. ✅

Merges cleanly into main with zero conflicts. Core `tsc --noEmit` is clean; no test regressions - the 6 failing vitest specs (rpc / seed / dasSource / skillSource / session / migrate) are pre-existing on main and env-dependent.

## Evidence

| Gate | Evidence |
| --- | --- |
| Before/After screenshots | **After (real, on-device):** `evidence/12-model-picker-after.png` - the composer picker's **MODE** row renders `ASK EDITS · AUTO EDIT · PLAN · BYPASS`; the Bypass chip this PR adds is present and selectable. What each chip *does* is the verifiable part - see the backend-log and trajectory rows below. |
| Video walkthrough (MP4) | `N/A - no UI flow beyond selecting a chip; the verifiable behavior (prompt-free tool execution) is captured in the backend-log and trajectory rows below.` |
| Backend logs | **Real, on-device (Solana Seeker):** a `bypassPermissions` turn ran its tools with **zero approval prompts** end-to-end, and the `AGENTNET_CODEX_SANDBOX` guest marker was confirmed present in the running server's environment (env of the proot guest process via `ps`) - i.e. the triple-guard's third condition was live on the exact box where the escalation is meant to fire. |
| Frontend logs | `N/A - no request/response shape changes; the chip only selects the mode string already sent on thread/start, and mode application happens server-side at spawn.` |
| Real-LLM trajectory | **Real, on-device:** the Bypass turn drove **Write + Bash** tool calls unattended - the model executed both without a single approval stop, confirming the mode reached the live claude subprocess. |
| Domain artifacts | The `IS_SANDBOX` escalation held to its triple guard in the verified run - it fired only with mode `bypassPermissions` + `euid == 0` + the guest marker present, and the unattended tool runs above are its downstream artifact. Test results: core `tsc --noEmit` clean; the 6 failing vitest specs are pre-existing on main and env-dependent (rpc / seed / dasSource / skillSource / session / migrate). |


![Composer picker - the MODE row shows the new BYPASS chip](https://github.com/RemilioNubilio/AgentNet/releases/download/pr-evidence/12-model-picker-after.png)


