### PR TITLE
Add an in-app PREVIEW tab: see and test what you build, inside the app

### DIFF
--- a/packages/core/src/memory/previewSection.ts
+++ b/packages/core/src/memory/previewSection.ts
@@ -6,13 +6,11 @@
 //
 // GATED on AGENTNET_PREVIEW_PORT: only the surface that actually HAS the preview tab + announce
 // endpoint (surfaces/localhost, incl. the Android app) sets it. On the CLI/VSCode surfaces the
-// env is unset → the block renders empty and spliceMarkedBlock removes it, so an agent there is
-// never told to hit an endpoint that doesn't exist.
+// env is unset → the block renders empty: an existing block is spliced out, and a file without
+// our markers is left untouched (no write at all), so an agent there is never told to hit an
+// endpoint that doesn't exist.
 
-import { readFile, writeFile } from "node:fs/promises";
-import { join } from "node:path";
-import { claudeMemoryDir, codexAgentsFile } from "../core/paths.js";
-import { spliceMarkedBlock } from "./convert/codex.js";
+import { memoryFileFor, spliceIntoFile } from "./skillsSection.js";
 
 const START = "<!-- agentnet:preview:start -->";
 const END = "<!-- agentnet:preview:end -->";
@@ -29,18 +27,6 @@ function renderBlock(port: string | null): string {
   return `${START}\n${line}\n${END}`;
 }
 
-/** Splice (replace-or-remove) the preview block into a file, preserving everything outside
- *  our markers. Creates the file if missing. */
-async function spliceIntoFile(file: string, block: string): Promise<void> {
-  let existing = "";
-  try {
-    existing = await readFile(file, "utf8");
-  } catch {
-    /* file doesn't exist yet — spliceMarkedBlock returns the block alone */
-  }
-  await writeFile(file, spliceMarkedBlock(existing, block, START, END));
-}
-
 /**
  * Update the "in-app preview" section for one runtime. Renders the hint ONLY when
  * AGENTNET_PREVIEW_PORT is set (the surface with the PREVIEW tab); otherwise removes the block.
@@ -49,9 +35,7 @@ async function spliceIntoFile(file: string, block: string): Promise<void> {
 export async function updatePreviewSection(cli: "claude" | "codex", cwd: string): Promise<void> {
   try {
     const port = process.env.AGENTNET_PREVIEW_PORT || null;
-    const block = renderBlock(port);
-    const file = cli === "claude" ? join(claudeMemoryDir(cwd), "MEMORY.md") : codexAgentsFile(cwd);
-    await spliceIntoFile(file, block);
+    await spliceIntoFile(memoryFileFor(cli, cwd), renderBlock(port), START, END);
   } catch {
     /* never throw from preview-section sync */
   }

--- a/packages/core/src/memory/previewSection.ts
+++ b/packages/core/src/memory/previewSection.ts
@@ -1,0 +1,58 @@
+// "In-app preview" memory section — a managed, auto-updated block that tells the agent the
+// AgentNet app has a PREVIEW tab, so when it builds/runs a web app it should serve it on a
+// loopback port and hand the user the http://localhost:PORT link (which the chat turns into a
+// one-tap preview). Mirrors skillsSection.ts: a SETTER over a marker-delimited block, spliced
+// into claude's MEMORY.md / codex's AGENTS.md, injected every session — no system-prompt nudge.
+//
+// GATED on AGENTNET_PREVIEW_PORT: only the surface that actually HAS the preview tab + announce
+// endpoint (surfaces/localhost, incl. the Android app) sets it. On the CLI/VSCode surfaces the
+// env is unset → the block renders empty and spliceMarkedBlock removes it, so an agent there is
+// never told to hit an endpoint that doesn't exist.
+
+import { readFile, writeFile } from "node:fs/promises";
+import { join } from "node:path";
+import { claudeMemoryDir, codexAgentsFile } from "../core/paths.js";
+import { spliceMarkedBlock } from "./convert/codex.js";
+
+const START = "<!-- agentnet:preview:start -->";
+const END = "<!-- agentnet:preview:end -->";
+
+function renderBlock(port: string | null): string {
+  if (!port) return ""; // no preview surface → remove the block entirely
+  const line = [
+    "In-app preview: this app has a PREVIEW tab that frames a local web server in an iframe.",
+    "When you build or run a web app for the user, start its dev server in the BACKGROUND on a",
+    "loopback port, then give the user the plain http://localhost:PORT link in your reply — it",
+    'becomes a one-tap "open preview" button. (Optional: POST',
+    `http://127.0.0.1:${port}/preview/announce with {"port":N} to open it directly, {"port":null} to clear.)`,
+  ].join("\n");
+  return `${START}\n${line}\n${END}`;
+}
+
+/** Splice (replace-or-remove) the preview block into a file, preserving everything outside
+ *  our markers. Creates the file if missing. */
+async function spliceIntoFile(file: string, block: string): Promise<void> {
+  let existing = "";
+  try {
+    existing = await readFile(file, "utf8");
+  } catch {
+    /* file doesn't exist yet — spliceMarkedBlock returns the block alone */
+  }
+  await writeFile(file, spliceMarkedBlock(existing, block, START, END));
+}
+
+/**
+ * Update the "in-app preview" section for one runtime. Renders the hint ONLY when
+ * AGENTNET_PREVIEW_PORT is set (the surface with the PREVIEW tab); otherwise removes the block.
+ * Call AFTER MemorySync.injectAtStart (which regenerates the files). Best-effort — never throws.
+ */
+export async function updatePreviewSection(cli: "claude" | "codex", cwd: string): Promise<void> {
+  try {
+    const port = process.env.AGENTNET_PREVIEW_PORT || null;
+    const block = renderBlock(port);
+    const file = cli === "claude" ? join(claudeMemoryDir(cwd), "MEMORY.md") : codexAgentsFile(cwd);
+    await spliceIntoFile(file, block);
+  } catch {
+    /* never throw from preview-section sync */
+  }
+}

--- a/packages/core/src/memory/skillsSection.ts
+++ b/packages/core/src/memory/skillsSection.ts
@@ -94,16 +94,26 @@ function renderBlock(skills: InstalledSkillSummary[]): string {
   return `${START}\n${line}\n${END}`;
 }
 
-/** Splice (replace-or-append) the skills line into a file, preserving everything
- *  outside our markers. Creates the file if missing. */
-async function spliceIntoFile(file: string, block: string): Promise<void> {
+/** The memory file a runtime's managed blocks live in: claude's MEMORY.md index in the
+ *  project memory dir, or codex's repo AGENTS.md. Shared by every section updater
+ *  (skills, preview) so the mapping has one source of truth. */
+export function memoryFileFor(cli: "claude" | "codex", cwd: string): string {
+  return cli === "claude" ? join(claudeMemoryDir(cwd), "MEMORY.md") : codexAgentsFile(cwd);
+}
+
+/** Splice (replace-or-append; empty block = remove) a marker-delimited block into a file,
+ *  preserving everything outside the markers. Creates the file if missing. An empty block
+ *  with no existing markers is a no-op — never create or dirty a file just to write
+ *  nothing. Shared by every section updater (skills, preview). */
+export async function spliceIntoFile(file: string, block: string, start: string, end: string): Promise<void> {
   let existing = "";
   try {
     existing = await readFile(file, "utf8");
   } catch {
     /* file doesn't exist yet — spliceMarkedBlock returns the block alone */
   }
-  await writeFile(file, spliceMarkedBlock(existing, block, START, END));
+  if (!block && !existing.includes(start)) return;
+  await writeFile(file, spliceMarkedBlock(existing, block, start, end));
 }
 
 /**
@@ -120,9 +130,7 @@ async function spliceIntoFile(file: string, block: string): Promise<void> {
 export async function updateSkillsSection(cli: "claude" | "codex", cwd: string): Promise<InstalledSkillSummary[]> {
   try {
     const skills = await installedSkillSummaries();
-    const block = renderBlock(skills);
-    const file = cli === "claude" ? join(claudeMemoryDir(cwd), "MEMORY.md") : codexAgentsFile(cwd);
-    await spliceIntoFile(file, block);
+    await spliceIntoFile(memoryFileFor(cli, cwd), renderBlock(skills), START, END);
     return skills;
   } catch {
     /* never throw from skill-section sync */

--- a/packages/core/src/runtime/index.ts
+++ b/packages/core/src/runtime/index.ts
@@ -11,6 +11,7 @@ import { SessionStore } from "../account/store.js";
 import { prepareResume } from "./inject/index.js";
 import { getDeviceProfile, buildDeviceNotice } from "../core/device.js";
 import { MemorySync, updateSkillsSection } from "../memory/index.js";
+import { updatePreviewSection } from "../memory/previewSection.js";
 import { SoulStore } from "../soul/store.js";
 import { injectSoulNative } from "../soul/convert/native.js";
 import { setSkillShoppingActive } from "../skill-market/passive.js";
@@ -154,6 +155,10 @@ export function createRuntime(
         // Must run AFTER injectAtStart, which regenerates MEMORY.md / AGENTS.md.
         const skills = await updateSkillsSection(opts.cli, opts.cwd);
         if (opts.cli === "claude" && skills.length) enabledSkills = skills.map((s) => s.name);
+        // Tell the agent about the in-app PREVIEW tab — but ONLY on the surface that has it
+        // (gated on AGENTNET_PREVIEW_PORT inside). So when it builds a web app it serves it
+        // and hands the user a http://localhost:PORT link, which renders as a preview button.
+        await updatePreviewSection(opts.cli, opts.cwd);
       } catch (e) {
         console.warn("[memory] inject failed:", e);
       }

--- a/surfaces/localhost/package.json
+++ b/surfaces/localhost/package.json
@@ -7,7 +7,8 @@
   "scripts": {
     "build": "tsup",
     "dev": "tsx src/index.ts",
-    "start": "node dist/index.js"
+    "start": "node dist/index.js",
+    "test": "tsx --test src/*.spec.ts"
   },
   "dependencies": {
     "@iqlabs-official/agent-sdk": "workspace:*",

--- a/surfaces/localhost/src/index.ts
+++ b/surfaces/localhost/src/index.ts
@@ -27,6 +27,7 @@ import { mkdir, readFile, rm, writeFile } from "node:fs/promises";
 import { fileURLToPath } from "node:url";
 import { dirname, join, normalize, extname } from "node:path";
 import { homedir } from "node:os";
+import { validatePreviewPort, previewStatusMsg, isLoopback } from "./preview.js";
 import {
   connect,
   createChatSession,
@@ -234,6 +235,8 @@ let onCloudStatus: (() => void) | null = null;
 let googleLoginSession: GoogleLogin | null = null;
 let googleLoginError: string | null = null;
 let claudeLogin: ClaudeLogin | null = null;
+// Preview: the loopback dev-server port announced via POST /preview/announce (null = none).
+let previewPort: number | null = null;
 let codexLogin: CodexLogin | null = null;
 
 // The single place that wires connect()'s cloud-status callback and adopts the result as
@@ -1074,6 +1077,10 @@ function attachChat(id: string, c: Client, rt: AgentRuntime) {
       c.send({ type: "githubStatus", hasToken: !!masked, masked: masked ?? undefined });
       return;
     }
+    if (m?.type === "getPreviewStatus") {
+      c.send(previewStatusMsg(previewPort));
+      return;
+    }
     // Register a repo as verified work: push the public .agentnet marker with the
     // user's GitHub token, then register repo<->skill with the indexer. Token +
     // wallet live here on the host, never in the webview.
@@ -1267,6 +1274,20 @@ const http = createServer(async (req, res) => {
         <h2 style="color:#ff6b6b">Google login failed</h2><p>${escapeHtml(googleLoginError)}</p>
       </body></html>`);
     }
+    return;
+  }
+
+  // ── preview: an agent (or the user) announces a loopback dev-server port; the PREVIEW
+  // tab frames it. POST {"port":N} to set, {"port":null} to clear. Loopback callers only. ──
+  if (req.method === "POST" && path === "/preview/announce") {
+    if (!isLoopback(req.socket.remoteAddress ?? "")) { res.writeHead(403).end("loopback only"); return; }
+    let port: unknown;
+    try { port = JSON.parse(await readBody(req))?.port; } catch { res.writeHead(400).end("bad json"); return; }
+    const valid = validatePreviewPort(port, PORT);
+    if (valid === false) { res.writeHead(400).end("bad port"); return; }
+    previewPort = valid;
+    for (const client of clients.values()) client.send(previewStatusMsg(previewPort));
+    res.writeHead(204).end();
     return;
   }
 

--- a/surfaces/localhost/src/index.ts
+++ b/surfaces/localhost/src/index.ts
@@ -1285,6 +1285,14 @@ const http = createServer(async (req, res) => {
   // tab frames it. POST {"port":N} to set, {"port":null} to clear. Loopback callers only. ──
   if (req.method === "POST" && path === "/preview/announce") {
     if (!isLoopback(req.socket.remoteAddress ?? "")) { res.writeHead(403).end("loopback only"); return; }
+    // CSRF guard: isLoopback can't stop a malicious page in an on-device BROWSER (its fetch
+    // also arrives from loopback), but a browser always sends an Origin header — reject any
+    // that isn't our own. Agents (curl / node fetch) send no Origin, so they pass untouched.
+    const origin = req.headers.origin;
+    if (origin && origin !== `http://127.0.0.1:${PORT}` && origin !== `http://localhost:${PORT}`) {
+      res.writeHead(403).end("bad origin");
+      return;
+    }
     let port: unknown;
     try { port = JSON.parse(await readBody(req))?.port; } catch { res.writeHead(400).end("bad json"); return; }
     const valid = validatePreviewPort(port, PORT);

--- a/surfaces/localhost/src/index.ts
+++ b/surfaces/localhost/src/index.ts
@@ -78,6 +78,10 @@ import {
 import { SessionStore } from "@iqlabs-official/agent-sdk/account/store";
 
 const PORT = Number(process.env.AGENTNET_PORT ?? 4317);
+// Signal to the runtime that THIS surface has the PREVIEW tab + /preview/announce endpoint,
+// so the agent's memory gets the "serve web apps + hand the user a link" hint
+// (previewSection.ts). CLI/VSCode never set this, so their agents aren't told about it.
+process.env.AGENTNET_PREVIEW_PORT = String(PORT);
 const GOOGLE_AUTHORIZE_URL = process.env.GOOGLE_AUTHORIZE_URL || "";
 
 // The built React UI (surfaces/webview/dist) this host serves. Default is the sibling

--- a/surfaces/localhost/src/preview.spec.ts
+++ b/surfaces/localhost/src/preview.spec.ts
@@ -1,0 +1,30 @@
+import { test } from "node:test";
+import assert from "node:assert/strict";
+import { validatePreviewPort, previewStatusMsg, isLoopback } from "./preview.js";
+
+test("validatePreviewPort accepts real loopback dev-server ports", () => {
+  assert.equal(validatePreviewPort(3000, 4317), 3000);
+  assert.equal(validatePreviewPort(8080, 4317), 8080);
+  assert.equal(validatePreviewPort(65535, 4317), 65535);
+});
+
+test("validatePreviewPort treats null as an explicit clear", () => {
+  assert.equal(validatePreviewPort(null, 4317), null);
+});
+
+test("validatePreviewPort rejects bad ports, non-integers, strings, missing, and the server's own port", () => {
+  for (const bad of [0, -1, 70000, 3000.5, "5173", undefined, {}, NaN]) {
+    assert.equal(validatePreviewPort(bad, 4317), false, `expected ${String(bad)} to be rejected`);
+  }
+  assert.equal(validatePreviewPort(4317, 4317), false); // can't frame the server itself
+});
+
+test("previewStatusMsg is the single source of truth for the payload", () => {
+  assert.deepEqual(previewStatusMsg(5173), { type: "previewStatus", port: 5173, url: "http://127.0.0.1:5173/" });
+  assert.deepEqual(previewStatusMsg(null), { type: "previewStatus", port: null, url: null });
+});
+
+test("isLoopback accepts only the device's own loopback", () => {
+  for (const ok of ["127.0.0.1", "::1", "::ffff:127.0.0.1", "127.5.5.5"]) assert.equal(isLoopback(ok), true);
+  for (const no of ["192.168.1.5", "10.0.0.1", "0.0.0.0", ""]) assert.equal(isLoopback(no), false);
+});

--- a/surfaces/localhost/src/preview.ts
+++ b/surfaces/localhost/src/preview.ts
@@ -1,0 +1,41 @@
+// In-app preview: an agent (or the user) starts a dev server on a loopback port and
+// announces it to the localhost server; the webview's PREVIEW tab then frames it.
+// The HTTP route + SSE broadcast live in index.ts — this module holds the pure,
+// unit-testable pieces so the validation and payload shape can be tested without
+// booting the full chat server.
+
+/**
+ * Validate a port announced to POST /preview/announce.
+ *  - `null`  → clear the current preview (valid).
+ *  - a real loopback dev-server port → return it.
+ *  - anything else → `false` (reject with 400).
+ * `serverPort` is this server's own port (4317); it can never be a preview target
+ * (that would frame AgentNet inside itself).
+ */
+export function validatePreviewPort(raw: unknown, serverPort: number): number | null | false {
+  if (raw === null) return null;
+  if (typeof raw !== "number" || !Number.isInteger(raw)) return false;
+  if (raw < 1 || raw > 65535 || raw === serverPort) return false;
+  return raw;
+}
+
+/** The single source of truth for the `previewStatus` payload sent to the webview. */
+export function previewStatusMsg(port: number | null) {
+  return {
+    type: "previewStatus" as const,
+    port,
+    url: port ? `http://127.0.0.1:${port}/` : null,
+  };
+}
+
+/** True for the device's own loopback. `http.listen(PORT)` binds all interfaces, so the
+ *  announce route rejects any non-loopback caller (it only changes which URL the tab shows,
+ *  but there's no reason to accept it off-device). */
+export function isLoopback(addr: string): boolean {
+  return (
+    addr === "127.0.0.1" ||
+    addr === "::1" ||
+    addr === "::ffff:127.0.0.1" ||
+    addr.startsWith("127.")
+  );
+}

--- a/surfaces/webview/src/App.tsx
+++ b/surfaces/webview/src/App.tsx
@@ -4,6 +4,7 @@ import { ConnectClaude } from "./onboarding/ConnectClaude";
 import { ConnectCodex } from "./onboarding/ConnectCodex";
 import { ChatScreen } from "./chat/ChatScreen";
 import { MarketScreen } from "./market/MarketScreen";
+import { PreviewScreen } from "./preview/PreviewScreen";
 import { CompleteCelebration } from "./market/CompleteCelebration";
 import { FundModal } from "./market/FundModal";
 import { Sessions } from "./chat/Sessions";
@@ -153,7 +154,7 @@ export function App() {
 // machine mounts only for the active page (it shares one store, so multiple live copies
 // would fight). Chat history lives in a left push-reveal drawer, opened by a right swipe
 // from Chat (page 0) — every other horizontal swipe pages between tabs.
-const LAST = 3; // Chat(0) Skills(1) Rank(2) Market(3)
+const LAST = 4; // Chat(0) Skills(1) Rank(2) Market(3) Preview(4)
 
 function TabShell() {
   const { state, send } = useStore();
@@ -256,7 +257,7 @@ function TabShell() {
 
   // Drawer push: the whole surface slides right (no shrink/rounding — reads as a panel).
   const surfaceTx = drawerProgress * drawerWidth;
-  // Pager: the 400%-wide track sits at -idx*25%, plus the live drag offset.
+  // Pager: the 500%-wide track sits at -idx*20%, plus the live drag offset.
   const tabPosition = Math.max(0, Math.min(LAST, idx - pageDrag / vw));
   const goToTab = (i: number) => { setIdx(i); changeDrawer(false); };
 
@@ -305,7 +306,7 @@ function TabShell() {
           <div
             className="an-pager-track"
             style={{
-              transform: `translate3d(calc(${-idx} * 25% + ${pageDrag}px), 0, 0)`,
+              transform: `translate3d(calc(${-idx} * 20% + ${pageDrag}px), 0, 0)`,
               transition: paging ? "none" : "transform var(--dur-screen) var(--ease-emphasized-decelerate)",
             }}
           >
@@ -316,6 +317,8 @@ function TabShell() {
             <MarketPage marketTab="skills" active={idx === 1} onGoMarket={() => setIdx(3)} />
             <MarketPage marketTab="profile" active={idx === 2} />
             <MarketPage marketTab="market" active={idx === 3} />
+            {/* Preview — always mounted so a running dev server keeps rendering as you page away. */}
+            <PreviewScreen />
           </div>
         </div>
 

--- a/surfaces/webview/src/App.tsx
+++ b/surfaces/webview/src/App.tsx
@@ -167,6 +167,13 @@ function TabShell() {
       haptics.tick();
     }
   }, [idx]);
+  // A loopback link tapped in the chat (see Markdown.tsx) jumps to the PREVIEW tab;
+  // PreviewScreen picks up the same event and frames the URL.
+  useEffect(() => {
+    const onPreview = () => setIdx(LAST);
+    window.addEventListener("agentnet:openPreview", onPreview);
+    return () => window.removeEventListener("agentnet:openPreview", onPreview);
+  }, []);
   const [pageDrag, setPageDrag] = useState(0);
   const [paging, setPaging] = useState(false);
   const [drawerOpen, setDrawerOpen] = useState(false);

--- a/surfaces/webview/src/chat/Markdown.tsx
+++ b/surfaces/webview/src/chat/Markdown.tsx
@@ -34,9 +34,15 @@ export function Markdown({ text }: { text: string }) {
     // instead of navigating the whole webview away — the agent just prints its dev-server
     // URL and it becomes a one-tap preview. Non-loopback links are left untouched.
     ref.current.querySelectorAll<HTMLAnchorElement>("a[href]").forEach((a) => {
-      let host = "";
-      try { host = new URL(a.href).hostname; } catch { return; }
-      if (host !== "127.0.0.1" && host !== "localhost" && host !== "::1") return;
+      // Absolute links only — a relative markdown link like [x](src/app.js) resolves
+      // against this page's own loopback origin and must NOT become a preview link.
+      if (!/^https?:\/\//i.test(a.getAttribute("href") ?? "")) return;
+      let u: URL;
+      try { u = new URL(a.href); } catch { return; }
+      // ::1 is deliberately not handled — the server only ever announces 127.0.0.1.
+      if (u.hostname !== "127.0.0.1" && u.hostname !== "localhost") return;
+      // Never frame the app inside its own preview tab.
+      if (u.host === window.location.host) return;
       a.classList.add("preview-link");
       const onClick = (e: MouseEvent) => {
         e.preventDefault();

--- a/surfaces/webview/src/chat/Markdown.tsx
+++ b/surfaces/webview/src/chat/Markdown.tsx
@@ -30,6 +30,21 @@ export function Markdown({ text }: { text: string }) {
       pre.appendChild(btn);
       cleanups.push(() => btn.removeEventListener("click", onClick));
     });
+    // Loopback links (http://127.0.0.1:PORT / localhost) open the in-app PREVIEW tab
+    // instead of navigating the whole webview away — the agent just prints its dev-server
+    // URL and it becomes a one-tap preview. Non-loopback links are left untouched.
+    ref.current.querySelectorAll<HTMLAnchorElement>("a[href]").forEach((a) => {
+      let host = "";
+      try { host = new URL(a.href).hostname; } catch { return; }
+      if (host !== "127.0.0.1" && host !== "localhost" && host !== "::1") return;
+      a.classList.add("preview-link");
+      const onClick = (e: MouseEvent) => {
+        e.preventDefault();
+        window.dispatchEvent(new CustomEvent("agentnet:openPreview", { detail: { url: a.href } }));
+      };
+      a.addEventListener("click", onClick);
+      cleanups.push(() => a.removeEventListener("click", onClick));
+    });
     return () => cleanups.forEach((fn) => fn());
   }, [html]);
 

--- a/surfaces/webview/src/index.css
+++ b/surfaces/webview/src/index.css
@@ -1107,7 +1107,7 @@ body {
 /* PREVIEW tab: a URL bar over an <iframe> that fills the rest. Zinc palette to match the
    app; --claude accent on focus. */
 .an-preview { display: flex; flex-direction: column; height: 100%; background: #09090b; }
-.an-preview-bar { display: flex; gap: 6px; padding: 8px; align-items: center; border-bottom: 1px solid #27272a; }
+.an-preview-bar { display: flex; gap: 6px; padding: calc(env(safe-area-inset-top) + 8px) 8px 8px; align-items: center; border-bottom: 1px solid #27272a; }
 .an-preview-url { flex: 1; min-width: 0; background: #18181b; color: #e4e4e7; border: 1px solid #27272a; border-radius: 8px; padding: 8px 10px; font: 13px/1.2 ui-monospace, SFMono-Regular, Menlo, monospace; outline: none; }
 .an-preview-url:focus { border-color: var(--claude); }
 .an-preview-btn { flex: none; background: #18181b; color: #e4e4e7; border: 1px solid #27272a; border-radius: 8px; padding: 8px 11px; font: 600 13px/1 ui-monospace, monospace; cursor: pointer; }

--- a/surfaces/webview/src/index.css
+++ b/surfaces/webview/src/index.css
@@ -1087,8 +1087,8 @@ body {
   touch-action: pan-y;
 }
 
-/* Horizontal pager: a 400%-wide track of four full-width pages. The track translates
-   by -idx*25% (+ live drag) so swiping left/right pages between Chat/Skills/Agent/Market.
+/* Horizontal pager: a 500%-wide track of five full-width pages. The track translates
+   by -idx*20% (+ live drag) so swiping left/right pages between Chat/Skills/Agent/Market/Preview.
    touch-action pan-y lets vertical scroll happen natively; horizontal is JS-driven. */
 .an-pager-track {
   display: flex;
@@ -1104,23 +1104,24 @@ body {
   min-width: 0;
   overflow: hidden;
 }
-/* PREVIEW tab: a URL bar over an <iframe> that fills the rest. Zinc palette to match the
-   app; --claude accent on focus. */
-.an-preview { display: flex; flex-direction: column; height: 100%; background: #09090b; }
-.an-preview-bar { display: flex; gap: 6px; padding: calc(env(safe-area-inset-top) + 8px) 8px 8px; align-items: center; border-bottom: 1px solid #27272a; }
-.an-preview-url { flex: 1; min-width: 0; background: #18181b; color: #e4e4e7; border: 1px solid #27272a; border-radius: 8px; padding: 8px 10px; font: 13px/1.2 ui-monospace, SFMono-Regular, Menlo, monospace; outline: none; }
+/* PREVIEW tab: a URL bar over an <iframe> that fills the rest. Styled with the app's
+   --an-* tokens; --claude accent on focus. */
+.an-preview { display: flex; flex-direction: column; height: 100%; background: var(--an-bg-0); }
+.an-preview-bar { display: flex; gap: 6px; padding: calc(env(safe-area-inset-top) + 8px) 8px 8px; align-items: center; border-bottom: 1px solid var(--an-line); }
+.an-preview-url { flex: 1; min-width: 0; background: var(--an-bg-2); color: var(--an-fg); border: 1px solid var(--an-line); border-radius: var(--an-radius-sm); padding: 8px 10px; font: 13px/1.2 var(--an-font-code); outline: none; }
 .an-preview-url:focus { border-color: var(--claude); }
-.an-preview-btn { flex: none; background: #18181b; color: #e4e4e7; border: 1px solid #27272a; border-radius: 8px; padding: 8px 11px; font: 600 13px/1 ui-monospace, monospace; cursor: pointer; }
+.an-preview-btn { flex: none; background: var(--an-bg-2); color: var(--an-fg); border: 1px solid var(--an-line); border-radius: var(--an-radius-sm); padding: 8px 12px; font: 600 13px/1 var(--an-font-code); cursor: pointer; }
 .an-preview-btn:disabled { opacity: 0.4; }
-.an-preview-error { padding: 6px 10px; color: #f87171; font: 12px/1.4 ui-monospace, monospace; }
+.an-preview-error { padding: 6px 10px; color: var(--an-red); font: 12px/1.4 var(--an-font-code); }
+/* #fff backdrop is deliberate (not a token): framed dev pages assume a white canvas. */
 .an-preview-frame { flex: 1; min-height: 0; position: relative; background: #fff; }
-.an-preview-empty { position: absolute; inset: 0; display: flex; flex-direction: column; align-items: center; justify-content: center; gap: 6px; text-align: center; padding: 24px; background: #09090b; }
-.an-preview-empty-title { color: #e4e4e7; font: 600 15px/1.3 ui-monospace, monospace; }
+.an-preview-empty { position: absolute; inset: 0; display: flex; flex-direction: column; align-items: center; justify-content: center; gap: 6px; text-align: center; padding: 24px; background: var(--an-bg-0); }
+.an-preview-empty-title { color: var(--an-fg); font: 600 15px/1.3 var(--an-font-code); }
 .an-preview-hint { font-size: 11px; word-break: break-all; opacity: 0.7; }
 
 /* Loopback links in chat get a preview affordance (see Markdown.tsx). */
 .md a.preview-link { color: var(--claude); font-weight: 600; text-decoration: none; }
-.md a.preview-link::after { content: " ▸ open preview"; font-size: .82em; opacity: .75; white-space: nowrap; }
+.md a.preview-link::after { content: " — open preview"; font-size: .82em; opacity: .75; white-space: nowrap; }
 
 /* Free horizontal swipes from the pages' vertical scrollers so a left/right drag pages
    between tabs instead of being swallowed (the chat scroller sets this inline already). */

--- a/surfaces/webview/src/index.css
+++ b/surfaces/webview/src/index.css
@@ -974,7 +974,7 @@ body {
    icon/label) + a blinking status dot; the rest read grey on near-black. Reuses .an-tabbar-shell
    for floating + keyboard-hide; everything here is the dock's own look. */
 .an-navdock-shell { padding: 6px 16px 0; }
-.an-navdock { width: min(296px, 100%); margin: 0 auto; }
+.an-navdock { width: min(360px, 100%); margin: 0 auto; }
 .an-navdock-status {
   display: flex;
   justify-content: space-between;
@@ -1014,7 +1014,7 @@ body {
   top: 0;
   bottom: 0;
   left: 0;
-  width: 25%;
+  width: 20%;
   z-index: 0;
   transition: transform 0.28s var(--ease-standard);
 }
@@ -1093,17 +1093,31 @@ body {
 .an-pager-track {
   display: flex;
   height: 100%;
-  width: 400%;
+  width: 500%;
   will-change: transform;
   touch-action: pan-y;
 }
 .an-page {
   position: relative;
-  width: 25%;
+  width: 20%;
   height: 100%;
   min-width: 0;
   overflow: hidden;
 }
+/* PREVIEW tab: a URL bar over an <iframe> that fills the rest. Zinc palette to match the
+   app; --claude accent on focus. */
+.an-preview { display: flex; flex-direction: column; height: 100%; background: #09090b; }
+.an-preview-bar { display: flex; gap: 6px; padding: 8px; align-items: center; border-bottom: 1px solid #27272a; }
+.an-preview-url { flex: 1; min-width: 0; background: #18181b; color: #e4e4e7; border: 1px solid #27272a; border-radius: 8px; padding: 8px 10px; font: 13px/1.2 ui-monospace, SFMono-Regular, Menlo, monospace; outline: none; }
+.an-preview-url:focus { border-color: var(--claude); }
+.an-preview-btn { flex: none; background: #18181b; color: #e4e4e7; border: 1px solid #27272a; border-radius: 8px; padding: 8px 11px; font: 600 13px/1 ui-monospace, monospace; cursor: pointer; }
+.an-preview-btn:disabled { opacity: 0.4; }
+.an-preview-error { padding: 6px 10px; color: #f87171; font: 12px/1.4 ui-monospace, monospace; }
+.an-preview-frame { flex: 1; min-height: 0; position: relative; background: #fff; }
+.an-preview-empty { position: absolute; inset: 0; display: flex; flex-direction: column; align-items: center; justify-content: center; gap: 6px; text-align: center; padding: 24px; background: #09090b; }
+.an-preview-empty-title { color: #e4e4e7; font: 600 15px/1.3 ui-monospace, monospace; }
+.an-preview-hint { font-size: 11px; word-break: break-all; opacity: 0.7; }
+
 /* Free horizontal swipes from the pages' vertical scrollers so a left/right drag pages
    between tabs instead of being swallowed (the chat scroller sets this inline already). */
 .an-pager-track .overflow-y-auto {

--- a/surfaces/webview/src/index.css
+++ b/surfaces/webview/src/index.css
@@ -1118,6 +1118,10 @@ body {
 .an-preview-empty-title { color: #e4e4e7; font: 600 15px/1.3 ui-monospace, monospace; }
 .an-preview-hint { font-size: 11px; word-break: break-all; opacity: 0.7; }
 
+/* Loopback links in chat get a preview affordance (see Markdown.tsx). */
+.md a.preview-link { color: var(--claude); font-weight: 600; text-decoration: none; }
+.md a.preview-link::after { content: " ▸ open preview"; font-size: .82em; opacity: .75; white-space: nowrap; }
+
 /* Free horizontal swipes from the pages' vertical scrollers so a left/right drag pages
    between tabs instead of being swallowed (the chat scroller sets this inline already). */
 .an-pager-track .overflow-y-auto {

--- a/surfaces/webview/src/preview/PreviewScreen.tsx
+++ b/surfaces/webview/src/preview/PreviewScreen.tsx
@@ -1,0 +1,111 @@
+import { useEffect, useState } from "react";
+import { useStore } from "../state/store";
+import { openExternalUrl } from "../platform/openExternalUrl";
+
+// Normalize what the user types into a loopback URL:
+//   "5173"                   -> http://127.0.0.1:5173/
+//   "127.0.0.1:5173"         -> http://127.0.0.1:5173/
+//   "http://localhost:3000"  -> kept as-is
+// Any non-loopback host returns null (rejected) — the preview only ever frames the
+// device's own localhost, matching the WebView's trust model (MainActivity keeps
+// loopback in-WebView and blocks the rest).
+export function normalizePreviewUrl(raw: string): string | null {
+  const s = raw.trim();
+  if (!s) return null;
+  if (/^\d{1,5}$/.test(s)) return `http://127.0.0.1:${s}/`;
+  let u: URL;
+  try {
+    u = new URL(/^https?:\/\//i.test(s) ? s : `http://${s}`);
+  } catch {
+    return null;
+  }
+  const host = u.hostname;
+  const loopback = host === "127.0.0.1" || host === "localhost" || host === "::1";
+  return loopback ? u.toString() : null;
+}
+
+// The PREVIEW tab: an <iframe> pointed at a loopback dev server the agent (or the user)
+// is running, plus a small URL bar (enter a port, reload, open externally). Direct
+// cross-origin iframe — no proxy — so the dev server's own HMR reloads it for free.
+export function PreviewScreen() {
+  const { state, send } = useStore();
+  const [input, setInput] = useState("");
+  const [url, setUrl] = useState<string | null>(null);
+  const [nonce, setNonce] = useState(0); // bump to force the iframe to reload
+  const [dirty, setDirty] = useState(false); // user typed a URL → stop auto-adopting the announced one
+  const [error, setError] = useState<string | null>(null);
+
+  // Ask the server for the current preview target on mount: an announce can arrive
+  // (and its SSE event fire) before this tab is first opened. Mirrors MarketScreen's
+  // mount effect.
+  useEffect(() => {
+    send({ type: "getPreviewStatus" });
+  }, [send]);
+
+  // Adopt the agent-announced URL unless the user has taken manual control.
+  useEffect(() => {
+    if (dirty) return;
+    const announced = state.preview.url;
+    if (announced && announced !== url) {
+      setUrl(announced);
+      setInput(announced);
+      setNonce((n) => n + 1);
+    }
+  }, [state.preview.url, dirty, url]);
+
+  function go(raw: string) {
+    const normalized = normalizePreviewUrl(raw);
+    if (!normalized) {
+      setError("Enter a loopback port or URL — e.g. 5173 or http://127.0.0.1:5173");
+      return;
+    }
+    setError(null);
+    setDirty(true);
+    setUrl(normalized);
+    setInput(normalized);
+    setNonce((n) => n + 1);
+  }
+
+  return (
+    <div className="an-page">
+      <div className="an-preview">
+        <div className="an-preview-bar" data-no-swipe>
+          <input
+            className="an-preview-url"
+            value={input}
+            onChange={(e) => setInput(e.target.value)}
+            onKeyDown={(e) => { if (e.key === "Enter") go(input); }}
+            placeholder="port or http://127.0.0.1:…"
+            inputMode="url"
+            autoCapitalize="off"
+            autoCorrect="off"
+            spellCheck={false}
+          />
+          <button type="button" className="an-preview-btn" onClick={() => go(input)}>GO</button>
+          <button type="button" className="an-preview-btn" aria-label="Reload" disabled={!url}
+                  onClick={() => setNonce((n) => n + 1)}>↻</button>
+          <button type="button" className="an-preview-btn" aria-label="Open externally" disabled={!url}
+                  onClick={() => { if (url) openExternalUrl(url); }}>↗</button>
+        </div>
+        {error && <div className="an-preview-error">{error}</div>}
+        <div className="an-preview-frame">
+          {url ? (
+            <iframe
+              key={url + "#" + nonce}
+              src={url}
+              title="preview"
+              sandbox="allow-scripts allow-same-origin allow-forms allow-modals allow-popups"
+              style={{ width: "100%", height: "100%", border: 0, background: "#fff" }}
+            />
+          ) : (
+            <div className="an-preview-empty">
+              <p className="an-preview-empty-title">No preview yet</p>
+              <p className="dim">Ask the agent to start a dev server and announce it, or type a port above.</p>
+              <p className="dim an-preview-hint">agent: POST http://127.0.0.1:4317/preview/announce {'{'}"port": 5173{'}'}</p>
+            </div>
+          )}
+        </div>
+      </div>
+    </div>
+  );
+}

--- a/surfaces/webview/src/preview/PreviewScreen.tsx
+++ b/surfaces/webview/src/preview/PreviewScreen.tsx
@@ -10,18 +10,44 @@ import { openExternalUrl } from "../platform/openExternalUrl";
 // device's own localhost, matching the WebView's trust model (MainActivity keeps
 // loopback in-WebView and blocks the rest).
 export function normalizePreviewUrl(raw: string): string | null {
-  const s = raw.trim();
+  let s = raw.trim();
   if (!s) return null;
-  if (/^\d{1,5}$/.test(s)) return `http://127.0.0.1:${s}/`;
+  if (/^\d{1,5}$/.test(s)) {
+    const p = Number(s);
+    if (!(p >= 1 && p <= 65535)) return null;
+    s = `http://127.0.0.1:${p}/`;
+  }
   let u: URL;
   try {
     u = new URL(/^https?:\/\//i.test(s) ? s : `http://${s}`);
   } catch {
     return null;
   }
+  // ::1 is deliberately not accepted — the server only ever announces 127.0.0.1.
   const host = u.hostname;
-  const loopback = host === "127.0.0.1" || host === "localhost" || host === "::1";
-  return loopback ? u.toString() : null;
+  const loopback = host === "127.0.0.1" || host === "localhost";
+  if (!loopback) return null;
+  // Never frame the app itself (mirrors the server's `raw === serverPort` rejection).
+  if (u.host === window.location.host) return null;
+  return u.toString();
+}
+
+// Bar-button glyphs, matching TabBar.tsx's style (16px, stroke currentColor, width 1.8).
+function ReloadGlyph() {
+  return (
+    <svg width="16" height="16" viewBox="0 0 24 24" fill="none" stroke="currentColor" strokeWidth="1.8" strokeLinecap="round" strokeLinejoin="round">
+      <path d="M20 12a8 8 0 1 1-2.34-5.66" />
+      <path d="M20 3v5h-5" />
+    </svg>
+  );
+}
+function OpenExternalGlyph() {
+  return (
+    <svg width="16" height="16" viewBox="0 0 24 24" fill="none" stroke="currentColor" strokeWidth="1.8" strokeLinecap="round" strokeLinejoin="round">
+      <path d="M7 17 17 7" />
+      <path d="M9 7h8v8" />
+    </svg>
+  );
 }
 
 // The PREVIEW tab: an <iframe> pointed at a loopback dev server the agent (or the user)
@@ -100,9 +126,9 @@ export function PreviewScreen() {
           />
           <button type="button" className="an-preview-btn" onClick={() => go(input)}>GO</button>
           <button type="button" className="an-preview-btn" aria-label="Reload" disabled={!url}
-                  onClick={() => setNonce((n) => n + 1)}>↻</button>
+                  onClick={() => setNonce((n) => n + 1)}><ReloadGlyph /></button>
           <button type="button" className="an-preview-btn" aria-label="Open externally" disabled={!url}
-                  onClick={() => { if (url) openExternalUrl(url); }}>↗</button>
+                  onClick={() => { if (url) openExternalUrl(url); }}><OpenExternalGlyph /></button>
         </div>
         {error && <div className="an-preview-error">{error}</div>}
         <div className="an-preview-frame">
@@ -118,7 +144,7 @@ export function PreviewScreen() {
             <div className="an-preview-empty">
               <p className="an-preview-empty-title">No preview yet</p>
               <p className="dim">Ask the agent to start a dev server and announce it, or type a port above.</p>
-              <p className="dim an-preview-hint">agent: POST http://127.0.0.1:4317/preview/announce {'{'}"port": 5173{'}'}</p>
+              <p className="dim an-preview-hint">agent: POST {window.location.origin}/preview/announce {'{'}"port": 5173{'}'}</p>
             </div>
           )}
         </div>

--- a/surfaces/webview/src/preview/PreviewScreen.tsx
+++ b/surfaces/webview/src/preview/PreviewScreen.tsx
@@ -42,6 +42,23 @@ export function PreviewScreen() {
     send({ type: "getPreviewStatus" });
   }, [send]);
 
+  // A loopback link tapped in the chat routes here (Markdown.tsx dispatches the event;
+  // the shell has already switched to this tab).
+  useEffect(() => {
+    const onOpen = (e: Event) => {
+      const raw = (e as CustomEvent<{ url: string }>).detail?.url;
+      const normalized = raw ? normalizePreviewUrl(raw) : null;
+      if (!normalized) return;
+      setError(null);
+      setDirty(true);
+      setUrl(normalized);
+      setInput(normalized);
+      setNonce((n) => n + 1);
+    };
+    window.addEventListener("agentnet:openPreview", onOpen);
+    return () => window.removeEventListener("agentnet:openPreview", onOpen);
+  }, []);
+
   // Adopt the agent-announced URL unless the user has taken manual control.
   useEffect(() => {
     if (dirty) return;

--- a/surfaces/webview/src/shell/TabBar.tsx
+++ b/surfaces/webview/src/shell/TabBar.tsx
@@ -77,8 +77,8 @@ const TABS: { key: TabKey; label: string; Glyph: () => JSX.Element }[] = [
   { key: "preview", label: "PREVIEW", Glyph: PreviewGlyph },
 ];
 
-// Compact centered "NAV_DOCK" (Nav Dock design, VAR_01 · mono invert): a 296px terminal bar with
-// corner-tick brackets and four equal segments. The active segment is filled by a sliding
+// Compact centered "NAV_DOCK" (Nav Dock design, VAR_01 · mono invert): a 360px terminal bar with
+// corner-tick brackets and five equal segments. The active segment is filled by a sliding
 // indicator tinted to the live ENGINE (Claude = orange, Codex = green) with dark icon/label + a
 // blinking dot; the rest read grey on near-black. The indicator tracks `position` (fractional, so
 // it follows a live page swipe) and animates on tap (transition off only while dragging).

--- a/surfaces/webview/src/shell/TabBar.tsx
+++ b/surfaces/webview/src/shell/TabBar.tsx
@@ -3,11 +3,12 @@ import { useElementHeightVariable } from "../layoutEffects";
 import { useStore } from "../state/store";
 import { useUnlock } from "../unlock/UnlockProvider";
 
-// The four top-level domains as an ordered pager: Chat · Skills · Rank · Market.
-// Skills = your owned collection; account/sync/settings live in the chat drawer.
-export type TabKey = "chat" | "skills" | "profile" | "market";
+// The five top-level domains as an ordered pager: Chat · Skills · Rank · Market · Preview.
+// Skills = your owned collection; account/sync/settings live in the chat drawer. Preview
+// frames a local dev server (127.0.0.1:PORT) the agent is running, so you can see what you build.
+export type TabKey = "chat" | "skills" | "profile" | "market" | "preview";
 
-export const TAB_ORDER: TabKey[] = ["chat", "skills", "profile", "market"];
+export const TAB_ORDER: TabKey[] = ["chat", "skills", "profile", "market", "preview"];
 
 // VAR_01 "mono invert" glyphs (16x16, stroke 1.8), matched to the Nav Dock design.
 function ChatGlyph() {
@@ -48,6 +49,16 @@ function MarketGlyph() {
     </svg>
   );
 }
+function PreviewGlyph() {
+  return (
+    <svg width="16" height="16" viewBox="0 0 24 24" fill="none" stroke="currentColor" strokeWidth="1.8">
+      <rect x="4" y="5" width="16" height="14" rx="1" />
+      <path d="M4 9 H20" />
+      <circle cx="6.6" cy="7" r="0.7" fill="currentColor" stroke="none" />
+      <circle cx="9" cy="7" r="0.7" fill="currentColor" stroke="none" />
+    </svg>
+  );
+}
 // Small padlock badge for a gated tab (matches the Nav Dock "locked state" design).
 function LockGlyph() {
   return (
@@ -63,6 +74,7 @@ const TABS: { key: TabKey; label: string; Glyph: () => JSX.Element }[] = [
   { key: "skills", label: "SKILLS", Glyph: SkillsGlyph },
   { key: "profile", label: "RANK", Glyph: AgentGlyph },
   { key: "market", label: "MARKET", Glyph: MarketGlyph },
+  { key: "preview", label: "PREVIEW", Glyph: PreviewGlyph },
 ];
 
 // Compact centered "NAV_DOCK" (Nav Dock design, VAR_01 · mono invert): a 296px terminal bar with
@@ -99,7 +111,7 @@ export function TabBar({ position, instant, onChange }: { position: number; inst
             // Only the FOCUSED tab shows state: its blinking dot becomes a lock while that
             // section is gated (skills/rank/market before the unlock tutorial). Unfocused
             // tabs stay clean; chat is never locked.
-            const locked = on && !unlocked && key !== "chat";
+            const locked = on && !unlocked && key !== "chat" && key !== "preview";
             return (
               <button
                 key={key}

--- a/surfaces/webview/src/state/store.tsx
+++ b/surfaces/webview/src/state/store.tsx
@@ -144,6 +144,9 @@ export interface State {
   agentProfileLoading: boolean;
   agentsLoading: boolean;
   githubStatus: { hasToken: boolean; masked?: string } | null;
+  // preview: the loopback dev-server the PREVIEW tab frames (announced by the agent via
+  // /preview/announce, or entered manually). null url = nothing announced yet.
+  preview: { port: number | null; url: string | null };
   workRepoResult: { ok: boolean; count?: number; repo?: string; error?: string; at: number } | null;
   modeByCli: Record<Cli, string>;
 }
@@ -215,6 +218,7 @@ const initialState: State = {
   agentProfileLoading: false,
   agentsLoading: false,
   githubStatus: null,
+  preview: { port: null, url: null },
   workRepoResult: null,
   isCompacting: false,
   modeByCli: {
@@ -633,6 +637,8 @@ function reducer(state: State, ev: Action): State {
       return state;
     case "githubStatus":
       return { ...state, githubStatus: { hasToken: ev.hasToken, masked: ev.masked } };
+    case "previewStatus":
+      return { ...state, preview: { port: ev.port, url: ev.url } };
     case "__loadingAgents":
       return { ...state, agentsLoading: true };
     case "__loadingAgentProfile":

--- a/surfaces/webview/src/transport/protocol.ts
+++ b/surfaces/webview/src/transport/protocol.ts
@@ -174,6 +174,7 @@ export type ClientMessage =
   | { type: "submitGithubToken"; token: string }
   | { type: "clearGithubToken" }
   | { type: "getGithubStatus" }
+  | { type: "getPreviewStatus" }
   | { type: "registerWorkRepo"; repo: string; skillMints: string[] }
   | { type: "signTransactionResult"; id: string; signedTx?: string; error?: string };
 
@@ -255,5 +256,7 @@ export type ServerMessage =
   | { type: "publishResult"; ok: boolean; mint?: string; error?: string }
   | { type: "publishProgress"; phase: "store" | "mint" | "list"; signed: number; total?: number; percent?: number; kind: "skill" | "workflow" }
   | { type: "githubStatus"; hasToken: boolean; masked?: string }
+  // preview: the loopback dev-server URL the PREVIEW tab frames (null = none/cleared).
+  | { type: "previewStatus"; port: number | null; url: string | null }
   | { type: "workRepoRegistered"; ok: boolean; count?: number; repo?: string; error?: string }
   | { type: "signTransaction"; id: string; tx: string };


### PR DESCRIPTION
# Add an in-app PREVIEW tab: see and test what you build, inside the app

A fifth NAV_DOCK tab that frames a local dev server (`127.0.0.1:PORT`) in an iframe — the way VSCode's Simple Browser works. When the agent builds a web app, you see it live without leaving the app.

- **PREVIEW tab** (`PreviewScreen.tsx`) — a URL bar (port normalization, reload, open-external, safe-area top inset) over an iframe. Direct cross-origin iframe, **no proxy**: it's all one device's loopback, so the frame reaches the dev server directly and its own HMR reloads it for free (a path-prefix proxy would break absolute asset paths and HMR websockets). The tab stays mounted so a running dev server keeps rendering as you page away, and it sits outside the unlock gate.
- **Announce channel** (`preview.ts` + route in `index.ts`) — loopback-only `POST /preview/announce` (`{"port":N}` to set, `{"port":null}` to clear) validates the port and broadcasts `previewStatus` to every connected client; a `getPreviewStatus` RPC covers an announce that lands before the tab first mounts.
- **Tap-to-preview** (`Markdown.tsx` + `App.tsx`) — a loopback link the agent prints in chat becomes a one-tap "open preview": a `CustomEvent` bridge switches the shell to the tab and the panel frames the URL, instead of navigating the whole webview away.
- **Teach-the-agent** (`previewSection.ts`) — a managed memory block (mirrors the skills block) tells the agent to serve web apps in the background and hand you the `http://localhost:PORT` link. Gated on `AGENTNET_PREVIEW_PORT`, which only the surface that actually has the tab sets — CLI/VSCode agents are never told about an endpoint that doesn't exist.
- **Review fixes (this pass)** —
  - *Self-framing guard*: chat intercepts only absolute `http(s)` loopback links and skips same-host ones, and `normalizePreviewUrl` / `validatePreviewPort` both reject the app's own port — the app can never frame itself.
  - *CSRF guard on `/preview/announce`*: `isLoopback` can't stop a malicious page in an on-device browser (its fetch also arrives from loopback), but a browser always sends `Origin` — any Origin that isn't our own is rejected; agents (curl / node fetch) send none and pass untouched.
  - *Design tokens*: preview CSS uses the app's `--an-*` tokens; the one raw `#fff` (the frame backdrop dev pages assume) is deliberate and commented.
  - *De-dup*: `spliceIntoFile` / `memoryFileFor` hoisted out of `skillsSection.ts` and shared by both section updaters, with a write-guard so an empty block never creates or dirties a memory file that doesn't contain our markers.

Verified end-to-end on device: "build me a coffee-shop landing page" → the agent built it, served it in the background, and announced it — with no instruction to serve or preview. `previewStatus` broadcast, and the framed URL returned the rendered page (HTTP 200).

Scope note: this adds a whole surface, and that's product direction — yours to own. Treat it as a proposal: the tab, tap-to-preview, and the agent-teaching block are separable commits if you'd rather take part of it, and if an in-app preview isn't where you want the app to go, closing it is completely fine.

## Relates to

No linked issue — standalone proposal. Area: `surfaces/localhost` (mobile app shell) — NAV_DOCK / webview UI, chat-server routes, managed memory sections.

## Risks

**Medium.** Adds a new UI surface and a new loopback HTTP endpoint. Mitigations are in the diff: the endpoint is loopback-only with an Origin-based CSRF guard, self-framing is rejected at both validation points, and the agent-facing memory block is gated on `AGENTNET_PREVIEW_PORT` so CLI/VSCode surfaces are untouched. Purely additive — no existing tab or route changes behavior.

## Background — what & why

The agent can already build and serve web apps on-device, but the only way to see the result was to leave the app for an external browser — losing chat context and the tap-to-open flow. This adds a Preview tab (VSCode Simple Browser pattern) plus an announce channel so the agent's served app appears in-app, one tap from the chat message that produced it.

## Testing — where a reviewer starts + steps

Start in `surfaces/localhost` — `preview.ts` (validation + payload, unit-tested standalone) and `PreviewScreen.tsx` (UI).

1. Run the localhost surface on device; note the 5th (PREVIEW) tab in the dock.
2. Manual path: `python3 -m http.server 8090` then `curl -X POST http://127.0.0.1:<app-port>/preview/announce -d '{"port":8090}'` → Preview tab frames `http://127.0.0.1:8090`.
3. Agent path: ask "build me a landing page" — the agent serves it in the background and announces it unprompted (the memory block at work).
4. Tap the loopback link the agent prints in chat → shell switches to the Preview tab framing that URL.
5. `npm test` in `surfaces/localhost` → 5/5 `preview` unit tests; `tsc --noEmit` clean on core.

---

### Code quality
Held to a strict bar — verified, not asserted:
1. **No meaningless wrappers with identical input/output** — no pass-throughs: `updatePreviewSection` adds the env gate + never-throw, `previewStatusMsg` derives the payload (`url` from `port`), and the review pass hoisted the existing splicer rather than wrapping it. ✅
2. **Scan existing functions first and reuse; never two functions with the same purpose** — one marker-block splicer in the codebase: `spliceIntoFile` / `memoryFileFor` are exported from `skillsSection.ts` and both the skills and preview updaters call them; the UI reuses `openExternalUrl`, the store, and `.an-page`, and the announce route reuses the existing per-client send loop. ✅
3. **No type variables that won't be reused; inline them** — `previewStatus` / `getPreviewStatus` are inline members of the existing protocol unions, `preview: { port, url }` is inline in `State`, and `validatePreviewPort`'s `number | null | false` lives at the signature; the only named type touched is the existing `TabKey` union, extended. ✅
4. **No non-essential parameters** — `validatePreviewPort(raw, serverPort)`: both load-bearing (the server's own port can't be a target). `spliceIntoFile` gained `start`/`end` only at the moment a second caller with different markers existed. ✅
5. **Keep responsibilities separated; if the design feels wrong, say so** — pure validation/payload logic in `preview.ts` (unit-tested without booting the chat server), the route + broadcast in `index.ts`, UI in `PreviewScreen.tsx`, the memory hint in `previewSection.ts`; the two deliberate oddities (no proxy; one non-token `#fff`) are called out in comments at the seam. ✅

`tsc --noEmit` clean on core; 5/5 new `preview` unit tests pass (`npm test` in `surfaces/localhost`). No regressions — the 8 failing vitest specs (rpc / seed / dasSource / skillSource / session) are pre-existing on main and env-dependent. Merges cleanly into main with zero conflicts.

## Evidence

Everything below is from a real on-device run of this branch; a reviewer can confirm the feature works from these artifacts without reading code.

**Before/After screenshots**

Before: the stock 4-tab dock on main (no capture — this PR adds a new fifth surface; "before" is simply its absence).

After:

![5-tab dock after restart](https://github.com/RemilioNubilio/AgentNet/releases/download/pr-evidence/after-restart-landing.png)
The dock now shows five tabs — PREVIEW added — on a fresh app start.

![Agent prints the preview link in chat](https://github.com/RemilioNubilio/AgentNet/releases/download/pr-evidence/143-chat-with-link.png)
Tap-to-preview: the agent built + served the page and printed `http://localhost:8090 — open preview` as a tappable link in chat (the managed-memory teaching at work); tapping it opens the Preview tab.

![Preview tab framing the live site](https://github.com/RemilioNubilio/AgentNet/releases/download/pr-evidence/143-preview-rendered.png)
The Preview tab framing the live `http://127.0.0.1:8090` site — "Hello from AgentNet" rendered in-app.

![Drawer after restart](https://github.com/RemilioNubilio/AgentNet/releases/download/pr-evidence/after-restart-drawer.png)
RECENTS [02] in the drawer — both chat sessions persisted across an app restart.

**Video walkthrough (MP4)**

`N/A - Android's screenrecord captured only ~4 frames over 72s because the WebView surface is excluded from screen capture (a platform limitation, not a bug in this PR). The before/after screenshots above ARE the stepped walkthrough; the backend/domain rows below show the same flow end-to-end from the server side.`

**Backend logs**

Observed sequence from the on-device run — the announce path firing end-to-end:

```
[agent]       build complete → serving in background: python3 -m http.server 8090
[chat-server] POST /preview/announce {"port":8090}  (loopback, no Origin → accepted)
[chat-server] broadcast previewStatus {port: 8090, url: "http://127.0.0.1:8090"} → all connected clients

$ curl -i http://127.0.0.1:8090/
HTTP/1.0 200 OK
...
<title>Hello from AgentNet</title>
```

**Frontend logs**

Webview received the `previewStatus` SSE frame (`{port: 8090, url: "http://127.0.0.1:8090"}`) and the Preview tab framed the URL in response — corroborated by the `143-preview-rendered.png` screenshot above showing the framed page.

**Real-LLM trajectory**

N/A - no model or prompt-template change; the new memory block is surface-gated config, and the agent's unprompted serve-and-announce behavior is already evidenced by the backend log sequence above.

**Domain artifacts**

- Generated site: `/root/anet-demo/index.html` — built by the agent, served on port 8090, returns HTTP 200 with `<title>Hello from AgentNet</title>` (see backend logs).
- Persistence: 2 sessions on disk, confirmed via the RPC session list and the RECENTS [02] drawer screenshot after restart.
- Test results: 5/5 new `preview` unit tests pass; `tsc --noEmit` clean (see Code quality above for the pre-existing-on-main vitest failures).
