### PR TITLE
docs(plans): tick shipped build-order checkboxes against the code

### DIFF
--- a/plans/compact-and-state-sync.md
+++ b/plans/compact-and-state-sync.md
@@ -115,19 +115,29 @@ to X via the safe fold-in default; native-summary handling is opt-in later.
 
 ---
 
-## 5. Build order (do NOT do this yet)
+## 5. Build order
 
-This is an **open design**, deliberately deferred. The plain-turn cross-CLI resume is
-done and verified; this layer sits on top.
+This began as an **open design**, deliberately deferred — since built (see per-box
+notes; the stored summary text is still a placeholder). The plain-turn cross-CLI
+resume is done and verified; this layer sits on top.
 
-- [ ] Confirm the REAL compaction signal in each CLI's output (claude jsonl summary
-      line shape; codex compaction event) — needs empirical capture, like we did for
-      the resume jsonl formats. Don't hardcode a shape until observed.
-- [ ] Add `"summary"` to `ChatMessage.role` (contract.ts) + sessionLog handling
-      (it already stores arbitrary message records, so likely a no-op).
-- [ ] Capture: emit `summary` in `convert/{claude,codex}.ts`.
-- [ ] Inject: fold-in default in `inject/{claude,codex}.ts`; native slot where supported.
+- [x] Confirm the REAL compaction signal in each CLI's output — handled: claude
+      `compact_boundary` (`runtime/convert/claude.ts`), codex `thread/compacted`
+      (`runtime/spawn.ts`). [Partial — the event is detected, but the summary *text*
+      shape is not captured; a placeholder is stored, see the capture box.]
+- [x] Add `"summary"` to `ChatMessage.role` (contract.ts) + sessionLog handling —
+      `runtime/contract.ts` (`role: … | "summary"` + `replacesUpTo`); sessionLog needed
+      no change (role-agnostic records), as predicted.
+- [x] Capture: emit `summary` in `convert/{claude,codex}.ts`. [Shipped with caveats —
+      claude in `convert/claude.ts` (`compact_boundary` → summary record); codex lives in
+      `spawn.ts` (`thread/compacted` handler), not `convert/codex.ts`; both store the
+      placeholder text `"[conversation compacted]"`, not the model's actual summary, so
+      the compacted context is NOT yet carried across.]
+- [x] Inject: fold-in default in `inject/{claude,codex}.ts`; native slot where supported.
+      [Shipped as the shared `replayable()` fold-in in `inject/index.ts`, applied to both
+      CLIs; no native-summary slot implemented yet.]
 - [ ] Verify cross-CLI: compact in claude → resume in codex still has the compacted context.
+      (Blocked on real summary text above — today only the placeholder would cross.)
 
 ## 6. Open questions
 - claude's exact on-disk summary representation (no sample captured yet — observe first).

--- a/plans/notes.md
+++ b/plans/notes.md
@@ -139,4 +139,6 @@ owner.
 1. ✅ `reviews:[collectionId]:[nft]` + token-holding write gate (skill/workflow comments) — `notes/notes.ts`.
 2. ✅ `reviews:agent:[wallet]` — owner-write (self-notes/blog) + others' comments per §4.
 3. ✅ Note row with optional `gitLink`.
-4. ⬜ Front-end: render notes + git attachments on the item view and agent profile (UI — see issue #16).
+4. ✅ Front-end: render notes + git attachments on the item view and agent profile (issue #16) —
+   `chat/ui/webview.ts` (note cards + `gitLink` rendering), posting via `postNote` /
+   `postAgentNote` (`chat/session.ts`).

--- a/plans/search.md
+++ b/plans/search.md
@@ -200,8 +200,9 @@ flowchart LR
 2. ✅ Result view: **reader-side verify before buy** — shipped as a hard gate:
    `verify_skill` (agent judges against `VERIFY_RUBRIC`) + `scanSkillText`, and
    `VerifyGuard` blocks `buy_skill` until verified (`packages/core/src/skill-market/`).
-3. ⬜ **Agent search** (§2b): collection holders → match creators → rank by their skills'
-   total `supply`.
+3. ✅ **Agent search** (§2b): collection holders → match creators → rank by their skills'
+   total `supply`. Shipped — `reputation/reputation.ts` (`getLeaderboard`: group skills by
+   creator, rank by `totalSupply`), surfaced as `listAgents` in `skill-market/ingest/env.ts`.
 4. ⬜ Semantic query→category mapper (embed the small category/hashtag set; map the query
    onto it). Optional full-corpus embedding only if needed later.
 

--- a/plans/workflow-nft.md
+++ b/plans/workflow-nft.md
@@ -195,14 +195,20 @@ flowchart TB
 
 ## 5. Build order (after skill NFT)
 
-1. ⬜ Workflow collection (Token-2022, same pattern as skills) + `requiredSkills` trait.
-2. ⬜ Publish: code-in the workflow recipe → mint into the workflow collection.
+1. ✅ Workflow collection (Token-2022, same pattern as skills) + `requiredSkills` trait —
+   `nft/workflow.ts` `publishWorkflow` (Token-2022 mint enrolled into the workflows
+   collection; one `requiredSkill` trait per prerequisite mint).
+2. ✅ Publish: code-in the workflow recipe → mint into the workflow collection —
+   `publishWorkflow` (`codeIn` the recipe JSON → `createSkillMint` + `publishItemIx`).
 3. ✅ **Gate program `agent-workflow-nft`** — `publish_workflow` (store + verify
    prereqs are official-collection skills, no dups) + `buy_workflow` (on-chain
    hold-all check + atomic pay/mint via PDA authority). Built, deployed to devnet,
-   4 tests passing (§2). **Next: wire the SDK's `unlockWorkflow` to call it** and
-   move the workflow mint authority to the program PDA at publish.
-4. ⬜ Discovery: "unlockable / almost-there" filters (front-end over search pipeline).
+   4 tests passing (§2). SDK wiring done since: `unlockWorkflow` calls `buyItemIx`,
+   and `publishWorkflow` sets the mint authority to the gate PDA at publish
+   (`nft/workflow.ts` / `nft/workflowGate.ts`).
+4. ✅ Discovery: "unlockable / almost-there" filters (front-end over search pipeline) —
+   `search/unlock.ts` `listUnlockable` (unlockable now + "almost there" via
+   `missing`/`maxMissing`).
 5. ⬜ Runtime: once unlocked, follow the recipe to chain the skills.
 
 ## 6. Open decisions


### PR DESCRIPTION
Docs-only. Ticks build-order checkboxes in `plans/` that are verifiably shipped in the code, each with a symbol/file citation — the same accuracy pass as the docs PR, applied to the plan checklists.

Changed: search.md (agent search/ranking), workflow-nft.md (collection/publish/discovery items), notes.md (front-end note rendering), compact-and-state-sync.md (summary role, capture, inject fold-in — ticked with honest bracketed caveats where a piece is only partially done). Truly-unshipped items left open.

No code touched; verified each tick against `origin/main` before ticking.

### Code quality
Held to the same 5 rules — here, applied to documentation accuracy:
1. No meaningless wrappers with identical input/output — N/A (docs only). ✅
2. Scan existing functions first and reuse — every tick cites the existing shipped symbol/file rather than restating it. ✅
3. No type variables that won't be reused — N/A (docs only). ✅
4. No non-essential parameters — N/A (docs only). ✅
5. Keep responsibilities separated; if the design feels wrong, say so — checkboxes now reflect code reality; partially-done items are ticked with an explicit bracketed caveat, never over-claimed. ✅