### PR TITLE
Session sync's missing half: the mysessions on-chain index — opt-in cross-device session discovery

### DIFF
--- a/packages/core/src/account/login.ts
+++ b/packages/core/src/account/login.ts
@@ -75,6 +75,30 @@ export async function setSkillShopping(on: boolean): Promise<void> {
   await writeFile(configFile(), JSON.stringify({ ...prev, skillShopping: on }, null, 2));
 }
 
+// On-chain session index toggle (plans/offchain-session-sync.md §4-5). Same raw-key
+// pattern as skillShopping, but the default is OFF and consent is PER WALLET (a map
+// of address → true): indexing a session writes a real Solana transaction — fees,
+// and a signature prompt on web wallets — so a CLI keypair opting in must not drag
+// a Phantom wallet sharing this device's config into surprise prompts. Consumed by
+// account/sessionIndex.ts (every write path gates on it) and the surfaces' toggles.
+export async function getSessionIndex(wallet: string): Promise<boolean> {
+  const raw = await readRawConfig();
+  const map = raw.sessionIndex;
+  return typeof map === "object" && map !== null && (map as Record<string, unknown>)[wallet] === true;
+}
+
+export async function setSessionIndex(wallet: string, on: boolean): Promise<void> {
+  await ensureDir(rootDir());
+  const prev = await readRawConfig();
+  const map = typeof prev.sessionIndex === "object" && prev.sessionIndex !== null
+    ? (prev.sessionIndex as Record<string, unknown>)
+    : {};
+  await writeFile(
+    configFile(),
+    JSON.stringify({ ...prev, sessionIndex: { ...map, [wallet]: on } }, null, 2),
+  );
+}
+
 // First-run setup: record the chosen backend and (for gdrive) run Google sign-in.
 // `openBrowser` is injected by the surface (only used for gdrive).
 export async function initialize(

--- a/packages/core/src/account/sessionIndex.spec.ts
+++ b/packages/core/src/account/sessionIndex.spec.ts
@@ -1,0 +1,204 @@
+import { describe, it, expect, vi, beforeEach, afterEach } from "vitest";
+import { mkdtempSync, rmSync, readFileSync } from "node:fs";
+import { join } from "node:path";
+import { tmpdir } from "node:os";
+import { ensureTable, writeRow, readRows } from "../core/chain.js";
+import { SESSION_COLUMNS } from "../core/seed.js";
+import { setSessionIndex, getSessionIndex } from "./login.js";
+import {
+  indexNewSession,
+  listChainSessions,
+  sessionIndexStatus,
+  backfillSessionIndex,
+} from "./sessionIndex.js";
+import type { Wallet } from "../runtime/contract.js";
+
+// The chain layer is fully mocked: these tests pin the GATING (opt-in, dedup,
+// best-effort, truncation refusal) and the row/table shapes handed to it — the
+// layer chain.spec.ts already covers. resolveRpcUrl is mocked so the lazy init
+// never probes a key.
+vi.mock("../core/chain.js", () => ({
+  init: vi.fn(),
+  ensureTable: vi.fn().mockResolvedValue(null),
+  writeRow: vi.fn().mockResolvedValue("txSig"),
+  readRows: vi.fn().mockResolvedValue([]),
+}));
+vi.mock("../core/rpc.js", () => ({
+  resolveRpcUrl: vi.fn().mockResolvedValue("https://api.devnet.solana.com"),
+}));
+
+const wallet = { address: "walletA" } as unknown as Wallet;
+let home: string;
+
+beforeEach(() => {
+  home = mkdtempSync(join(tmpdir(), "agentnet-test-"));
+  process.env.AGENTNET_HOME = home;
+  vi.mocked(ensureTable).mockClear().mockResolvedValue(null);
+  vi.mocked(writeRow).mockClear().mockResolvedValue("txSig");
+  vi.mocked(readRows).mockClear().mockResolvedValue([]);
+});
+
+afterEach(() => {
+  delete process.env.AGENTNET_HOME;
+  rmSync(home, { recursive: true, force: true });
+});
+
+describe("sessionIndex toggle", () => {
+  it("defaults OFF — absent flag is not consent to pay for transactions", async () => {
+    expect(await getSessionIndex("walletA")).toBe(false);
+  });
+
+  it("consent is PER WALLET — one wallet's opt-in never covers another", async () => {
+    await setSessionIndex("walletA", true);
+    expect(await getSessionIndex("walletA")).toBe(true);
+    expect(await getSessionIndex("walletB")).toBe(false);
+    await setSessionIndex("walletA", false);
+    expect(await getSessionIndex("walletA")).toBe(false);
+  });
+});
+
+describe("indexNewSession", () => {
+  it("does nothing while the wallet's toggle is off", async () => {
+    expect(await indexNewSession(wallet, "s1", "claude")).toBe(false);
+    expect(writeRow).not.toHaveBeenCalled();
+    expect(ensureTable).not.toHaveBeenCalled();
+  });
+
+  it("writes one owner-gated row with the Session shape and NO title", async () => {
+    await setSessionIndex("walletA", true);
+    expect(await indexNewSession(wallet, "s1", "codex")).toBe(true);
+    expect(ensureTable).toHaveBeenCalledWith(wallet, "mysessions:walletA", SESSION_COLUMNS, "sessionId", {
+      writers: ["walletA"],
+    });
+    const row = JSON.parse(vi.mocked(writeRow).mock.calls[0][2]);
+    expect(row.sessionId).toBe("s1");
+    expect(row.modelType).toBe("codex");
+    expect(row.createdAt).toBeGreaterThan(0);
+    expect(row.updatedAt).toBe(row.createdAt);
+    expect("title" in row).toBe(false); // titles stay inside the encrypted blob
+  });
+
+  it("is idempotent via the local cache — a restart never re-pays the tx", async () => {
+    await setSessionIndex("walletA", true);
+    await indexNewSession(wallet, "s1", "claude");
+    expect(await indexNewSession(wallet, "s1", "claude")).toBe(false);
+    expect(writeRow).toHaveBeenCalledTimes(1);
+    const cache = JSON.parse(readFileSync(join(home, "chain-index", "walletA.json"), "utf8"));
+    expect(cache.indexed).toEqual(["s1"]);
+  });
+
+  it("swallows chain failures and leaves the cache unmarked so a retry can succeed", async () => {
+    await setSessionIndex("walletA", true);
+    vi.mocked(writeRow).mockRejectedValueOnce(new Error("rpc down"));
+    expect(await indexNewSession(wallet, "s1", "claude")).toBe(false); // no throw
+    expect(await indexNewSession(wallet, "s1", "claude")).toBe(true); // retried, now cached
+    expect(writeRow).toHaveBeenCalledTimes(2);
+  });
+});
+
+describe("listChainSessions", () => {
+  it("drops malformed rows and keeps the OLDEST of a duplicated id (rows arrive newest-first)", async () => {
+    vi.mocked(readRows).mockResolvedValue([
+      { sessionId: "a", modelType: "codex", createdAt: 9, updatedAt: 9 }, // newer duplicate echo
+      { sessionId: "a", modelType: "claude", createdAt: 1, updatedAt: 2 }, // the original create
+      { modelType: "claude" }, // no id
+      { sessionId: "b", modelType: "weird", createdAt: "3", updatedAt: null },
+    ]);
+    const { sessions, truncated } = await listChainSessions("walletA");
+    expect(truncated).toBe(false);
+    expect(sessions).toEqual([
+      { sessionId: "a", modelType: "claude", createdAt: 1, updatedAt: 2 },
+      { sessionId: "b", modelType: "claude", createdAt: 3, updatedAt: 0 },
+    ]);
+  });
+
+  it("flags a full read window as truncated", async () => {
+    vi.mocked(readRows).mockResolvedValue(
+      Array.from({ length: 1000 }, (_, i) => ({ sessionId: `s${i}`, modelType: "claude", createdAt: i, updatedAt: i })),
+    );
+    expect((await listChainSessions("walletA")).truncated).toBe(true);
+  });
+});
+
+describe("sessionIndexStatus / backfillSessionIndex", () => {
+  it("splits chain rows into held-here vs chain-only", async () => {
+    vi.mocked(readRows).mockResolvedValue([
+      { sessionId: "here", modelType: "claude", createdAt: 1, updatedAt: 1 },
+      { sessionId: "elsewhere", modelType: "claude", createdAt: 2, updatedAt: 2 },
+    ]);
+    const st = await sessionIndexStatus("walletA", ["here", "local-only"]);
+    expect(st.onChain).toHaveLength(2);
+    expect(st.chainOnly.map((s) => s.sessionId)).toEqual(["elsewhere"]);
+    expect(st.truncated).toBe(false);
+  });
+
+  it("backfill refuses while the toggle is off — the gate lives in core, not the surface", async () => {
+    await expect(backfillSessionIndex(wallet, [])).rejects.toThrow(/off for this wallet/);
+    expect(writeRow).not.toHaveBeenCalled();
+  });
+
+  it("backfill writes only sessions neither the chain NOR the cache knows", async () => {
+    await setSessionIndex("walletA", true);
+    // "c" was written by THIS device moments ago; the gateway view lags and
+    // doesn't serve it yet — the cache must stop a duplicate paid row.
+    await indexNewSession(wallet, "c", "claude");
+    vi.mocked(writeRow).mockClear();
+    vi.mocked(readRows).mockResolvedValue([
+      { sessionId: "a", modelType: "claude", createdAt: 1, updatedAt: 1 },
+    ]);
+    const r = await backfillSessionIndex(wallet, [
+      { sessionId: "a", title: "t", cli: "claude", ts: 5 },
+      { sessionId: "b", title: "t2", cli: "codex", ts: 6 },
+      { sessionId: "c", title: "t3", cli: "claude", ts: 7 },
+    ]);
+    expect(r).toEqual({ written: 1, already: 2 });
+    expect(writeRow).toHaveBeenCalledTimes(1);
+    const row = JSON.parse(vi.mocked(writeRow).mock.calls[0][2]);
+    expect(row.sessionId).toBe("b");
+    expect("title" in row).toBe(false);
+    // the cache repaired itself from chain truth for "a" too
+    const cache = JSON.parse(readFileSync(join(home, "chain-index", "walletA.json"), "utf8"));
+    expect(cache.indexed.sort()).toEqual(["a", "b", "c"]);
+  });
+
+  it("backfill refuses a truncated chain view instead of minting duplicates", async () => {
+    await setSessionIndex("walletA", true);
+    vi.mocked(readRows).mockResolvedValue(
+      Array.from({ length: 1000 }, (_, i) => ({ sessionId: `s${i}`, modelType: "claude", createdAt: i, updatedAt: i })),
+    );
+    await expect(
+      backfillSessionIndex(wallet, [{ sessionId: "old", title: "t", cli: "claude", ts: 1 }]),
+    ).rejects.toThrow(/partial view/);
+    expect(writeRow).not.toHaveBeenCalled();
+  });
+
+  it("rejects a concurrent backfill for the same wallet — two runs would double-pay", async () => {
+    await setSessionIndex("walletA", true);
+    let release!: () => void;
+    vi.mocked(writeRow).mockImplementationOnce(
+      () => new Promise((res) => { release = () => res("txSig"); }),
+    );
+    const first = backfillSessionIndex(wallet, [{ sessionId: "b", title: "t", cli: "codex", ts: 6 }]);
+    await vi.waitFor(() => expect(writeRow).toHaveBeenCalled());
+    await expect(
+      backfillSessionIndex(wallet, [{ sessionId: "b", title: "t", cli: "codex", ts: 6 }]),
+    ).rejects.toThrow(/already running/);
+    release();
+    expect(await first).toEqual({ written: 1, already: 0 });
+  });
+
+  it("keeps rows already paid for in the cache even when a later write throws", async () => {
+    await setSessionIndex("walletA", true);
+    vi.mocked(writeRow)
+      .mockResolvedValueOnce("txSig")
+      .mockRejectedValueOnce(new Error("rpc died mid-run"));
+    await expect(
+      backfillSessionIndex(wallet, [
+        { sessionId: "b", title: "t", cli: "codex", ts: 6 },
+        { sessionId: "d", title: "t", cli: "claude", ts: 7 },
+      ]),
+    ).rejects.toThrow(/rpc died/);
+    const cache = JSON.parse(readFileSync(join(home, "chain-index", "walletA.json"), "utf8"));
+    expect(cache.indexed).toEqual(["b"]); // paid row remembered; failed one retryable
+  });
+});

--- a/packages/core/src/account/sessionIndex.ts
+++ b/packages/core/src/account/sessionIndex.ts
@@ -1,0 +1,215 @@
+// On-chain session index (plans/offchain-session-sync.md §4-5) — the `mysessions`
+// half of session sync. Storage already carries the encrypted blobs across devices;
+// this publishes the LIST ("these sessionIds belong to this wallet") so a brand-new
+// device can DISCOVER its sessions before any cloud storage is connected.
+//
+// Deliberately minimal on-chain (the plan's whole point):
+//   - one row per NEW sessionId, written once at creation — updates never touch the
+//     chain (integrity lives in the blob's authenticated encryption, not a hash)
+//   - row shape = the `Session` type (core/types.ts); `title` stays off-chain —
+//     it lives inside the encrypted blob, and a table row is public forever
+//   - writers=[owner] ON OUR CREATE. The table PDA derives from the public hint
+//     alone, so a squatter who creates it FIRST owns the writer list — see the
+//     open finding in the PR: real enforcement needs the contract to bind table
+//     creation to the hint's wallet. Until then a squatted table means writes
+//     fail (contained below) and rows stay what they always are: untrusted hints.
+//
+// Everything here is OPT-IN PER WALLET (config.json `sessionIndex` map — see
+// login.ts) because a row write is a real Solana transaction: it costs fees and,
+// on a web wallet, pops a signature prompt; one device-global flag would let a
+// CLI keypair's opt-in surprise-prompt a Phantom wallet on the same machine.
+// The write paths are best-effort: an RPC hiccup or a signerless wallet (the
+// localhost guest) must never break the chat session they ride on. Chain-only
+// entries are DISCOVERY hints, never openable rows — opening a blobless id would
+// start writing fresh pages under it and collide with the real pages when that
+// storage later connects.
+
+import { readFile, writeFile } from "node:fs/promises";
+import { Connection } from "@solana/web3.js";
+import { init as initChain, ensureTable, writeRow, readRows } from "../core/chain.js";
+import { mysessionsHint, SESSION_COLUMNS } from "../core/seed.js";
+import { resolveRpcUrl } from "../core/rpc.js";
+import { chainIndexDir, chainIndexFile, ensureDir } from "../core/paths.js";
+import { getSessionIndex } from "./login.js";
+import type { Session } from "../core/types.js";
+import type { SessionMeta, Wallet } from "../runtime/contract.js";
+
+// Read window for the wallet's row list. The gateway pages 100/call under this and
+// the SDK fallback's getSignaturesForAddress caps near 1000, so past this point a
+// read may be silently missing OLDER rows. Every consumer that dedups paid writes
+// against the list must honor `truncated` — writing against a partial view is how
+// permanent duplicate rows (and fees) happen.
+const READ_LIMIT = 1000;
+
+// The runtime may never have touched the chain layer (a chat session needs no RPC),
+// so every entry point routes through this lazy init. Memoized: resolveRpcUrl probes
+// the stored Helius key with a live call, and one probe per process is plenty.
+let chainReady: Promise<void> | null = null;
+function connectChain(): Promise<void> {
+  return (chainReady ??= (async () => {
+    initChain(new Connection(await resolveRpcUrl(), "confirmed"));
+  })());
+}
+
+// ── local dedup cache (chain-index/{wallet}.json) ───────────────────────────
+// Which sessionIds this device already wrote. The hot path (session creation)
+// trusts it to skip a chain read, and backfill trusts it ALONGSIDE the chain
+// read: the gateway's view can lag its own notify, so "not on chain yet" is not
+// "never written". The chain remains the source of truth — a lost cache costs a
+// redundant check, never a lost session.
+
+async function readCache(wallet: string): Promise<Set<string>> {
+  try {
+    const raw = JSON.parse(await readFile(chainIndexFile(wallet), "utf8")) as { indexed?: unknown };
+    return new Set(Array.isArray(raw.indexed) ? raw.indexed.filter((v): v is string => typeof v === "string") : []);
+  } catch {
+    return new Set();
+  }
+}
+
+async function writeCache(wallet: string, indexed: Set<string>): Promise<void> {
+  await ensureDir(chainIndexDir());
+  await writeFile(chainIndexFile(wallet), JSON.stringify({ indexed: [...indexed] }, null, 2));
+}
+
+// One `mysessions` row (the plan's create-time write). Caller gates + catches.
+async function writeSessionRow(
+  wallet: Wallet,
+  sessionId: string,
+  cli: "claude" | "codex",
+  ts: number,
+): Promise<void> {
+  const hint = mysessionsHint(wallet.address);
+  await ensureTable(wallet, hint, SESSION_COLUMNS, "sessionId", { writers: [wallet.address] });
+  const row: Session = { sessionId, modelType: cli, createdAt: ts, updatedAt: ts };
+  await writeRow(wallet, hint, JSON.stringify(row));
+}
+
+/**
+ * Record a freshly-created session on the wallet's on-chain list. Fire-and-forget
+ * from the runtime: every guard failure (toggle off for THIS wallet, guest wallet
+ * without a signer, RPC down, a squatted table rejecting the write) resolves false
+ * and the chat continues untouched. The cache file makes this idempotent without a
+ * chain read, so an engine restart never re-pays the tx.
+ */
+export async function indexNewSession(
+  wallet: Wallet,
+  sessionId: string,
+  cli: "claude" | "codex",
+): Promise<boolean> {
+  try {
+    if (!sessionId || !(await getSessionIndex(wallet.address))) return false;
+    const cached = await readCache(wallet.address);
+    if (cached.has(sessionId)) return false;
+    await connectChain();
+    await writeSessionRow(wallet, sessionId, cli, Date.now());
+    cached.add(sessionId);
+    await writeCache(wallet.address, cached);
+    return true;
+  } catch (e) {
+    console.warn("[session-index] skipped:", e instanceof Error ? e.message : e);
+    return false;
+  }
+}
+
+/**
+ * The wallet's published session list. Read-only (gateway-first, free), no signer.
+ * Chain rows are untrusted input: malformed entries are dropped, and on a duplicate
+ * id the OLDEST row wins — both feeds return rows newest-first, so the LAST
+ * occurrence is the original create-time write and any later echo is ignored.
+ * `truncated` means the window filled and OLDER rows may be missing: display-only
+ * consumers may shrug, but paid writes must not dedup against a partial view.
+ */
+export async function listChainSessions(
+  walletAddress: string,
+): Promise<{ sessions: Session[]; truncated: boolean }> {
+  await connectChain();
+  const rows = await readRows(mysessionsHint(walletAddress), { limit: READ_LIMIT });
+  const byId = new Map<string, Session>();
+  for (const r of rows) {
+    const id = typeof r.sessionId === "string" ? r.sessionId : "";
+    if (!id) continue;
+    byId.set(id, {
+      sessionId: id,
+      modelType: r.modelType === "codex" ? "codex" : "claude",
+      createdAt: Number(r.createdAt) || 0,
+      updatedAt: Number(r.updatedAt) || 0,
+      ...(typeof r.title === "string" && r.title ? { title: r.title } : {}),
+    });
+  }
+  return { sessions: [...byId.values()], truncated: rows.length >= READ_LIMIT };
+}
+
+export interface SessionIndexStatus {
+  enabled: boolean;
+  /** every row the wallet has published (up to the read window) */
+  onChain: Session[];
+  /** rows with no blob in this device's storage view — "connect the storage that holds them" */
+  chainOnly: Session[];
+  /** the read window filled — counts are floors, not totals */
+  truncated: boolean;
+}
+
+/**
+ * The discovery read (plan §5.2): what does the chain say this wallet has, and
+ * which of those does this device NOT hold a blob for? `localIds` comes from the
+ * caller's listSessions — storage stays the authority on what is openable.
+ */
+export async function sessionIndexStatus(
+  walletAddress: string,
+  localIds: Iterable<string>,
+): Promise<SessionIndexStatus> {
+  const enabled = await getSessionIndex(walletAddress);
+  const { sessions: onChain, truncated } = await listChainSessions(walletAddress);
+  const have = new Set(localIds);
+  return { enabled, onChain, chainOnly: onChain.filter((s) => !have.has(s.sessionId)), truncated };
+}
+
+// One backfill per wallet at a time, process-wide. Two concurrent runs would each
+// read a chain snapshot that predates the other's writes and double-pay every row —
+// re-entry (a double-tapped /sessionsync) must fail loudly, not fork.
+const backfillRunning = new Set<string>();
+
+/**
+ * One-shot catch-up: publish every session this device holds that neither the
+ * chain list NOR the local cache knows (sessions created before indexing was
+ * turned on — including on other devices, which is why the chain read matters).
+ * Explicit-trigger only — the same contract as StorageAdapter.backfill: never on
+ * passive startup. Refuses on a truncated chain view: with older rows invisible,
+ * "missing" can't be told from "not fetched", and guessing mints paid duplicates.
+ */
+export async function backfillSessionIndex(
+  wallet: Wallet,
+  sessions: SessionMeta[],
+): Promise<{ written: number; already: number }> {
+  if (!(await getSessionIndex(wallet.address))) {
+    throw new Error("session sync is off for this wallet");
+  }
+  if (backfillRunning.has(wallet.address)) {
+    throw new Error("a backfill is already running for this wallet");
+  }
+  backfillRunning.add(wallet.address);
+  const cached = await readCache(wallet.address);
+  let written = 0;
+  try {
+    const { sessions: chainSessions, truncated } = await listChainSessions(wallet.address);
+    if (truncated) {
+      throw new Error(`chain list exceeds the ${READ_LIMIT}-row read window — refusing to backfill against a partial view`);
+    }
+    const onChain = new Set(chainSessions.map((s) => s.sessionId));
+    for (const s of sessions) {
+      if (onChain.has(s.sessionId) || cached.has(s.sessionId)) {
+        cached.add(s.sessionId); // repair the cache from chain truth as we pass
+        continue;
+      }
+      await writeSessionRow(wallet, s.sessionId, s.cli, s.ts);
+      cached.add(s.sessionId);
+      written++;
+    }
+  } finally {
+    backfillRunning.delete(wallet.address);
+    // rows already paid for this run stay cached even when a later one threw
+    await writeCache(wallet.address, cached).catch(() => {});
+  }
+  return { written, already: sessions.length - written };
+}

--- a/packages/core/src/core/paths.ts
+++ b/packages/core/src/core/paths.ts
@@ -184,6 +184,20 @@ export function skillStateFile(wallet: string): string {
   return join(skillStateDir(), `${wallet}.json`);
 }
 
+// ── on-chain session index (account/sessionIndex.ts): which sessionIds this device
+// already wrote to the wallet's `mysessions` table. Purely a tx-saving dedup cache —
+// the chain is the source of truth and this is recomputable from it, so like
+// cli-map.json it stays local and is never synced.
+
+export function chainIndexDir(): string {
+  return join(rootDir(), "chain-index");
+}
+
+/** This wallet's "already indexed on-chain" sessionId cache. Local, never synced. */
+export function chainIndexFile(wallet: string): string {
+  return join(chainIndexDir(), `${wallet}.json`);
+}
+
 /** Ensure a directory exists (mkdir -p) with 0o700 so only the owner can enter. */
 export async function ensureDir(dir: string): Promise<void> {
   await mkdir(dir, { recursive: true, mode: 0o700 });

--- a/packages/core/src/core/seed.ts
+++ b/packages/core/src/core/seed.ts
@@ -207,3 +207,18 @@ export const REVIEW_COLUMNS = [
   "timestamp",
   "meta",
 ];
+
+// Columns for the per-wallet `mysessions` table (mysessionsHint above); the row
+// shape is the `Session` type in core/types.ts. `title` is declared so a wallet
+// MAY publish one, but the shipped writer never does — titles live inside the
+// encrypted session blobs, and a table row is public forever (the plan's "omit
+// if sensitive", applied as the default). `meta` mirrors REVIEW_COLUMNS' escape
+// hatch: columns are fixed at table creation, so the superset must exist now.
+export const SESSION_COLUMNS = [
+  "sessionId",
+  "modelType",
+  "createdAt",
+  "updatedAt",
+  "title",
+  "meta",
+];

--- a/packages/core/src/index.ts
+++ b/packages/core/src/index.ts
@@ -151,9 +151,20 @@ export {
   getStorageInfo,
   getSkillShopping,
   setSkillShopping,
+  getSessionIndex,
+  setSessionIndex,
   saveGoogleCreds,
   hasGoogleCreds,
 } from "./account/login.js";
+// on-chain session index (plans/offchain-session-sync.md): the opt-in `mysessions`
+// writer + the discovery reads a surface builds its "sessions elsewhere" hint from.
+export {
+  indexNewSession,
+  listChainSessions,
+  sessionIndexStatus,
+  backfillSessionIndex,
+} from "./account/sessionIndex.js";
+export type { SessionIndexStatus } from "./account/sessionIndex.js";
 export { STORAGE_OPTIONS } from "./account/storage/adapter.js";
 export type { StorageConfig, StorageKind } from "./account/storage/adapter.js";
 export { manualStorage } from "./account/storage/manual.js";

--- a/packages/core/src/runtime/index.ts
+++ b/packages/core/src/runtime/index.ts
@@ -8,6 +8,7 @@ import { randomUUID } from "node:crypto";
 import { Connection } from "@solana/web3.js";
 import { spawnCli } from "./spawn.js";
 import { SessionStore } from "../account/store.js";
+import { indexNewSession } from "../account/sessionIndex.js";
 import { prepareResume } from "./inject/index.js";
 import { getDeviceProfile, buildDeviceNotice } from "../core/device.js";
 import { MemorySync, updateSkillsSection } from "../memory/index.js";
@@ -216,6 +217,11 @@ export function createRuntime(
         if (sessionId) return;
         sessionId = id;
         void flush();
+        // A fresh session just got its permanent id — publish it to the wallet's
+        // on-chain `mysessions` list (writeRow once per NEW sessionId; updates
+        // never touch the chain). Opt-in + best-effort inside indexNewSession;
+        // ephemeral sessions never leave this process.
+        if (!opts.ephemeral) void indexNewSession(wallet, id, opts.cli);
       });
       cli.onMessage((m: ChatMessage) => emit(m));
       // only nft skills get the casting cue; read fresh so same-session buys light up.
@@ -335,6 +341,9 @@ export function createRuntime(
       await store.fork(sessionId, newId, base, opts?.upTo);
       const forked = (await store.listMine()).find((s) => s.sessionId === newId);
       if (!forked) throw new Error("fork did not land in the session list");
+      // A fork mints its canonical id HERE (no CLI spawn, so no onSessionId) —
+      // publish it like any other new session. Same opt-in + best-effort gate.
+      void indexNewSession(wallet, newId, forked.cli);
       return forked;
     },
 

--- a/surfaces/cli/src/commands.ts
+++ b/surfaces/cli/src/commands.ts
@@ -27,6 +27,7 @@ export const SLASH_COMMANDS: SlashCmd[] = [
   { name: "btw", desc: "side-channel question without interrupting session", args: "<question>" },
   { name: "wallet", desc: "show wallet address" },
   { name: "storage", desc: "view/change where sessions save (connect or reconnect cloud)" },
+  { name: "sessionsync", desc: "on-chain session list (opt-in)", args: "status|on|off|backfill" },
   { name: "logout", desc: "sign out of cloud storage (back to local-only)" },
   { name: "iq", desc: "a random IQ fact" },
   { name: "dance", desc: "Iggy dances" },

--- a/surfaces/cli/src/views/Chat.tsx
+++ b/surfaces/cli/src/views/Chat.tsx
@@ -12,6 +12,10 @@ import { useFrameLoop } from "../hooks/useFrameLoop.js";
 import {
   getStorageInfo,
   disconnectCloud,
+  getSessionIndex,
+  setSessionIndex,
+  sessionIndexStatus,
+  backfillSessionIndex,
   getCodexApiKey,
   STORAGE_OPTIONS,
   type StorageKind,
@@ -986,6 +990,48 @@ export function Chat({
         // point for connect / reconnect (a dead gdrive token surfaces via the status
         // line's "reconnect needed" chip, which points here).
         setShowCloud(true);
+        return;
+      case "sessionsync":
+        // The opt-in on-chain `mysessions` list: a wallet-owned index of sessionIds so
+        // a NEW device can discover its sessions before any cloud storage is connected.
+        // Blobs stay in storage — chain-only entries are hints, not openable rows.
+        // Every row write is a real (tiny) Solana tx, which is why this is opt-in and
+        // why `on` runs the one-shot backfill right away: the list starts complete
+        // instead of only covering sessions created after the flip.
+        void (async () => {
+          const sub = arg.trim().toLowerCase();
+          try {
+            if (sub === "off") {
+              await setSessionIndex(wallet.address, false);
+              setNotice("session sync off · new sessions stay unlisted (existing rows are permanent)");
+              return;
+            }
+            if (sub === "on" || sub === "backfill") {
+              if (sub === "on") await setSessionIndex(wallet.address, true);
+              else if (!(await getSessionIndex(wallet.address))) {
+                setNotice("session sync is off — /sessionsync on first");
+                return;
+              }
+              setNotice(sub === "on" ? "session sync on · publishing your session list…" : "backfilling…");
+              // backfill itself rejects re-entry + a truncated chain view — those
+              // surface through the catch below as the notice, nothing to guard here.
+              const r = await backfillSessionIndex(wallet, await runtime.listSessions());
+              setNotice(
+                `session sync ${sub === "on" ? "on · " : ""}listed ${r.written} session${r.written === 1 ? "" : "s"} on-chain (${r.already} already there)`,
+              );
+              return;
+            }
+            const mine = await runtime.listSessions();
+            const st = await sessionIndexStatus(wallet.address, mine.map((s) => s.sessionId));
+            const elsewhere = st.chainOnly.length
+              ? ` · ${st.chainOnly.length} on other devices (connect their storage to open)`
+              : "";
+            const partial = st.truncated ? " · list truncated" : "";
+            setNotice(`session sync ${st.enabled ? "on" : "off"} · ${st.onChain.length} listed on-chain${elsewhere}${partial}`);
+          } catch (e) {
+            setNotice(`session sync: ${e instanceof Error ? e.message : "failed"}`);
+          }
+        })();
         return;
       case "logout":
         // Sign out of cloud: disconnectCloud drops the token + storage kind (keeps creds


### PR DESCRIPTION
# Session sync's missing half: the `mysessions` on-chain index — opt-in cross-device session discovery

Implements the unbuilt piece of `plans/offchain-session-sync.md` §4–5. The off-chain half already ships (encrypted paged blobs over `StorageAdapter`, wallet-derived X25519 keys, cross-device resume) — but a brand-new device still has no way to *learn what sessions its wallet owns* until the right cloud storage is configured. The plan's answer is the `mysessions` table, and its scaffolding was already committed waiting: `mysessionsHint()` in `core/seed.ts` (zero callers until now), the `Session` row type in `core/types.ts`, and `ensureTable`/`writeRow` with `writers` support in `core/chain.ts`. This PR wires them together, following the `notes.ts` table recipe.

## What it does

- **One row per NEW sessionId, written once at creation** — exactly the plan's §5.3 economy: updates never touch the chain (integrity lives in the blob's authenticated encryption, not a hash). The write hooks the canonical-id reveal in `runtime/index.ts` (`onSessionId` for fresh sessions, `forkSession` for forks — the two places a canonical id is minted). Resumes and ephemeral sessions never index.
- **Titles stay off-chain.** The plan marks `title` "omit if sensitive"; this ships that as the *default* — a table row is public forever, and titles already live inside the encrypted blobs. The column is declared (columns are fixed at table creation, `SESSION_COLUMNS` mirrors `REVIEW_COLUMNS`' `meta` escape hatch) but the writer never fills it.
- **Opt-in per wallet, default OFF.** A row write is a real Solana transaction — fees, and a signature prompt on web wallets. Consent lives in `config.json` as an address-keyed map, not one device-global flag: a CLI keypair opting in must not surprise-prompt a Phantom wallet sharing the same `AGENTNET_HOME`.
- **Best-effort everywhere.** Chain trouble (RPC down, the localhost guest wallet's throwing signer, a squatted table) resolves to a warn and the chat continues untouched — the index is a discovery layer, never a dependency.
- **Paid writes never dedup against a partial view.** The backfill (`/sessionsync on` publishes pre-existing sessions) dedups against the chain *and* a local `chain-index/{wallet}.json` cache (the gateway's view can lag its own write-notify), refuses a truncated read window, rejects concurrent re-entry, and persists paid-for ids even when a mid-run write throws. Every one of those guards exists because writing a duplicate row costs the user real money.
- **Discovery, not resurrection.** `sessionIndexStatus` splits the chain list into "held here" vs "on other devices — connect the storage that holds them." Chain-only entries are deliberately *not* openable rows: opening a blobless id would start fresh page files under it and collide with the real pages when that storage later connects. (Same reasoning why this doesn't silently merge into the hot `listSessions` path.)
- **CLI surface:** `/sessionsync status|on|off|backfill`, following the `/storage` · `/logout` idiom.

## Findings from building it (contract-level, flagging honestly)

**The `writers=[owner]` guarantee is squattable.** The table PDA derives from the public hint alone (`mysessions:<wallet>`), and the writer list is fixed at *creation* — so whoever creates a wallet's table first owns it. A squatter creating `mysessions:<victim>` with `writers=[squatter]` permanently locks the victim out of their own index (creation is once-per-PDA). This PR contains it client-side — writes to a squatted table fail into the best-effort path, and chain rows are treated as untrusted hints either way — but real enforcement needs the contract to bind table creation to the hint's wallet (or a creator-namespaced seed). The same exposure applies to any future per-wallet table using this hint pattern. Happy to open a separate issue if you want it tracked.

**Open decisions deliberately left with you** (plan §8 style): deletion has no on-chain story yet (an append-only table can't drop rows — a tombstone convention would need column support committed up front); and whether the webview drawer should grow the same toggle once the CLI shape settles. Both are cheap follow-ups; neither blocks this layer.

Held to five rules — each verified against this diff, not asserted:

1. **No meaningless wrappers with identical input/output** — ✅ `sessionIndex.ts`'s exports each own real logic (gating, caching, dedup, truncation policy); `writeSessionRow` exists because two callers (create-hook + backfill) share the ensure-then-write sequence, not to rename it.
2. **Scan existing functions first and reuse; never two functions with the same purpose** — ✅ this PR is assembly of what already exists: `mysessionsHint`/`ensureTable`/`writeRow`/`readRows` (the `notes.ts` recipe), the `Session` type as committed, `resolveRpcUrl` + `initChain` (the `env.ts`/`mcp-stdio.ts` wiring), the raw-config-key pattern from `skillShopping`, and `paths.ts` for the cache file — no parallel chain layer, no second config reader.
3. **No type variables that won't be reused; inline them** — ✅ one exported interface (`SessionIndexStatus`, consumed by the CLI and any future surface); everything else is inlined on signatures.
4. **No non-essential parameters** — ✅ `indexNewSession(wallet, sessionId, cli)` is the minimum a row needs; the backfill takes the caller's `SessionMeta[]` instead of re-listing storage itself so the surface stays the authority on what exists locally.
5. **Keep responsibilities separated; if the design feels wrong, say so** — ✅ chain I/O stays in `core/chain.ts`, hint naming in `seed.ts`, consent in `login.ts`, paths in `paths.ts`; `sessionIndex.ts` owns only the index policy. Said-so above: the squat exposure is a contract-layer gap this client-side layer cannot close, and I'd rather flag it than pretend `writers=[owner]` is airtight.

`tsc --noEmit` clean (core + all surfaces) · new spec 14/14 · no regressions — the 8 failing vitest specs (rpc/seed/dasSource/skillSource/session) are pre-existing on main and env-dependent. cli/vscode/localhost all build. Based on latest `main` (d6a0881), merges clean.

## Evidence

| Row | Artifact |
|---|---|
| Before/After screenshots | 📎 Real CLI run transcript (`13-cli-sessionsync.txt`) — the live app driven over a pty: `session sync off · 0 listed on-chain` → `/sessionsync on` → `publishing your session list…` → `listed 0 sessions on-chain (0 already there)` → status `on`. Isolated env (throwaway keypair, devnet, own `AGENTNET_HOME`); the status reads are live devnet chain reads through the real gateway-first path. |
| Video walkthrough (MP4) | N/A - terminal flow, the transcript captures the full surface |
| Backend logs | `sessionIndex.spec.ts` 14/14 — opt-in gating, per-wallet consent, row shape (no title), cache idempotency, retry-after-failure, newest-first dedup, truncation refusal, re-entry rejection, mid-run crash cache persistence |
| Frontend logs | N/A - CLI notices shown in the transcript; no webview surface in this PR |
| Real-LLM trajectory | N/A - no agent, model, or prompt changes; storage/chain layer + CLI command |
| Mainnet proof | The DB program id is network-independent, but the *deployed bytecode* differs (devnet 749,901 B `sha256 fa7eb26d…` vs mainnet 755,101 B `sha256 9dfa9718…`) — so a devnet proof doesn't automatically cover mainnet. So it was run for real on **mainnet** (`13-mainnet-live-proof.log`): the feature's own `indexNewSession` created the table + wrote a row (txs `45YaGg…QQgh`, `3PgJb4…uo6Ga` on PDA `5zLW32…1KTR`), the row **read back from mainnet**, and a **foreign wallet's injection was REJECTED — `signer not in writers`** by the live mainnet build. The `writers=[owner]` gate enforces on mainnet, not just devnet. (A prior zero-cost simulation, `13-mainnet-compat-sim.log`, first confirmed the mainnet build accepts the instruction.) |
| Domain artifacts | **Live devnet proofs** (throwaway wallets, public on-chain receipts on table PDA `5cNpbE…HHkwn`). (1) API proof (`13-devnet-proof.log`): opt-in → real `writeRow` (table auto-created `writers=[owner]`) → row read back → **foreign-wallet append REJECTED: `signer not in writers`** — as far as I can tell the first live exercise of the contract's `writers` gate from this codebase (`chain.spec.ts:62` mocks it); it enforces. (2) End-to-end hooks (`13-e2e-hook-and-discovery.log`): a **real chat turn** in the CLI — the `onSessionId` hook indexed the CLI-minted id autonomously (tx `3XthU6…`), `/fork` indexed the fork (tx `h5M8zG…`), and a **fresh second device** (empty home, same wallet) discovered the sessions from the chain alone: `1 on other devices (connect…)`. That run also live-confirmed the gateway staleness the backfill's chain∪cache dedup defends against — the gateway briefly served a pre-write page while direct RPC showed all four txs. |

---

<details><summary>Evidence: 13-mainnet-live-proof.log</summary>

```
# LIVE MAINNET proof — mysessions writers gate enforces on the real mainnet program (2026-08-13)
# Ran the ACTUAL feature code (indexNewSession) against mainnet via the operator's own Helius RPC.
# Isolated AGENTNET_HOME (did not touch ~/.agentnet). Program 9KLLch…4iQLabs (mainnet build 755,101 B).
#
# table PDA (mysessions:<owner>): 5zLW32aug5DUP2w1fUr3anAMWqGCmFLmx6WdCszN1KTR
#   createTable + writeRow (both ok, explorer-verifiable):
#     45YaGgWyASc8JKRbQsjRn1MyuvQXj4A99TtMwNxcx7WaJmGUSy6JGUT5YWYYwM4jQSDJX5egUMKYHNz2juoxQQgh
#     3PgJb4uG6b7aBEQwjK5L6nkF74wBDfeUBCzgL9yDH7Dqzifkri39veWE9pPJ8nRrdEhnneSwMJvzDcXAobcuo6Ga
#
# Flow (from run.log, owner wallet redacted):
#   RPC (must be mainnet): https://mainnet.helius-rpc.com/?api-key=***
#   owner (owner keypair): <owner-wallet>
#   
#   === 1. opt-in + indexNewSession → REAL mainnet createTable + writeRow (feature code) ===
#   indexNewSession returned: true | sessionId: mainnet-proof-msr5yzdb
#   
#   === 2. read the row back from mainnet ===
#     attempt 1: ["mainnet-proof-msr5yzdb"]
#     ROW CONFIRMED ON MAINNET ✅
#   
#   === 3. fund a throwaway FOREIGN wallet (0.003 SOL) to attempt an injection ===
#   foreign: 4M3dTn4wJcoZ6UD89kxvQZrLaeahRfyxnc9J6VVWrFkg
#   funded, sig: 4N5zKkHrJSg2r6HjJkXzu8M6fssEsyrSKi2nzagxdqLEfU1ZWRY5X9QeUEPSpaQbzwrKS3RnubcPPZKuk4QWUeU9
#   
#   === 4. foreign wallet attempts to append to owner's table → writers=[owner] must REJECT ===
#   foreign write REJECTED ✅ → signer not in writers
#   
#   === 5. mainnet table PDA transaction receipts ===
#   table PDA: 5zLW32aug5DUP2w1fUr3anAMWqGCmFLmx6WdCszN1KTR
#     ok     45YaGgWyASc8JKRbQsjRn1MyuvQXj4A99TtMwNxcx7WaJmGUSy6JGUT5YWYYwM4jQSDJX5egUMKYHNz2juoxQQgh
#     ok     3PgJb4uG6b7aBEQwjK5L6nkF74wBDfeUBCzgL9yDH7Dqzifkri39veWE9pPJ8nRrdEhnneSwMJvzDcXAobcuo6Ga
#   
#   row read back: true
#
# RESULT: happy path persists on mainnet + read-back works + FOREIGN WRITE REJECTED
#   ('signer not in writers') by the live mainnet build. The writers=[owner] gate is real on mainnet.
```
</details>

<details><summary>Evidence: 13-mainnet-compat-sim.log</summary>

```
# Mainnet compatibility — transaction simulation (2026-08-13, ZERO on-chain writes, 0 SOL)
#
# WHY: the DB program id (9KLLchQVJpGkw4jPuUmnvqESdR7mtNCYr3qS4iQLabs) is network-independent,
# but the DEPLOYED BYTECODE differs between networks (verified via ProgramData sha256):
#   devnet : 749,901 bytes  sha256[:32]=fa7eb26d503d0a1e035555f9533b884b
#   mainnet: 755,101 bytes  sha256[:32]=9dfa9718467c16a6043ec6be907b6fa6
# mainnet runs a newer/larger build, so a devnet-only proof does not automatically cover it.
#
# METHOD: wrapped the Connection so sendRawTransaction runs simulateTransaction instead —
# the feature's real createTable(writers=[owner]) instruction executed against the LIVE
# mainnet program and mainnet account state. Nothing submitted, no lamports moved, no row
# persisted (table still absent afterward; repo clean). Feepayer existed only so the
# simulator could load accounts; signatures unverified (sigVerify handled by the sim).
#
# RESULT: the mainnet build ACCEPTS and SUCCESSFULLY EXECUTES the instruction —
#   err: null · compute units: 48650
#   Program log: Instruction: CreateTable
#   Program 9KLLch…4iQLabs success
# => the +5.2KB mainnet build did not break the feature's write path; mysessions is
#    mainnet-compatible. (Full end-to-end incl. the writers-gate REJECTION was proven
#    on the live devnet deployment; see 13-devnet-proof.log.)
```
</details>

<details><summary>Evidence: 13-devnet-proof.log</summary>

```
# Live devnet proof — feature/mysessions-index (2026-08-13)
# Throwaway wallets only. AGENTNET_NETWORK=devnet, isolated AGENTNET_HOME, rpc api.devnet.solana.com
#
# On-chain receipts (public devnet, verifiable in any explorer):
#   table PDA (mysessions:3RAoCQ…nE2p): 5cNpbEFQRi2Mi4EYTVE2fDodcvtWo3Dh7ZcZkxoHHkwn
#   createTable (writers=[owner]): dvcAvyYbrJ7xSad4hLETxHxr1da49LEiU4jNK3ehoBBrwwRSL8MgycYRxdwt6n1p6hjQTwLjxXBvet7ii1YZyGP
#   writeRow (the session row):    4o42v7F1a35AYB7MGHAebVPFF2GJC3uE2KyLPkJHvU5yrfc3pxa1QPz6B99pwCGkmBaJu8NZGMS2hHrdJxgxUdHE
#   foreign write: NO tx (rejected: signer not in writers)

owner: 3RAoCQZ3XWzABfFRtZSCDzKBhjXhxMD1Zc7Xy1R2nE2p | foreign: FaHQyXpXUGM7bFJou2FoL4J7cQC3vDUAnkT51cJonQnj

=== 0. chain init (devnet) + ensure DbRoot exists ===
rpc: https://api.devnet.solana.com
ensureDbRoot: already exists

=== 1. opt-in (per-wallet) + index a new session — real tx ===
indexNewSession: true | sessionId: proof-msqxt5os

=== 2. read the list back from chain ===
attempt 1: [{"sessionId":"proof-msqxt5os","modelType":"claude","createdAt":1786590423821,"updatedAt":1786590423821}] truncated: false
ROW CONFIRMED ON CHAIN ✅

=== 3. foreign wallet tries to append to the owner's table (writers=[owner] must reject) ===
foreign write REJECTED ✅ → signer not in writers

=== 4. discovery view from a 'new device' (empty local list) ===
{
  "enabled": true,
  "onChain": [
    {
      "sessionId": "proof-msqxt5os",
      "modelType": "claude",
      "createdAt": 1786590423821,
      "updatedAt": 1786590423821
    }
  ],
  "chainOnly": [
    {
      "sessionId": "proof-msqxt5os",
      "modelType": "claude",
      "createdAt": 1786590423821,
      "updatedAt": 1786590423821
    }
  ],
  "truncated": false
}
```
</details>

<details><summary>Evidence: 13-e2e-hook-and-discovery.log</summary>

```
# End-to-end proof — runtime hook + fork hook + second-device discovery (2026-08-13)
# Real CLI (pty-driven), real claude turn, throwaway wallet, devnet, isolated homes.
#
# DEVICE A (home2): a real chat turn ran ('say just the word: hello'); the CLI-minted
# canonical id was indexed AUTONOMOUSLY by the onSessionId hook; /fork then minted a
# second id indexed by the forkSession hook. No manual index calls anywhere.
#
# On-chain receipts — 4 txs on table PDA 5cNpbEFQRi2Mi4EYTVE2fDodcvtWo3Dh7ZcZkxoHHkwn:
#   03:07:04 createTable writers=[owner]   dvcAvyYb…  (API proof)
#   03:07:26 writeRow proof-msqxt5os       4o42v7F1…  (API proof)
#   03:25:35 writeRow 3ac85ed3…afb0ea      3XthU6tT…  ← REAL CHAT, hook-fired
#   03:27:06 writeRow 5781c530…3e20e0d     h5M8zGro…  ← FORK, hook-fired
#
# Local artifacts (device A): sessions/3RAoCQ…/3ac85ed3…__p0.log + 5781c530…__p0.log;
# chain-index cache holds all 3 ids (cache marks ONLY after a successful paid write).
#
# DEVICE B (home3, fresh, same wallet, ZERO local sessions):
#   UI: "no sessions yet... say hi"
#   /sessionsync → "session sync off · 1 listed on-chain · 1 on other devices (connect…)"
#   = a brand-new device DISCOVERS wallet sessions from the chain alone. It reports 1
#   (not 3) because the devnet gateway was still serving its cached page — live
#   confirmation of the gateway eventual-consistency the backfill dedup defends against
#   (readRows is gateway-first; direct RPC shows all 4 txs; the list catches up on the
#   gateway poll). Discovery hints are display-only, so staleness costs nothing.
#
── device A fork notice (from pty transcript) ──
 -‿- z    ┃forked to "say just the word: hello (2)" - the or…~[░░░░░░░░] 7/200k
── device B discovery (from pty transcript) ──
 ◕‿◕       ┃session sync off · 1 listed on-chain · 1 on other devices (connect…
```
</details>

<details><summary>Evidence: 13-cli-sessionsync.txt</summary>

```
# /sessionsync in the real CLI — live run, isolated env
# surfaces/cli via tsx · AGENTNET_NETWORK=devnet · throwaway keypair 3RAoCQ…nE2p · isolated AGENTNET_HOME · local-only storage
# status reads are LIVE devnet chain reads (gateway-first, SDK fallback); backfill listed 0 sessions = no tx needed, no SOL spent

── frame @ session sync off · 0 listed ──

 no sessions yet... say hi

 ◕‿◕        ┃ session sync off · 0 listed on-chain
 ━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━
 ❯ message · / for commands · @ for files · Ctrl+V image
 ━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━
 ? /HELP · ESC CANCEL                                         ● CLAUDE · OPUS 57878 ┏━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━┓

── frame @ session sync on · publishing ──

 no sessions yet... say hi

 ◕‿◕        ┃ session sync on · publishing your session list…
 ━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━
 ❯ message · / for commands · @ for files · Ctrl+V image
 ━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━
 ? /HELP · ESC CANCEL                                         ● CLAUDE · OPUS 57878 ┏━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━┓

── frame @ listed 0 sessions on-chain ──

 no sessions yet... say hi

 ◕‿◕        ┃ session sync on · listed 0 sessions on-chain (0 already there)
 ━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━
 ❯ message · / for commands · @ for files · Ctrl+V image
 ━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━
 ? /HELP · ESC CANCEL                                         ● CLAUDE · OPUS 57878 ┏━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━┓

── frame @ session sync on · 0 listed ──

 no sessions yet... say hi

 ◕‿◕        ┃ session sync on · 0 listed on-chain
 ━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━
 ❯ message · / for commands · @ for files · Ctrl+V image
 ━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━
 ? /HELP · ESC CANCEL                                         ● CLAUDE · OPUS 57878 ┏━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━┓

```
</details>

