### PR TITLE
cli: approval variants — fix AskUserQuestion, add plan card, 10-min auto-deny

### DIFF
--- a/plans/cli-design-parity.md
+++ b/plans/cli-design-parity.md
@@ -116,27 +116,48 @@ screenshots. Every in-scope tab read against its CLI owner.
 - GitHub `submitGithubToken`/`getGithubStatus`/`registerWorkRepo`: message
   types exist but `marketplaceEnv` exposes none -> needs CORE additions. [24,26]
 
-## Phase 2 - batch order (feature branch `cli-design-parity`)
+## Phase 2 - execution order (finalized 2026-08-13)
 
-Batches are ordered high-value-first and low-risk-first, so the CLI is
-usable earlier and the scary subsystems come last. Commit per batch.
+Ordered by CODE COHESION + dependency (not perceived impact, per sumin): same
+file/module together, shared/base code before its consumers. Each item ships
+with a QA checklist (what to smoke-test + what could regress) for sumin to
+verify before the next. Contained items go direct to main; the big clusters
+(panels, market, nav/hint) go on a branch -> merge.
 
-1. **Foundation**: add the missing structural colors + copy strings to
-   `theme.ts` (single source). No visual change yet; unblocks every batch.
-2. **Bottom chrome + rising panels** (28, 30): the highest-value fix for
-   "UI feels chaotic". Convert full-frame Sessions/Model/Fork overlays into
-   one in-frame panel slot above the composer; make footer items legible.
-3. **Core chat surfaces** (04 chat turn, 05 approval, 09 long chat): the
-   screens hit every turn. Labels, tool card, diff, pinned-turn states.
-4. **Entry surfaces** (01 boot, 02 onboarding, 03 welcome): first-run + home.
-5. **Sessions + model** (06, 07, 31 fork panel): vertical session rows,
-   model detail pane, fork picker (background option deferred to nav).
-6. **Market** (08, 24, 25): tile silhouette, detail/publish bands + plaque.
-7. **Agent system** (Phase 3): 20 directory grid, 21/22 profile+comments
-   compose, 26 connections+funding. Includes the core/API glue above.
-8. **Approval variants** (27): Kind A question, Kind B plan, 10-min auto-deny.
-9. **Big-ticket, scope-gated** (23 multi-session nav, 29 hint mode): each a
-   new subsystem. Do LAST, only if in scope - see decision below.
+### Already applied (on main as of e2757ab, CLI 0.1.2)
+- 03 Welcome (stacked //TAG_ bands), 06 Model Picker (split frame),
+  07 Sessions (vertical rows + age column), 04/09 transcript (calm //YOU_
+  bands, tool nodes, code boxes, one-colour diff), foundation `theme.ts`
+  tokens. Also non-design fixes this session: resize-OOM guard, session sort
+  by last activity, background history backfill, mouse-reporting off, approval
+  escalation popup.
+
+### Remaining, in execution order
+
+1. **Approval** (`ApprovalCard.tsx`, `InkApprovalChannel.ts`) - one cohesive
+   file, 27 extends 05:
+   - 05 card redesign: green `//REQUEST_` band, 5-col key grid, uppercase.
+   - 27 variants: Kind A (question) + Kind B (plan) renderers; 10-min auto-deny.
+2. **Startup** (`app.tsx` boot, `BootChecklist.tsx`, `Banner.tsx`; then
+   `Onboarding.tsx`, `Iggy.tsx`) - shared startup + status-band/mascot:
+   - 01 Boot: `//WALLET_//CLAUDE_//CODEX_//STORAGE_` bands, IQ logo, copy.
+   - 02 Onboarding: 5-rung ladder, step counter, meter, wallet-linked band.
+3. **Bottom chrome + panels** (`Footer.tsx`, `StatusLine.tsx`, then `Chat.tsx`
+   overlay model) - the frame-architecture cluster, do carefully, QA hard:
+   - 28 chrome: footer items `SESSIONS/MODEL`, persistent `ready` label.
+   - 30 rising-panel architecture: full-frame Sessions/Model/Fork overlays ->
+     one in-frame panel slot above the composer.
+   - 31 Fork panel: plugs into 30's slot (background-fork option waits on 23).
+4. **Market / agent** (core glue first, then `SkillMarket.tsx`, `market/*`):
+   - core glue: `MarketApi.postAgentNote(parentId)`, `buySkill` `code`,
+     `airdrop()` (additive; 22/26 depend on it).
+   - 08 tiles -> 24 skill detail -> 25 publish forge -> 20 agent directory ->
+     21 agent profile -> 22 comments compose (21/22 same file) -> 26 funding.
+5. **Big subsystems, scope-gated** (new modules; confirm scope first):
+   - 23 global nav + multi-session tabs, 29 hint mode. 31's background-fork
+     unblocks once 23 lands.
+
+Deferred by decision: 10-14 NEXT tabs.
 
 ## Phase 2 - apply, tab by tab
 

--- a/surfaces/cli/src/InkApprovalChannel.ts
+++ b/surfaces/cli/src/InkApprovalChannel.ts
@@ -14,11 +14,27 @@ type Pending = { req: ApprovalRequest; resolve: (d: ApprovalDecision) => void };
 export class InkApprovalChannel implements ApprovalChannel {
   private pending: Pending | null = null;
   private listener: ((req: ApprovalRequest | null) => void) | null = null;
+  private timer: ReturnType<typeof setTimeout> | null = null;
+
+  // Auto-deny an unanswered request after this long so a turn never blocks forever when
+  // the user walks away (design tab 27: "nothing hangs forever"). This lives HERE rather
+  // than in core's generic withTimeout() because the timeout must also clear the on-screen
+  // card — resolve() does both — which a plain request()-wrapping combinator cannot.
+  constructor(private readonly timeoutMs = 10 * 60 * 1000) {}
 
   request(req: ApprovalRequest): Promise<ApprovalDecision> {
     return new Promise<ApprovalDecision>((resolve) => {
       this.pending = { req, resolve };
       this.listener?.(req);
+      if (this.timer) clearTimeout(this.timer);
+      this.timer = setTimeout(
+        () =>
+          this.resolve(req.id, {
+            outcome: "deny",
+            reason: "Approval timed out — no response in 10 minutes.",
+          }),
+        this.timeoutMs,
+      );
       // The turn is now blocked on a human. If that human is in another window they have
       // no way to know - the card is drawn on a terminal they are not looking at. The
       // escalated dialog carries Approve/Deny buttons; a click resolves right there.
@@ -52,6 +68,10 @@ export class InkApprovalChannel implements ApprovalChannel {
     const p = this.pending;
     if (p && p.req.id === id) {
       this.pending = null;
+      if (this.timer) {
+        clearTimeout(this.timer);
+        this.timer = null;
+      }
       clearAttention();
       this.listener?.(null);
       p.resolve(decision);

--- a/surfaces/cli/src/components/ApprovalCard.tsx
+++ b/surfaces/cli/src/components/ApprovalCard.tsx
@@ -1,28 +1,32 @@
 import React from "react";
 import { Box, Text } from "ink";
 import type { ApprovalRequest } from "@iqlabs-official/agent-sdk/runtime/approval/channel";
-import { colors, glyph } from "../theme.js";
+import { colors, glyph, tag } from "../theme.js";
 import { DiffView } from "./DiffView.js";
-import { wrapHard } from "../format.js";
+import { wrapHard, wrapBlock, padCells, displayWidth } from "../format.js";
 
 // The decision ring. ONE list drives both the rendered buttons and the key handler in
 // Chat, so a hotkey can never drift from what the card says it does. Order is the
 // ←/→ order, and index 0 is what a bare ↵ commits — allow, the overwhelmingly common
-// answer, exactly like the vscode card's focused [Approve].
+// answer, exactly like the vscode card's focused [Approve]. `cell` is the compact
+// uppercase label the design's key grid shows; `label` is the sentence the hint spells.
 export const APPROVAL_CHOICES = [
-  { key: "y", label: "allow once", tint: colors.ok },
-  { key: "a", label: "always", tint: colors.iqMagenta },
-  { key: "n", label: "deny", tint: colors.err },
-  { key: "r", label: "deny + reason", tint: colors.iqViolet },
+  { key: "y", cell: "ONCE", label: "allow once", tint: colors.ok },
+  { key: "a", cell: "ALWAYS", label: "always", tint: colors.bone },
+  { key: "n", cell: "DENY", label: "deny", tint: colors.err },
+  { key: "r", cell: "REASON", label: "deny + reason", tint: colors.iqViolet },
 ] as const;
 
 export type ApprovalChoiceKey = (typeof APPROVAL_CHOICES)[number]["key"];
 
 // A calm question, not an alarm — UNLESS the action is flagged risky, then we alarm on
-// purpose (red border + warning). The exact command/diff/file is shown verbatim so the
+// purpose (red band + warning). The exact command/diff/file is shown verbatim so the
 // user decides on real information.
 //
-// Two shapes, same content:
+// Three shapes share this one slot (design tab 27): a tool-permission card (bash/edit/…),
+// a PLAN card (ExitPlanMode), and a QUESTION card (AskUserQuestion). Each renders its own
+// band + body; the key grid only appears for the permission shape.
+//
 //   popup=false → inline, takes the composer's slot in the chat frame (row-budgeted)
 //   popup=true  → a bordered modal drawn OVER whatever overlay the user was on
 export function ApprovalCard({
@@ -33,27 +37,36 @@ export function ApprovalCard({
   activeDiffFileIdx = 0,
   maxRows = 12,
   selected = 0,
+  qCursor = 0,
+  qChecked = [],
+  qIndex = 0,
   popup = false,
 }: {
   req: ApprovalRequest;
-  reply?: "reason" | "edit" | null;
+  reply?: "reason" | "edit" | "custom" | null;
   replyText?: string;
   diffExpanded?: boolean;
   activeDiffFileIdx?: number;
   maxRows?: number; // rows the frame can give this band before it clips
   selected?: number; // index into APPROVAL_CHOICES highlighted for ↵
+  qCursor?: number; // question: highlighted option row
+  qChecked?: number[]; // question: checked option rows (multiSelect)
+  qIndex?: number; // question: which question of many we are on
   popup?: boolean;
 }) {
   const danger = req.risk === "danger";
-  const accent = danger ? colors.err : colors.warn;
+  const accent = danger ? colors.danger : colors.ok;
   const canEdit = req.kind === "bash";
   const cols = process.stdout.columns || 80;
   // popup draws a real border (2 cols) + padding (2); inline sits flush in the frame.
   const width = Math.max(24, cols - 2);
   const innerW = popup ? width - 4 : width;
 
-  // corner focus marks (ㄱ top-right / ㄴ bottom-left), same language as the composer —
-  // the inline card takes the composer's slot, so it wears the same frame.
+  const question = req.kind === "question" ? req.questions?.[qIndex] : undefined;
+  const isPlan = req.kind === "plan";
+
+  // corner focus marks, same language as the composer — the inline card takes the
+  // composer's slot, so it wears the same frame.
   const cornerTop = " ".repeat(Math.max(0, cols - 5)) + (danger ? "══╗" : "──┐");
   const cornerBottom = danger ? "╚══" : "└──";
 
@@ -61,89 +74,207 @@ export function ApprovalCard({
   // renders past `maxRows` is not scrolled — it is clipped away, bottom-first. The
   // bottom is where the keys live, so an unbounded card silently eats its own answer row
   // and the prompt reads as a truncated blob you can't act on. Budget the rows: the
-  // question and the keys are fixed cost, the diff gets whatever is left. A popup owns
-  // the whole screen, so it only needs to stay under the terminal height.
+  // fixed chrome is counted, the diff/plan/options get whatever is left.
   const showCwd = req.kind === "bash" && Boolean(req.cwd);
   const fixedRows =
     1 + // marginTop
     1 + // corner top / border top
-    1 + // "<cli> wants to use <tool>"
-    1 + // title
+    1 + // //REQUEST_ band (or //ASK_ / //PLAN_)
+    (question ? 1 : isPlan ? 0 : 1) + // title (permission) or question prompt line
     (req.command ? 1 : 0) +
     (showCwd ? 1 : 0) +
     (req.file ? 1 : 0) +
-    (reply ? 4 : 3) + // reply editor (margin+label+input+hint) or margin+choices+hint
+    (reply ? 4 : 3) + // reply editor (margin+label+input+hint) or margin+keys+hint
     1; // corner bottom / border bottom
   const budget = popup ? Math.max(6, (process.stdout.rows || 24) - 4) : maxRows;
-  const diffRows = Math.max(0, budget - fixedRows);
+  const bodyRows = Math.max(0, budget - fixedRows);
+
+  // An inverted band: label pinned left, detail pinned right, filling the inner width.
+  const bandRow = (left: string, right: string): string => {
+    const gap = innerW - displayWidth(left) - displayWidth(right);
+    if (gap < 1) return padCells(`${left} ${right}`, innerW).slice(0, innerW);
+    return padCells(left + " ".repeat(gap) + right, innerW);
+  };
+  const bandBg = danger ? colors.danger : colors.ok;
+  const bandFg = danger ? colors.bone : colors.ink;
 
   // Long commands/paths have no break opportunity, so ink cannot wrap them and they run
   // past the frame. Wrap them ourselves; show the head and fold the rest.
   const commandRows = req.command ? wrapHard(`$ ${req.command}`, innerW).slice(0, 3) : [];
 
+  // ── PLAN (Kind B): the model wants to leave plan mode. ↵ runs it, esc keeps planning.
+  const planBody = isPlan ? (
+    <>
+      <Text backgroundColor={bandBg} color={bandFg} bold>
+        {bandRow(tag("plan"), `${glyph.thinking} ${req.cli.toUpperCase()} PROPOSES A PLAN`)}
+      </Text>
+      {wrapBlock(req.plan ?? req.title, innerW)
+        .slice(0, Math.max(1, bodyRows))
+        .map((r, i) => (
+          <Text key={i} dimColor>
+            {r}
+          </Text>
+        ))}
+    </>
+  ) : null;
+
+  // ── QUESTION (Kind A): AskUserQuestion. The user's PICK becomes the tool result, so
+  // this is a choice list, not a yes/no gate. ↵ answers; the options are numbered.
+  const questionBody = question ? (
+    <>
+      <Text backgroundColor={bandBg} color={bandFg} bold>
+        {bandRow(
+          tag(question.header || "ask"),
+          (req.questions?.length ?? 1) > 1
+            ? `${qIndex + 1} OF ${req.questions?.length} · ${req.cli.toUpperCase()} ASKS`
+            : `${req.cli.toUpperCase()} ASKS`,
+        )}
+      </Text>
+      {wrapBlock(question.question, innerW)
+        .slice(0, 2)
+        .map((r, i) => (
+          <Text key={i} wrap="truncate-end">
+            {r}
+          </Text>
+        ))}
+      {question.options.slice(0, Math.max(1, bodyRows)).map((o, i) => {
+        const on = i === qCursor;
+        const checked = qChecked.includes(i);
+        const mark = question.multiSelect ? (checked ? "[x] " : "[ ] ") : "";
+        const line = ` ${i + 1} ${mark}${o.label}${o.description ? `  ${o.description}` : ""}`;
+        return (
+          <Text
+            key={i}
+            color={on ? colors.ink : colors.bone}
+            backgroundColor={on ? colors.bone : undefined}
+            bold={on}
+            wrap="truncate-end"
+          >
+            {padCells(line, on ? innerW : displayWidth(line))}
+          </Text>
+        );
+      })}
+    </>
+  ) : null;
+
+  // ── PERMISSION (Kind C / tab 05): bash/edit/write/read/other. Green //REQUEST_ band
+  // (red when danger), the exact command/diff/file, then the decision grid.
+  const permissionBody =
+    !isPlan && !question ? (
+      <>
+        <Text backgroundColor={bandBg} color={bandFg} bold>
+          {bandRow(
+            danger ? tag("danger") : tag("request"),
+            `${glyph.thinking} ${req.cli.toUpperCase()} WANTS TO USE ${req.tool.toUpperCase()}`,
+          )}
+        </Text>
+        <Box justifyContent="space-between">
+          <Text wrap="truncate-end">{req.title}</Text>
+          {req.file ? (
+            <Text dimColor wrap="truncate-start">
+              {req.file}
+            </Text>
+          ) : null}
+        </Box>
+        {commandRows.map((r, i) => (
+          <Text key={i} color={colors.ok}>
+            {r}
+          </Text>
+        ))}
+        {showCwd ? (
+          <Text dimColor wrap="truncate-end">
+            in {req.cwd}
+          </Text>
+        ) : null}
+        {req.diff && bodyRows >= 3 ? (
+          <DiffView
+            diff={req.diff}
+            width={innerW}
+            maxLines={Math.max(1, bodyRows - 2)}
+            expanded={diffExpanded}
+            activeFileIdx={activeDiffFileIdx}
+          />
+        ) : req.diff && bodyRows >= 1 ? (
+          <Text dimColor wrap="truncate-end">
+            (diff hidden - terminal too short)
+          </Text>
+        ) : null}
+      </>
+    ) : null;
+
+  // The footer under the body: the typed reply editor, or the key row for this kind.
+  const footer = reply ? (
+    <Box marginTop={1} flexDirection="column">
+      <Text color={accent}>
+        {reply === "reason"
+          ? "deny: tell the model why:"
+          : reply === "custom"
+            ? "type your own answer, then ↵:"
+            : "edit command, then ↵ to run:"}
+      </Text>
+      <Box>
+        <Text color={colors.ok}>❯ </Text>
+        <Text>
+          {replyText}
+          <Text inverse> </Text>
+        </Text>
+      </Box>
+      <Text dimColor>↵ submit · esc back</Text>
+    </Box>
+  ) : question ? (
+    <Box marginTop={1} flexDirection="column">
+      <Text dimColor wrap="truncate-end">
+        {"↑/↓ move · "}
+        {question.multiSelect ? "space toggle · ↵ confirm" : "↵ answer"}
+        {question.allowCustomInput ? " · [t] type your own" : ""}
+        {" · esc cancel"}
+      </Text>
+    </Box>
+  ) : isPlan ? (
+    <Box marginTop={1} flexDirection="column">
+      <Text>
+        <Text color={colors.ok} bold>
+          {"↵ approve and run"}
+        </Text>
+        <Text dimColor>{"   ·   esc keep planning"}</Text>
+      </Text>
+    </Box>
+  ) : (
+    <Box marginTop={1} flexDirection="column">
+      {/* the decision grid: ←/→ moves, ↵ commits the highlighted one. The letter in
+          brackets still works directly, so nothing that used to be muscle memory
+          stopped working. */}
+      <Box>
+        {APPROVAL_CHOICES.map((c, i) => {
+          const on = i === selected;
+          return (
+            <Text
+              key={c.key}
+              color={on ? colors.ink : c.tint}
+              backgroundColor={on ? c.tint : undefined}
+              bold={on}
+            >
+              {` [${c.key.toUpperCase()}] ${c.cell} `}
+            </Text>
+          );
+        })}
+        {req.diff ? <Text dimColor>{"  [D] DIFF"}</Text> : null}
+      </Box>
+      <Text dimColor wrap="truncate-end">
+        {"←/→ move · ↵ "}
+        {APPROVAL_CHOICES[selected]?.label ?? "allow once"}
+        {canEdit ? " · [e] edit" : ""}
+        {" · esc deny"}
+      </Text>
+    </Box>
+  );
+
   const body = (
     <>
-      <Text color={accent} bold wrap="truncate-end">
-        {danger ? "⚠ DANGER · " : `${glyph.thinking} `}
-        {req.cli} wants to use {req.tool}
-      </Text>
-      <Text wrap="truncate-end">{req.title}</Text>
-      {commandRows.map((r, i) => (
-        <Text key={i} color={colors.iqCyan}>{r}</Text>
-      ))}
-      {showCwd ? <Text dimColor wrap="truncate-end">in {req.cwd}</Text> : null}
-      {req.file ? <Text dimColor wrap="truncate-end">{req.file}</Text> : null}
-      {req.diff && diffRows >= 3 ? (
-        <DiffView
-          diff={req.diff}
-          width={innerW}
-          // an expanded diff adds a tab row + a "N more lines" row on top of its lines
-          maxLines={Math.max(1, diffRows - 2)}
-          expanded={diffExpanded}
-          activeFileIdx={activeDiffFileIdx}
-        />
-      ) : req.diff && diffRows >= 1 ? (
-        <Text dimColor wrap="truncate-end">(diff hidden - terminal too short)</Text>
-      ) : null}
-
-      {reply ? (
-        <Box marginTop={1} flexDirection="column">
-          <Text color={accent}>
-            {reply === "reason" ? "deny: tell the model why:" : "edit command, then ↵ to run:"}
-          </Text>
-          <Box>
-            <Text color={colors.iqCyan}>❯ </Text>
-            <Text>
-              {replyText}
-              <Text inverse> </Text>
-            </Text>
-          </Box>
-          <Text dimColor>↵ submit · esc back</Text>
-        </Box>
-      ) : (
-        <Box marginTop={1} flexDirection="column">
-          {/* the decision ring: ←/→ moves, ↵ commits the highlighted one. The letter in
-              brackets still works directly, so nothing that used to be muscle memory
-              stopped working. */}
-          <Box>
-            {APPROVAL_CHOICES.map((c, i) => {
-              const on = i === selected;
-              return (
-                <Text key={c.key} color={on ? colors.ink : c.tint} backgroundColor={on ? c.tint : undefined} bold={on}>
-                  {` [${c.key}] ${c.label} `}
-                </Text>
-              );
-            })}
-          </Box>
-          <Text dimColor>
-            {"←/→ move · ↵ "}
-            {APPROVAL_CHOICES[selected]?.label ?? "allow once"}
-            {req.diff ? " · [d] toggle diff" : ""}
-            {canEdit ? " · [e] edit" : ""}
-            {" · esc deny"}
-          </Text>
-        </Box>
-      )}
+      {permissionBody}
+      {planBody}
+      {questionBody}
+      {footer}
     </>
   );
 
@@ -152,7 +283,13 @@ export function ApprovalCard({
     // say what happened and promise the way back — the same contract the vscode desktop
     // popup makes when the window isn't focused.
     return (
-      <Box flexDirection="column" width={width} borderStyle={danger ? "double" : "round"} borderColor={accent} paddingX={1}>
+      <Box
+        flexDirection="column"
+        width={width}
+        borderStyle={danger ? "double" : "round"}
+        borderColor={accent}
+        paddingX={1}
+      >
         <Text color={accent} bold>
           {glyph.sparkle} APPROVAL NEEDED
           <Text dimColor>{"  ·  answering returns you to where you were"}</Text>

--- a/surfaces/cli/src/views/Chat.tsx
+++ b/surfaces/cli/src/views/Chat.tsx
@@ -3,7 +3,11 @@ import { Box, Text, Static, useApp, useInput } from "ink";
 import type { AgentRuntime, Wallet, ChatMessage, SkillActivation } from "@iqlabs-official/agent-sdk/runtime/contract";
 import type { CliReport, StorageConfig } from "@iqlabs-official/agent-sdk";
 import type { CloudStatus } from "@iqlabs-official/agent-sdk/account/storage/mirror";
-import type { ApprovalRequest } from "@iqlabs-official/agent-sdk/runtime/approval/channel";
+import type {
+  ApprovalRequest,
+  ApprovalQuestion,
+  ApprovalQuestionResponse,
+} from "@iqlabs-official/agent-sdk/runtime/approval/channel";
 import type { AppOptions } from "../app.js";
 import type { InkApprovalChannel } from "../InkApprovalChannel.js";
 import { SLASH_COMMANDS } from "../commands.js";
@@ -394,9 +398,17 @@ export function Chat({
   const [activeDiffFileIdx, setActiveDiffFileIdx] = useState(0);
   const [approvalIdx, setApprovalIdx] = useState(0); // highlighted APPROVAL_CHOICES entry
   // approval reply mode: null = y/a/n buttons; "reason" = typing a deny reason;
-  // "edit" = editing the bash command before allowing.
-  const [replyMode, setReplyMode] = useState<"reason" | "edit" | null>(null);
+  // "edit" = editing the bash command before allowing; "custom" = typing a free-form
+  // answer to an AskUserQuestion.
+  const [replyMode, setReplyMode] = useState<"reason" | "edit" | "custom" | null>(null);
   const [replyText, setReplyText] = useState("");
+  // AskUserQuestion state (kind === "question"): which option is highlighted, which are
+  // checked (multiSelect), which question of many we are on, and the answers accumulated
+  // for the questions already passed. The pick becomes the tool result, not a yes/no.
+  const [qCursor, setQCursor] = useState(0);
+  const [qChecked, setQChecked] = useState<number[]>([]);
+  const [qIndex, setQIndex] = useState(0);
+  const qAccum = useRef<ApprovalQuestionResponse[]>([]);
   const [showSessions, setShowSessions] = useState(false);
   const [showMarket, setShowMarket] = useState(false);
   // which market screen /market, /agents and /skills land on
@@ -511,8 +523,46 @@ export function Chat({
         setDiffExpanded(false);
         setActiveDiffFileIdx(0);
         setApprovalIdx(0); // every request starts focused on "allow once"
+        setQCursor(0);
+        setQChecked([]);
+        setQIndex(0);
+        qAccum.current = [];
       }),
     [approval],
+  );
+
+  // Commit one answer to an AskUserQuestion. If more questions remain, bank this response
+  // and advance; on the last one, resolve the whole request with every questionResponse —
+  // the engine turns those into the tool result. A free-form `text` (type-your-own) rides
+  // in the same shape as a picked option.
+  const answerQuestion = useCallback(
+    (
+      req: ApprovalRequest,
+      q: ApprovalQuestion,
+      pick: { selected: string[]; text?: string },
+    ) => {
+      if (!approval) return;
+      const response: ApprovalQuestionResponse = {
+        question: q.question,
+        questionId: q.id,
+        selected: pick.selected,
+        text: pick.text,
+      };
+      const all = req.questions ?? [];
+      if (qIndex + 1 < all.length) {
+        qAccum.current.push(response);
+        setQIndex((i) => i + 1);
+        setQCursor(0);
+        setQChecked([]);
+        setReplyMode(null);
+      } else {
+        approval.resolve(req.id, {
+          outcome: "once",
+          questionResponses: [...qAccum.current, response],
+        });
+      }
+    },
+    [approval, qIndex],
   );
 
   // buttons mode. Two ways to answer the same ring, because both are muscle memory:
@@ -522,6 +572,47 @@ export function Chat({
   useInput(
     (input, key) => {
       if (!pendingApproval || !approval) return;
+
+      // QUESTION (AskUserQuestion): the pick IS the answer, so this is a choice list,
+      // not a yes/no gate. ↑/↓ or number keys move; space toggles under multiSelect;
+      // ↵ commits; [t] types a free-form answer; esc cancels the whole ask.
+      if (pendingApproval.kind === "question") {
+        const q = pendingApproval.questions?.[qIndex];
+        if (!q) return;
+        const n = q.options.length;
+        if (key.upArrow) return setQCursor((i) => (i - 1 + n) % n);
+        if (key.downArrow) return setQCursor((i) => (i + 1) % n);
+        if (/^[1-9]$/.test(input)) {
+          const idx = parseInt(input, 10) - 1;
+          if (idx < n) setQCursor(idx);
+          return;
+        }
+        if (input === " " && q.multiSelect)
+          return setQChecked((c) =>
+            c.includes(qCursor) ? c.filter((x) => x !== qCursor) : [...c, qCursor],
+          );
+        if ((input === "t" || input === "T") && q.allowCustomInput) {
+          setReplyText("");
+          return setReplyMode("custom");
+        }
+        if (key.escape)
+          return approval.resolve(pendingApproval.id, { outcome: "deny", reason: "denied by user" });
+        if (key.return) {
+          const rows = q.multiSelect ? (qChecked.length ? qChecked : [qCursor]) : [qCursor];
+          const selected = rows.map((i) => q.options[i]?.label).filter(Boolean) as string[];
+          return answerQuestion(pendingApproval, q, { selected });
+        }
+        return;
+      }
+
+      // PLAN (ExitPlanMode): ↵ approves and runs it, esc saves the plan and keeps planning.
+      if (pendingApproval.kind === "plan") {
+        if (key.return) return approval.resolve(pendingApproval.id, { outcome: "once" });
+        if (key.escape)
+          return approval.resolve(pendingApproval.id, { outcome: "deny", reason: "keep planning" });
+        return;
+      }
+
       const decide = (k: ApprovalChoiceKey) => {
         if (k === "y") return approval.resolve(pendingApproval.id, { outcome: "once" });
         if (k === "a") return approval.resolve(pendingApproval.id, { outcome: "always" });
@@ -565,6 +656,10 @@ export function Chat({
         const text = replyText.trim();
         if (replyMode === "reason") {
           approval.resolve(pendingApproval.id, { outcome: "deny", reason: text || "denied by user" });
+        } else if (replyMode === "custom") {
+          // free-form answer to an AskUserQuestion — same commit path as a picked option.
+          const q = pendingApproval.questions?.[qIndex];
+          if (q) answerQuestion(pendingApproval, q, { selected: [], text });
         } else {
           approval.resolve(pendingApproval.id, {
             outcome: "once",
@@ -1089,6 +1184,9 @@ export function Chat({
           diffExpanded={diffExpanded}
           activeDiffFileIdx={activeDiffFileIdx}
           selected={approvalIdx}
+          qCursor={qCursor}
+          qChecked={qChecked}
+          qIndex={qIndex}
           popup
         />
       </Box>
@@ -1513,6 +1611,9 @@ export function Chat({
           activeDiffFileIdx={activeDiffFileIdx}
           maxRows={approvalMaxRows}
           selected={approvalIdx}
+          qCursor={qCursor}
+          qChecked={qChecked}
+          qIndex={qIndex}
         />
       ) : null}
       {/* The composer is HIDDEN during an approval, never unmounted. Unmounting threw


### PR DESCRIPTION
Design tab **27 (Approval Variants)** gives the approval slot three shapes; the CLI rendered only one. This makes the other two real, and fixes a live bug along the way.

## The bug this fixes

`AskUserQuestion` (kind `question`) and `ExitPlanMode` (kind `plan`) were routed to the same yes/no ring as a bash card. So for a question the user could **never actually pick an option** — a bare `↵` sent `once` with no `questionResponses`, and the engine got a meaningless answer. Questions were effectively unanswerable in the terminal. The webview already handled these; the CLI did not.

## What changed

```mermaid
flowchart TD
  E[engine wants a decision] --> C{ApprovalRequest.kind}
  C -->|bash / edit / write / read / other| P["Permission card (tab 05)<br/>green //REQUEST_ band + key grid<br/>y / a / n / r + [d] diff"]
  C -->|plan| PL["Plan card<br/>//PLAN_ band + steps<br/>↵ approve · esc keep planning"]
  C -->|question| Q["Question card (Kind A)<br/>//ASK_ band + numbered options<br/>↑/↓ · space toggle · [t] type · ↵"]
  P --> D[ApprovalDecision: once/always/deny]
  PL --> D
  Q --> QR[questionResponses]
  D --> R[resolve → engine unblocks]
  QR --> R
  T[["10-min timer<br/>(InkApprovalChannel)"]] -. no answer .-> R
```

- **ApprovalCard** branches by `kind`: permission (tab 05 — green `//REQUEST_` band, red when danger, uppercase key grid), plan (`//PLAN_` band + steps), question (`//ASK_` band, numbered options, multiSelect checkboxes, type-your-own).
- **Chat** wires the question path: arrow/number to move, space to toggle under multiSelect, `↵` commits structured `questionResponses`, `[t]` for free-form, multi-question accumulation across a batch.
- **InkApprovalChannel** auto-denies after 10 minutes so a walked-away turn never blocks forever (tab 27: "nothing hangs forever"). Kept in the surface, not core's generic `withTimeout`, because the timeout must also clear the on-screen card.

## Verification

- Typecheck + build pass.
- Offline capture probe rendered all five shapes (edit+diff, danger bash, plan, question single, question multiSelect) at 60 and 80 columns: **zero frame overflow**, height stays 10–11 rows.
- No core changes — other surfaces (app / webview / mobile) untouched.
