### PR TITLE
cli: boot status bands + first-run setup ladder (design 01, 02)

### DIFF
--- a/surfaces/cli/src/app.tsx
+++ b/surfaces/cli/src/app.tsx
@@ -37,10 +37,10 @@ export interface AppOptions {
 export function App({ options }: { options: AppOptions }) {
   const [phase, setPhase] = useState<Phase>("boot");
   const [steps, setSteps] = useState<BootStep[]>([
-    { label: "loading wallet", status: "pending" },
-    { label: "checking claude", status: "pending" },
-    { label: "checking codex", status: "pending" },
-    { label: "restoring storage", status: "pending" },
+    { tag: "wallet", label: "loading wallet", status: "pending" },
+    { tag: "claude", label: "checking claude", status: "pending" },
+    { tag: "codex", label: "checking codex", status: "pending" },
+    { tag: "storage", label: "restoring storage", status: "pending" },
   ]);
   const [address, setAddress] = useState("");
   const [report, setReport] = useState<CliReport>({ claude: "missing", codex: "missing" });
@@ -75,7 +75,7 @@ export function App({ options }: { options: AppOptions }) {
     const rt = await buildRuntime(w, approval.current ?? autoApprove(), setCloudStatus);
     setRuntime(rt);
     setWallet(w);
-    set(3, { status: "ok", label: "storage ready" });
+    set(3, { status: "ok", label: "storage ready", detail: "READY" });
     // wipe the boot banner/checklist from the scrollback so the welcome panel lands on a
     // clean screen (Ink leaves prior static output in the terminal history otherwise),
     // then pad down to the bottom edge. Chat's frame is only as tall as its live content,
@@ -115,8 +115,10 @@ export function App({ options }: { options: AppOptions }) {
         const rep = await detectCli();
         if (!alive) return;
         setReport(rep);
-        set(1, { status: rep.claude === "ok" ? "ok" : "fail", label: `claude ${rep.claude}` });
-        set(2, { status: rep.codex === "ok" ? "ok" : "fail", label: `codex ${rep.codex}` });
+        const engineDetail = (s: CliReport["claude"]) =>
+          s === "ok" ? "OK" : s === "no-login" ? "NEEDS LOGIN" : "NOT INSTALLED";
+        set(1, { status: rep.claude === "ok" ? "ok" : "fail", label: `claude ${rep.claude}`, detail: engineDetail(rep.claude) });
+        set(2, { status: rep.codex === "ok" ? "ok" : "fail", label: `codex ${rep.codex}`, detail: engineDetail(rep.codex) });
 
         // onboard only on a TRUE first run: neither a finished-setup marker nor a
         // configured cloud. (Local-only writes no storage config, so the marker is what
@@ -149,7 +151,7 @@ export function App({ options }: { options: AppOptions }) {
           }
         } else {
           if (!alive) return;
-          set(3, { status: "ok", label: "storage: pick on next screen" });
+          set(3, { status: "ok", label: "storage: pick on next screen", detail: "PICK NEXT" });
           setPhase("onboard");
           onboardFinish.current = async (engine: "claude" | "codex", cfg?: StorageConfig) => {
             if (cfg) await chooseStorage(cfg);

--- a/surfaces/cli/src/components/BootChecklist.tsx
+++ b/surfaces/cli/src/components/BootChecklist.tsx
@@ -1,34 +1,42 @@
 import React from "react";
 import { Box, Text } from "ink";
 import { Spinner } from "./Spinner.js";
-import { glyph, colors } from "../theme.js";
+import { glyph, colors, tag as tagOf } from "../theme.js";
 
 export type BootStatus = "pending" | "ok" | "fail";
 export interface BootStep {
-  label: string;
+  tag: string; // the //TAG_ shown on the left of the band (wallet / claude / …)
+  label: string; // human line, kept as the fallback right-side value when no detail
   status: BootStatus;
-  detail?: string;
+  detail?: string; // the value shown on the right when resolved (address, OK, version…)
 }
 
-// The live "waking engines…" list. Each line shows a spinner while pending, then flips
-// to ✓/✗ as the real check (detectCli / wallet / storage) resolves — honest status, not
-// theater. Renders fine without animation (spinner falls back to a static frame).
+// The live boot status, drawn as the design's stacked full-width bands (tab 01): each
+// engine/check is one justified row — //TAG_ on the left, its live state on the right.
+// A spinner runs while pending, then the row flips to the real ✓/✗ result — honest
+// status, not theater. Renders fine without animation (spinner falls back to a static
+// frame).
 export function BootChecklist({ steps }: { steps: BootStep[] }) {
   return (
     <Box flexDirection="column" paddingX={1} marginTop={1}>
       {steps.map((s, i) => (
-        <Box key={i}>
-          <Box width={2}>
-            {s.status === "pending" ? (
-              <Spinner />
-            ) : s.status === "ok" ? (
-              <Text color={colors.ok}>{glyph.ok}</Text>
-            ) : (
-              <Text color={colors.err}>{glyph.fail}</Text>
-            )}
-          </Box>
-          <Text color={s.status === "fail" ? colors.err : undefined}>{s.label}</Text>
-          {s.detail ? <Text dimColor> {s.detail}</Text> : null}
+        <Box key={i} justifyContent="space-between">
+          <Text bold color={s.status === "fail" ? colors.err : colors.bone}>
+            {tagOf(s.tag)}
+          </Text>
+          {s.status === "pending" ? (
+            <Text color={colors.ok}>
+              <Spinner /> connecting…
+            </Text>
+          ) : s.status === "ok" ? (
+            <Text color={colors.ok}>
+              {s.detail ?? s.label} {glyph.ok}
+            </Text>
+          ) : (
+            <Text color={colors.err}>
+              {glyph.fail} {s.detail ?? s.label}
+            </Text>
+          )}
         </Box>
       ))}
     </Box>

--- a/surfaces/cli/src/components/SetupLadder.tsx
+++ b/surfaces/cli/src/components/SetupLadder.tsx
@@ -1,0 +1,63 @@
+import React from "react";
+import { Box, Text } from "ink";
+import { colors, surface, glyph } from "../theme.js";
+
+// The first-run progress ladder from design tab 02. Five conceptual rungs; the CLI's
+// many real onboarding steps (install, codex auth, gdrive…) collapse into whichever rung
+// they belong to, so the user always sees WHERE they are and how much is left — without
+// the functional flow having to change shape. `rung` is 1-based (1 = WALLET … 5 = chat).
+const RUNGS = [
+  { n: "01", label: "WALLET" },
+  { n: "02", label: "ENGINE" },
+  { n: "03", label: "WHERE SESSIONS LIVE" },
+  { n: "04", label: "READING THE CHAIN" },
+  { n: "05", label: "SAY SOMETHING" },
+] as const;
+
+export function SetupLadder({ rung, address }: { rung: number; address: string }) {
+  const filled = Math.max(0, Math.min(RUNGS.length, rung));
+  const meter = "█".repeat(filled) + "░".repeat(RUNGS.length - filled);
+  const short = address ? `${address.slice(0, 6)}…${address.slice(-4)}` : "";
+  const left = RUNGS.length - rung;
+
+  return (
+    <Box flexDirection="column">
+      <Box justifyContent="space-between">
+        <Text bold>SETTING YOU UP</Text>
+        <Text color={colors.ok}>{meter}</Text>
+      </Box>
+      <Box flexDirection="column" marginTop={1}>
+        {RUNGS.map((r, i) => {
+          const idx = i + 1;
+          const done = idx < rung;
+          const now = idx === rung;
+          const mark = done ? glyph.ok : now ? "▶" : "○";
+          const value = idx === 1 ? short : now ? "in progress" : "";
+          const color = done ? colors.ok : now ? colors.ink : surface.locked;
+          return (
+            <Box key={r.n} justifyContent="space-between">
+              <Text
+                color={color}
+                backgroundColor={now ? colors.bone : undefined}
+                bold={now}
+              >
+                {` ${mark} ${r.n}  ${r.label} `}
+              </Text>
+              {value ? (
+                <Text color={now ? colors.ink : colors.dim} backgroundColor={now ? colors.bone : undefined}>
+                  {`${value} `}
+                </Text>
+              ) : null}
+            </Box>
+          );
+        })}
+      </Box>
+      <Box marginTop={1} justifyContent="space-between">
+        <Text color={colors.ok}>{glyph.sparkle} WALLET LINKED</Text>
+        <Text dimColor>
+          {left > 0 ? `${left} step${left === 1 ? "" : "s"} left · ` : ""}your key never leaves this machine
+        </Text>
+      </Box>
+    </Box>
+  );
+}

--- a/surfaces/cli/src/views/Onboarding.tsx
+++ b/surfaces/cli/src/views/Onboarding.tsx
@@ -7,6 +7,28 @@ import { STORAGE_OPTIONS, type StorageConfig, type StorageKind, startCodexLogin,
 import type { CliReport, CliStatus } from "@iqlabs-official/agent-sdk";
 import { colors, glyph } from "../theme.js";
 import { Iggy } from "../components/Iggy.js";
+import { SetupLadder } from "../components/SetupLadder.js";
+
+// Collapse the many real onboarding steps into the design's five-rung ladder position
+// (tab 02). Wallet is already linked when onboarding starts, so the live rung is 2+.
+function rungOf(step: OnboardStep): number {
+  switch (step) {
+    case "engine":
+    case "install":
+    case "codexAuthChoice":
+    case "codexLogin":
+    case "codexApiKey":
+      return 2; // ENGINE
+    case "storage":
+    case "location":
+    case "gdriveLogin":
+      return 3; // WHERE SESSIONS LIVE
+    case "rpc":
+      return 4; // READING THE CHAIN
+    default:
+      return 2;
+  }
+}
 
 // First-run setup. Sequence: engine pick → codex login (if needed) → storage → rpc.
 //
@@ -212,11 +234,12 @@ export function Onboarding({
 
   return (
     <Box flexDirection="column" paddingX={1} gap={1}>
+      <SetupLadder rung={rungOf(step)} address={address} />
+
       <Box>
         <Iggy mood="idle" />
-        <Text bold color={colors.iqMagenta}>{" "}welcome to AgentNet</Text>
+        <Text dimColor>{" "}pick the brain you want to talk to — you can swap it any time.</Text>
       </Box>
-      <Text dimColor>wallet {address.slice(0, 6)}…{address.slice(-4)}</Text>
 
       <Box flexDirection="column">
         <Box><Text>claude </Text>{statusBadge(rep.claude)}</Box>


### PR DESCRIPTION
Brings the two first-run screens up to the design: **tab 01 (Boot)** and **tab 02 (Onboarding)**. Visual only — no functional flow changed.

## Boot (tab 01)

The "waking engines" checklist becomes the design's stacked full-width status bands. Each check is a justified row: `//TAG_` on the left, live state on the right.

```
 //WALLET_                                     6QzT4a…9fKe ✓
 //CLAUDE_                                              OK ✓
 //CODEX_                                    ✗ NOT INSTALLED
 //STORAGE_                                    ⠋ connecting…
```

A spinner runs while a check is pending, then the row flips to the real `✓`/`✗` result — honest status, driven by the same `detectCli` / wallet / storage checks as before.

## Onboarding (tab 02)

A five-rung ladder now heads first-run setup, with a progress meter and a "wallet linked" band. The CLI has *many* real steps (engine pick, install, codex device-auth, API key, storage, gdrive, RPC); they collapse into whichever conceptual rung they belong to, so the user always sees where they are and how much is left.

```mermaid
flowchart LR
  subgraph Ladder [5-rung ladder]
    R1[01 WALLET] --> R2[02 ENGINE] --> R3[03 WHERE SESSIONS LIVE] --> R4[04 READING THE CHAIN] --> R5[05 SAY SOMETHING]
  end
  S1[engine / install / codex*] -->|rungOf| R2
  S2[storage / location / gdrive] -->|rungOf| R3
  S3[rpc] -->|rungOf| R4
```

The functional step bodies (Select / TextInput / device-auth) are untouched — only a `SetupLadder` header and copy were added around them.

## Verification

- Typecheck + build pass.
- Offline capture probe: boot bands and ladder (rungs 2 and 3) render with **zero overflow** at 80 columns.
- CLI-only. `app.tsx` gains `tag`/`detail` on boot steps; core and other surfaces untouched.
