### PR TITLE
cli: footer names SESSIONS/MODEL, calm face line reads 'ready' (design 28)

### DIFF
--- a/surfaces/cli/src/components/Footer.tsx
+++ b/surfaces/cli/src/components/Footer.tsx
@@ -17,11 +17,13 @@ export function Footer({
 }) {
   const modelLabel = (model ?? "default").toUpperCase();
   const cols = process.stdout.columns || 80;
+  // The design's footer names the panels that open (SESSIONS, MODEL) rather than raw
+  // slash commands — /sessions and /model open exactly these, so the labels stay honest.
   const shortcuts =
     cols >= 90
-      ? ["? /HELP", "ESC CANCEL", "/NEW SESSION", "/ACCOUNT"]
+      ? ["? /HELP", "ESC CANCEL", "SESSIONS", "MODEL"]
       : cols >= 64
-        ? ["? /HELP", "ESC CANCEL"]
+        ? ["? /HELP", "SESSIONS", "MODEL"]
         : ["? /HELP"];
 
   return (

--- a/surfaces/cli/src/views/Chat.tsx
+++ b/surfaces/cli/src/views/Chat.tsx
@@ -81,7 +81,9 @@ function ActivityRow({
   const think = useFrameLoop(thinkingLabels.length, 1.2);
   const cast = useFrameLoop(castingFrames.length, 8);
 
-  let body: React.ReactNode = <Text> </Text>;
+  // The calm face line always carries a word (design tab 28): a steady dim "ready" when
+  // nothing is happening, replaced by the live status the moment something does.
+  let body: React.ReactNode = <Text dimColor>ready</Text>;
   if (error) {
     body = (
       <>


### PR DESCRIPTION
Design tab 28 (Bottom Chrome), the safe/contained parts.

- **Footer**: the bottom hint row names the panels that open — `SESSIONS`, `MODEL` — instead of raw `/new-session` / `/account`. `/sessions` and `/model` open exactly those, so the labels stay honest and more discoverable.
- **Face line**: the activity row's calm state was blank; it now carries a steady dim `ready`, replaced by the live status (thinking / skill / notice / interrupt) the moment something happens. Still exactly one row, fixed height.

Deferred to a later coordinated pass (they restructure the Chat frame, which a parallel session is also in): tab 28's rising SESSIONS panel and tab 30's footer-panel architecture.

Verified: typecheck + build pass. CLI-only; StatusLine left untouched. Two files (Footer, Chat activity row).