### PR TITLE
Keep one failed action from killing the whole chat server (#150 B1)

### DIFF
--- a/packages/core/src/chat/session.spec.ts
+++ b/packages/core/src/chat/session.spec.ts
@@ -50,7 +50,7 @@ const waitForNotice = async (transport: any, text: string) => {
   throw new Error(`notice "${text}" was never sent`);
 };
 
-function harness(opts: { cwd?: string; ownedSkills?: string[]; googleCredsConfigured?: boolean } = {}) {
+function harness(opts: { cwd?: string; ownedSkills?: string[]; googleCredsConfigured?: boolean; env?: Record<string, unknown> } = {}) {
   const handles: ReturnType<typeof fakeHandle>[] = [];
   const startSession = vi.fn(async (opts: any) => {
     const h = fakeHandle("sess-" + handles.length, opts.cli);
@@ -67,6 +67,7 @@ function harness(opts: { cwd?: string; ownedSkills?: string[]; googleCredsConfig
     walletAddress: () => null,
     storageInfo: async () => ({ info: {}, options: [], googleCredsConfigured: opts.googleCredsConfigured }),
     ownedSkills: opts.ownedSkills ? async () => opts.ownedSkills : undefined,
+    ...opts.env,
   };
   const chat = createChatSession(startSessionRuntime(startSession), transport as any, env);
   return { handles, startSession, fromUI, chat, transport };
@@ -448,5 +449,31 @@ describe("chat/session — slash commands", () => {
     } finally {
       await rm(cwd, { recursive: true, force: true });
     }
+  });
+});
+
+// A throwing handler used to escape the pump as an unhandled rejection and take the whole
+// host process down (issue #150 B1: connectCloud without Google creds). The dispatcher must
+// survive it, keep draining the queue, and tell the client its action failed.
+describe("chat/session — a handler that throws", () => {
+  it("keeps the dispatcher alive, reports the failure, and drains the rest of the queue", async () => {
+    const { fromUI, transport } = harness({
+      env: {
+        connectCloud: async () => {
+          throw new Error("gdrive needs an openBrowser callback for sign-in");
+        },
+      },
+    });
+
+    fromUI({ type: "connectCloud", kind: "gdrive" });
+    fromUI({ type: "wallet" }); // queued behind the failing message
+    await flush();
+
+    expect(transport.send).toHaveBeenCalledWith({
+      type: "notice",
+      text: "connectCloud failed: gdrive needs an openBrowser callback for sign-in",
+    });
+    // the message behind the failure is still handled — a throw must not abandon the queue
+    expect(transport.send).toHaveBeenCalledWith({ type: "wallet", address: null });
   });
 });

--- a/packages/core/src/chat/session.ts
+++ b/packages/core/src/chat/session.ts
@@ -473,13 +473,29 @@ export function createChatSession(
   // open()) and a fast "send" overlap, and ready's open() stops the handle send just
   // created → an empty turn. A surface may fire ready+send back-to-back (reconnect,
   // automation), so the dispatcher owns the ordering rather than trusting arrival gaps.
+  //
+  // Each message is also isolated: the pump is started with `void pump()`, so a handler
+  // that rejects would escape as an unhandled rejection and take the whole process down —
+  // one client's failed cloud connect would kill every other client's session. Catching
+  // per message keeps the process up, keeps the REST of the queue draining (a thrown
+  // handler used to abandon the messages behind it), and tells the client its action
+  // failed instead of leaving it waiting on a reply that never comes.
   const queue: any[] = [];
   let pumping = false;
   async function pump() {
     if (pumping) return;
     pumping = true;
     try {
-      while (queue.length) await handle(queue.shift());
+      while (queue.length) {
+        const m = queue.shift();
+        try {
+          await handle(m);
+        } catch (err) {
+          const text = err instanceof Error ? err.message : String(err);
+          console.warn(`[chat] ${m?.type ?? "message"} failed:`, text);
+          transport.send({ type: "notice", text: `${m?.type ?? "action"} failed: ${text}` });
+        }
+      }
     } finally {
       pumping = false;
     }


### PR DESCRIPTION
# Keep one failed action from killing the whole chat server

Fixes **B1 in #150**. A dispatcher handler that rejects escaped as an unhandled rejection — `pump()` is started with `void pump()` — so the host process exited. One client's failed cloud connect took down *every other client's* session, and the sender saw only its `204` and the stream closing.

The reproducer in #150 is `connectCloud` on an install with no Google credentials (`initialize` throws `gdrive needs an openBrowser callback for sign-in`), but the exposure is every case in the switch: `connectCloud`/`disconnectCloud`/`reconnectCloud`/`openCloud` have no `try/catch`, unlike the wallet and market cases beside them.

## What changed

One guard, inside the existing pump loop:

- **The process stays up.** A rejection is caught per message instead of escaping to the runtime.
- **The queue keeps draining.** Previously a throw abandoned every message queued behind it — the loop exited through the exception. Now later messages are still handled, which matters because the dispatcher deliberately owns strict ordering.
- **The client is told.** The failure goes back as the protocol's existing `notice` message (`"connectCloud failed: gdrive needs an openBrowser callback for sign-in"`) instead of silence, so the UI can stop waiting on a reply that will never come.

Ordering semantics are unchanged: one message still runs to completion before the next starts.

Held to five rules — each verified against this diff, not asserted:

1. **No meaningless wrappers with identical input/output** — ✅ no new function; the guard is a `try/catch` inside the existing `pump()` loop, and the failure path reuses `transport.send` directly.
2. **Scan existing functions first and reuse; never two functions with the same purpose** — ✅ reports through the protocol's existing `notice` message (`protocol.ts:186`) rather than inventing an error message type, and reuses the `console.warn` convention already used for best-effort failures in this file.
3. **No type variables that won't be reused; inline them** — ✅ no new types; the caught value is narrowed inline with `err instanceof Error`.
4. **No non-essential parameters** — ✅ no signature changes anywhere; `pump()` and `handle()` keep their existing shapes.
5. **Keep responsibilities separated; if the design feels wrong, say so** — ✅ the pump owns delivery and failure isolation; handlers keep owning their own logic and stay free to throw. Said-so: a generic guard means a handler that throws now reports a developer-facing `Error.message` to the UI. That is a real improvement over silence, but if you'd rather each case own a tailored message (and the guard be the last-resort net), that's a reasonable shape too — happy to change it.

`tsc --noEmit` clean · new spec passes and **fails without the guard** (verified by reverting the hunk) · full core suite shows no new failures — the 2 failing `session.spec` slash-command tests (`/resume`, `/skills`) are pre-existing on `main` and reproduce identically on an untouched checkout. Based on `6ab2fb2` (v0.1.6).

## Evidence

| Row | Artifact |
|---|---|
| Before/After screenshots | N/A - server-side dispatcher, no UI surface; the before/after is the process living or dying, shown below |
| Video walkthrough (MP4) | N/A - the observable behaviour is a process staying alive; logs capture it fully |
| Backend logs | **Before (on `6ab2fb2`):** `connectCloud` → `204`, then `Error: gdrive needs an openBrowser callback for sign-in`, process exits, port dead (`ECONNREFUSED`). **After:** process alive, `GET /` still served, log line `[chat] connectCloud failed: gdrive needs an openBrowser callback for sign-in` |
| Frontend logs | Client SSE after the failure: `{"type":"notice","text":"connectCloud failed: gdrive needs an openBrowser callback for sign-in"}`, and the session keeps answering — a following `{"type":"wallet"}` returns `{"type":"wallet","address":"3RAoCQ…nE2p"}` |
| Real-LLM trajectory | N/A - no agent, model, or prompt changes; message-dispatch layer only |
| Domain artifacts | `session.spec.ts` regression: a handler that throws must leave the pump alive, emit the notice, and still handle the message queued behind it. Mutation-checked — reverting the guard fails the test |
