### PR TITLE
Stop an unknown storage kind from bricking the install (#150 B2)

### DIFF
--- a/packages/core/src/account/login.ts
+++ b/packages/core/src/account/login.ts
@@ -11,7 +11,7 @@
 
 import { readFile, writeFile, rm } from "node:fs/promises";
 import { configFile, tokenFile, rootDir, ensureDir } from "../core/paths.js";
-import { buildStorage, type StorageConfig, type StorageKind } from "./storage/adapter.js";
+import { buildStorage, isStorageKind, type StorageConfig, type StorageKind } from "./storage/adapter.js";
 import { manualStorage, migrateLocalSessions } from "./storage/manual.js";
 import { mirrorStorage, type CloudStatus } from "./storage/mirror.js";
 import { migrateLegacyDriveSessions } from "./storage/gdrive.js";
@@ -24,9 +24,28 @@ export interface Session {
   storage: StorageAdapter;
 }
 
+// Kinds already reported as unbuildable, so the warning below is printed once per kind
+// instead of on every config read.
+const warnedKinds = new Set<string>();
+
+// A `kind` this build can't construct (a newer//hand-edited config, a backend that was
+// removed) is treated as NO cloud choice rather than a fatal one: buildStorage throws on
+// an unknown kind, and that throw used to escape the connect path and take the process
+// down on every launch — an unopenable install until config.json was deleted by hand.
+// Falling back to local-only keeps sessions working and leaves the picker free to connect
+// a real backend. Every consumer of the storage choice reads through here, so they all
+// agree on what is configured.
 async function readConfig(): Promise<StorageConfig | null> {
   try {
-    return JSON.parse(await readFile(configFile(), "utf8")) as StorageConfig;
+    const cfg = JSON.parse(await readFile(configFile(), "utf8")) as StorageConfig;
+    if (cfg?.kind != null && !isStorageKind(cfg.kind)) {
+      if (!warnedKinds.has(String(cfg.kind))) {
+        warnedKinds.add(String(cfg.kind));
+        console.warn(`[storage] ignoring unknown storage kind "${cfg.kind}" in config — using this device only`);
+      }
+      return null;
+    }
+    return cfg;
   } catch {
     return null;
   }
@@ -81,6 +100,12 @@ export async function initialize(
   cfg: StorageConfig,
   openBrowser?: (url: string) => void,
 ): Promise<void> {
+  // Validate BEFORE writing. `kind` arrives from the surfaces as a plain string, so an
+  // unbuildable value used to be persisted first and only rejected later when login built
+  // the backend — leaving a config on disk that fails on every subsequent connect.
+  if (!isStorageKind(cfg.kind)) {
+    throw new Error(`unknown storage kind: ${cfg.kind}`);
+  }
   if (cfg.kind === "gdrive" && !(await isSignedIn())) {
     if (!openBrowser) throw new Error("gdrive needs an openBrowser callback for sign-in");
     await googleLogin(openBrowser);

--- a/packages/core/src/account/storage/adapter.ts
+++ b/packages/core/src/account/storage/adapter.ts
@@ -34,6 +34,16 @@ export async function buildStorage(cfg: StorageConfig, walletAddress = ""): Prom
   return make(cfg, walletAddress);
 }
 
+/**
+ * True when `kind` names a backend this build can actually construct. `builders` is the
+ * one list of kinds, so callers validate against what buildStorage will really accept
+ * rather than a second copy that can drift. Used to keep an unbuildable persisted kind
+ * from reaching buildStorage (which throws) and to reject one before it is saved.
+ */
+export function isStorageKind(kind: unknown): kind is StorageKind {
+  return typeof kind === "string" && Object.prototype.hasOwnProperty.call(builders, kind);
+}
+
 // What the UI shows in the "where to save?" picker.
 export const STORAGE_OPTIONS: { kind: StorageKind; label: string; needs: string }[] = [
   { kind: "gdrive", label: "Google Drive", needs: "sign in with Google" },

--- a/packages/core/src/account/storageKind.spec.ts
+++ b/packages/core/src/account/storageKind.spec.ts
@@ -1,0 +1,54 @@
+import { describe, it, expect, beforeEach, afterEach, vi } from "vitest";
+import { mkdtempSync, rmSync, writeFileSync, readFileSync } from "node:fs";
+import { join } from "node:path";
+import { tmpdir } from "node:os";
+import { isStorageKind } from "./storage/adapter.js";
+import { initialize, isCloudConnected, currentStorageKind, getStorageInfo } from "./login.js";
+
+// A storage kind this build can't construct (hand-edited config, a backend removed in a
+// downgrade) used to reach buildStorage and throw inside the connect path, killing the
+// host process on EVERY launch — an install that could only be recovered by deleting
+// config.json. #150 B2.
+let home: string;
+
+beforeEach(() => {
+  home = mkdtempSync(join(tmpdir(), "agentnet-test-"));
+  process.env.AGENTNET_HOME = home;
+});
+
+afterEach(() => {
+  delete process.env.AGENTNET_HOME;
+  rmSync(home, { recursive: true, force: true });
+  vi.restoreAllMocks();
+});
+
+describe("storage kind validation", () => {
+  it("accepts every kind the registry can build, and nothing else", () => {
+    for (const k of ["local", "gdrive", "icloud", "custom"]) expect(isStorageKind(k)).toBe(true);
+    for (const k of ["dropbox", "", "toString", null, undefined, 7]) expect(isStorageKind(k)).toBe(false);
+  });
+
+  it("treats an unbuildable persisted kind as no cloud instead of throwing", async () => {
+    writeFileSync(join(home, "config.json"), JSON.stringify({ kind: "dropbox" }));
+    vi.spyOn(console, "warn").mockImplementation(() => {});
+
+    // every consumer of the storage choice agrees: no cloud configured, so callers fall
+    // back to local-only rather than building (and crashing on) an unknown backend.
+    await expect(isCloudConnected()).resolves.toBe(false);
+    await expect(currentStorageKind()).resolves.toBeNull();
+    await expect(getStorageInfo()).resolves.toBeNull();
+    expect(console.warn).toHaveBeenCalled();
+  });
+
+  it("still reads a valid persisted kind", async () => {
+    writeFileSync(join(home, "config.json"), JSON.stringify({ kind: "icloud", location: "/tmp/x" }));
+    await expect(currentStorageKind()).resolves.toBe("icloud");
+  });
+
+  it("refuses to persist an unknown kind", async () => {
+    writeFileSync(join(home, "config.json"), JSON.stringify({ kind: "local" }));
+    await expect(initialize({ kind: "dropbox" } as never)).rejects.toThrow(/unknown storage kind/);
+    // the previous choice survives — a rejected connect must not corrupt the config
+    expect(JSON.parse(readFileSync(join(home, "config.json"), "utf8")).kind).toBe("local");
+  });
+});


### PR DESCRIPTION
# Stop an unknown storage kind from bricking the install

Fixes **B2 in #150**. A `kind` this build can't construct reached `buildStorage`, which throws `unknown storage kind: …`. The throw landed inside the async connect path, so the process exited on the **first client connect** — and again on every launch afterwards. The install was recoverable only by deleting `config.json` by hand.

It isn't only a hand-edit scenario: `connectCloud` types `kind` as a plain `string` on the wire, and `initialize` persisted it *before* `login` ever tried to build it — so the protocol itself could write the value that bricks the next boot.

## What changed

Two halves, both validated against the `builders` registry so there's no second list to drift:

- **`readConfig` treats an unbuildable kind as "no cloud choice."** Sessions keep working on local, a one-time warning explains what was ignored, and the picker can still connect a real backend. Because every consumer of the storage choice (`login`, `isCloudConnected`, `currentStorageKind`, `getStorageInfo`, `isInitialized`) reads through this one seam, they all agree — the UI says "this device only" and that is exactly what's happening, rather than showing a phantom backend.
- **`initialize` validates before writing.** An unknown kind is rejected up front, so it can never be persisted and the previous valid choice survives a rejected connect.

`isStorageKind` is derived from `builders` itself, so it accepts precisely what `buildStorage` can construct — adding a backend stays a one-entry change.

Held to five rules — each verified against this diff, not asserted:

1. **No meaningless wrappers with identical input/output** — ✅ `isStorageKind` is a real guard (an unknown-typed value narrowed to `StorageKind` against the live registry), not a rename of an existing call; it has two distinct callers with different purposes (don't build, don't persist).
2. **Scan existing functions first and reuse; never two functions with the same purpose** — ✅ validates against the existing `builders` record rather than a new hardcoded kind list (a second list would drift from `buildStorage` the moment a backend is added), and the fallback rides the existing `readConfig` seam every consumer already uses instead of adding a check to each one.
3. **No type variables that won't be reused; inline them** — ✅ no new types; `isStorageKind` reuses the exported `StorageKind` as a type predicate.
4. **No non-essential parameters** — ✅ no signature changes; `isStorageKind(kind: unknown)` takes exactly what callers have (a parsed-JSON value and a wire string).
5. **Keep responsibilities separated; if the design feels wrong, say so** — ✅ the registry owns "what kinds exist," `login` owns "what is configured," and `buildStorage` still throws for direct callers rather than being softened. Said-so: falling back silently-but-warned is a judgement call — if you'd rather a bad config surface in the UI as an explicit "your saved backend is unavailable, pick another" state instead of quietly reading as local-only, that's a better user story and a small change from here.

`tsc --noEmit` clean · 4 new specs pass and the key one **fails without the fix** (verified by reverting the `readConfig` hunk) · full core suite shows no new failures — the 2 failing `session.spec` slash-command tests are pre-existing on `main`. Based on `6ab2fb2` (v0.1.6).

## Evidence

| Row | Artifact |
|---|---|
| Before/After screenshots | N/A - boot-path/config layer, no UI surface; before/after is the process living or dying, shown below |
| Video walkthrough (MP4) | N/A - the observable behaviour is a server surviving its first connect; logs capture it fully |
| Backend logs | **Before (on `6ab2fb2`):** with `{"kind":"dropbox"}` the server boots, then the first SSE connect kills it — `Error: unknown storage kind: dropbox`, and every reboot repeats it. **After:** boots, serves the first SSE client (`client id c1` issued), logs `[storage] ignoring unknown storage kind "dropbox" in config — using this device only` |
| Frontend logs | Session remains functional with the bad config present: a `{"type":"wallet"}` round-trip answers normally over SSE |
| Real-LLM trajectory | N/A - no agent, model, or prompt changes; config/boot layer only |
| Domain artifacts | `storageKind.spec.ts`: the registry accepts exactly the four buildable kinds (and rejects `dropbox`, `""`, `toString`, `null`, `7`); an unbuildable persisted kind yields no-cloud across every consumer; a valid kind still reads back; `initialize` rejects an unknown kind and leaves the existing `config.json` untouched |
