### PR TITLE
Write wallet keys owner-only (#150 B3)

### DIFF
--- a/packages/core/src/account/localWallet.spec.ts
+++ b/packages/core/src/account/localWallet.spec.ts
@@ -1,0 +1,41 @@
+import { describe, it, expect, beforeEach, afterEach } from "vitest";
+import { mkdtempSync, rmSync, statSync } from "node:fs";
+import { join } from "node:path";
+import { tmpdir } from "node:os";
+import { localWallet } from "./localWallet.js";
+
+// The keypair file is a plaintext ed25519 secret key. It used to be written with the
+// default 0644 — readable by every local account on a shared machine — while the rest of
+// our secrets already used 0600 (rpc.ts) inside 0700 dirs (paths.ts). #150 B3.
+let dir: string;
+
+beforeEach(() => {
+  dir = mkdtempSync(join(tmpdir(), "agentnet-test-"));
+});
+
+afterEach(() => {
+  rmSync(dir, { recursive: true, force: true });
+});
+
+const mode = (p: string) => statSync(p).mode & 0o777;
+
+describe("local wallet key permissions", () => {
+  it("writes a generated key owner-only, inside an owner-only directory", async () => {
+    const path = join(dir, "nested", "id.json");
+    const res = await localWallet(path);
+
+    expect(res.created).toBe(true);
+    expect(mode(path)).toBe(0o600);
+    expect(mode(join(dir, "nested"))).toBe(0o700);
+  });
+
+  it("reuses an existing key without touching its permissions", async () => {
+    const path = join(dir, "id.json");
+    const first = await localWallet(path);
+    const second = await localWallet(path);
+
+    expect(second.created).toBe(false);
+    expect(second.address).toBe(first.address);
+    expect(mode(path)).toBe(0o600);
+  });
+});

--- a/packages/core/src/account/localWallet.ts
+++ b/packages/core/src/account/localWallet.ts
@@ -72,10 +72,16 @@ export async function loadOrCreateWallet(
     );
   }
 
-  // missing, or invalid+overwrite → generate and write
+  // missing, or invalid+overwrite → generate and write. The file is a plaintext ed25519
+  // secret key, so it is written owner-only (0600) inside an owner-only directory (0700) —
+  // what solana-keygen does, and what the rest of our own secrets already get (rpc.ts
+  // writes the Helius token with mode 0o600, paths.ts creates dirs with 0o700). Without
+  // the modes these defaulted to 0644: every local account could read a wallet the app
+  // invites the user to fund. Only keys we create are set here — an existing file's
+  // permissions are left to whoever created it.
   const kp = Keypair.generate();
-  await mkdir(dirname(path), { recursive: true });
-  await writeFile(path, JSON.stringify(Array.from(kp.secretKey)));
+  await mkdir(dirname(path), { recursive: true, mode: 0o700 });
+  await writeFile(path, JSON.stringify(Array.from(kp.secretKey)), { mode: 0o600 });
   return { wallet: keypairWallet(kp), address: kp.publicKey.toBase58(), created: true, path };
 }
 


### PR DESCRIPTION
# Write wallet keys owner-only

Fixes **B3 in #150**. `loadOrCreateWallet` writes the generated keypair — a plaintext ed25519 secret key — with a bare `writeFile`, so it lands at the default `0644`, and creates its directory with a bare `mkdir`. On a shared or multi-account machine, every local user can read a wallet the app actively invites people to fund.

This reads as one file out of step rather than a different policy: the codebase already treats key material as owner-only everywhere else — `rpc.ts` writes the Helius token with `{ mode: 0o600 }`, `paths.ts` creates its directories with `ensureDir(0o700)`, and `solana-keygen` itself writes `0600`.

## What changed

`0600` on the key, `0700` on its parent directory — two mode arguments on calls that were already there.

Scope is deliberately narrow: **only keys this code creates are set.** An existing keyfile is left exactly as its owner created it, because silently `chmod`-ing a file the app didn't write (`~/.config/solana/id.json` is commonly a user's own long-lived wallet) is a surprise that belongs to the user, not to us. If you'd rather it also tighten a loose existing key — or warn about one — that's a small addition and a reasonable call to make differently.

Held to five rules — each verified against this diff, not asserted:

1. **No meaningless wrappers with identical input/output** — ✅ no new function; two mode arguments added to the existing `mkdir`/`writeFile` calls.
2. **Scan existing functions first and reuse; never two functions with the same purpose** — ✅ adopts the modes the repo already standardised on (`rpc.ts`'s `0o600`, `paths.ts`'s `0o700`) rather than inventing a permissions helper; no second way to write a secret.
3. **No type variables that won't be reused; inline them** — ✅ no new types; the options objects are inline literals.
4. **No non-essential parameters** — ✅ no signature changes; `loadOrCreateWallet` and `localWallet` are untouched from the caller's side.
5. **Keep responsibilities separated; if the design feels wrong, say so** — ✅ key creation owns the permissions of what it creates, and nothing else changes. Said-so above: leaving an existing loose keyfile alone is a judgement call, and the opposite choice is defensible — flagging it rather than deciding it silently.

`tsc --noEmit` clean · 2 new specs, both **fail without the fix** (verified by reverting the hunk: `expected 420 to be 384`) · full core suite shows no new failures — the 2 failing `session.spec` slash-command tests are pre-existing on `main`. Based on `6ab2fb2` (v0.1.6).

## Evidence

| Row | Artifact |
|---|---|
| Before/After screenshots | N/A - filesystem permissions, no UI surface; the before/after is the file mode, below |
| Video walkthrough (MP4) | N/A - the observable change is a single file mode |
| Backend logs | Real localhost surface, fresh isolated `AGENTNET_HOME`, first SSE connect creates the guest wallet — **before (on `6ab2fb2`): `-rw-r--r--`; after: `-rw-------`** |
| Frontend logs | N/A - no client-visible behaviour changes; the wallet loads and signs exactly as before |
| Real-LLM trajectory | N/A - no agent, model, or prompt changes |
| Domain artifacts | `localWallet.spec.ts`: a generated key is `0600` inside a `0700` directory, and re-loading an existing key returns the same address without altering its mode. Mutation-checked — reverting the modes fails both |
