### PR TITLE
cli: market/skill screens — MARKET title, card silhouettes, //BUY_ band, mint plaque (08/24/25)

### DIFF
--- a/surfaces/cli/src/components/Band.tsx
+++ b/surfaces/cli/src/components/Band.tsx
@@ -1,0 +1,44 @@
+import React from "react";
+import { Box, Text } from "ink";
+import { colors, tag } from "../theme.js";
+import { padCells, displayWidth } from "../format.js";
+
+// The design's section band (tabs 05/08/24/25): a full-width row with a //LABEL_ pinned
+// left and a note pinned right. `inverted` fills the row bone-on-ink for the one band a
+// screen wants to shout (//BUY_, //NEXT_). One source of truth so every screen's bands
+// line up instead of each re-deriving the padding.
+export function Band({
+  label,
+  note,
+  inverted = false,
+  width,
+}: {
+  label: string;
+  note: string;
+  inverted?: boolean;
+  width?: number;
+}) {
+  // Market/detail screens sit inside a rounded box with paddingX={1}: border 2 + pad 2.
+  const w = Math.max(12, (width ?? process.stdout.columns ?? 80) - 4);
+  const left = tag(label);
+  const gap = w - displayWidth(left) - displayWidth(note);
+
+  if (inverted) {
+    const row = gap >= 1 ? left + " ".repeat(gap) + note : `${left} ${note}`;
+    return (
+      <Text backgroundColor={colors.bone} color={colors.ink} bold>
+        {padCells(row.slice(0, w), w)}
+      </Text>
+    );
+  }
+  return (
+    <Box width={w} justifyContent="space-between">
+      <Text bold color={colors.bone}>
+        {left}
+      </Text>
+      <Text dimColor wrap="truncate-end">
+        {note}
+      </Text>
+    </Box>
+  );
+}

--- a/surfaces/cli/src/views/SkillMarket.tsx
+++ b/surfaces/cli/src/views/SkillMarket.tsx
@@ -6,6 +6,7 @@ import { maskedHeliusKey, hasDasRpc, saveHeliusKey, getNetwork } from "@iqlabs-o
 import { colors, glyph } from "../theme.js";
 import type { OwnedSkill } from "../components/WelcomePanel.js";
 import { ChipCarousel } from "../components/ChipCarousel.js";
+import { Band } from "../components/Band.js";
 import { tierInfo } from "./market/tiers.js";
 import { AgentProfileView, type ProfileSub } from "./market/AgentProfileView.js";
 import { SkillDetailView, type DetailSub } from "./market/SkillDetailView.js";
@@ -84,26 +85,37 @@ function SkillChip({
   const cat = (card.category || (isWorkflow ? "workflow" : "skill")).toUpperCase().slice(0, 8);
   const price = card.price && card.price !== "0" ? sol(Number(card.price)) : "FREE";
   const { cur } = tierInfo(card.stars ?? 0);
+  // design tab 08: grey silhouette = skill, gold = workflow; the selected card lights up.
+  const accent = isWorkflow ? colors.warn : colors.dim;
   return (
     <Box
       flexDirection="column"
       width={SKILL_CHIP_W}
       paddingX={1}
       borderStyle="round"
-      borderColor={focused ? colors.iqCyan : isWorkflow ? colors.warn : colors.dim}
+      borderColor={focused ? colors.iqCyan : accent}
     >
-      <Text dimColor>[ {cat} {isWorkflow ? "/ FLOW" : "/ SKILL"} ]</Text>
-      <Text color={focused ? colors.iqCyan : undefined} bold={focused}>
+      {/* barcode glyph + category/type mark, the card's top strip */}
+      <Box justifyContent="space-between">
+        <Text color={accent}>▐▖▐</Text>
+        <Text dimColor>{cat} / {isWorkflow ? "FLOW" : "SKILL"}</Text>
+      </Box>
+      <Text color={focused ? colors.iqCyan : colors.bone} bold>
         {card.name.slice(0, SKILL_CHIP_W - 4)}
       </Text>
-      <Box>
-        <Text dimColor>×{card.supply ?? 0}</Text>
-        {card.stars ? <Text color={colors.warn}> ★{card.stars}</Text> : null}
-        {cur ? <Text color={colors.warn}> [{cur.name}]</Text> : null}
+      {/* the big supply number, like the design's card corner count */}
+      <Box justifyContent="space-between">
+        <Text bold color={colors.bone}>×{card.supply ?? 0}</Text>
+        <Text>
+          {card.stars ? <Text color={colors.warn}>★{card.stars} </Text> : null}
+          {cur ? <Text color={colors.warn}>[{cur.name}]</Text> : null}
+        </Text>
       </Box>
-      <Box>
+      <Box justifyContent="space-between">
         <Text color={colors.iqViolet}>{price}</Text>
-        <Text color={isOwned ? colors.ok : colors.dim}> {isOwned ? `OWNED${firing ? ` ${glyph.sparkle}` : ""}` : "GET"}</Text>
+        <Text color={isOwned ? colors.ok : colors.dim} bold={isOwned}>
+          {isOwned ? `OWNED${firing ? ` ${glyph.sparkle}` : ""}` : "GET"}
+        </Text>
       </Box>
     </Box>
   );
@@ -768,9 +780,18 @@ export function SkillMarket({
   if (stage === "publish") {
     if (pubResult) {
       const ok = pubResult.startsWith("published");
+      const mint = ok ? pubResult.split("mint:")[1]?.trim() : null;
       return (
         <Box flexDirection="column" paddingX={1} borderStyle="round" borderColor={ok ? colors.ok : colors.err}>
-          <Text bold color={ok ? colors.ok : colors.err}>{pubResult}</Text>
+          {ok ? (
+            <Box flexDirection="column" alignItems="center">
+              <Text dimColor>ON SUCCESS</Text>
+              <Text bold color={colors.ok}>{glyph.sparkle} {pubKind.toUpperCase()} MINTED {glyph.sparkle}</Text>
+              {mint && mint !== "?" ? <Text dimColor>{mint}</Text> : null}
+            </Box>
+          ) : (
+            <Text bold color={colors.err}>{pubResult}</Text>
+          )}
           <Box marginTop={1}><Text dimColor>[esc] / [↵] close</Text></Box>
         </Box>
       );
@@ -934,13 +955,15 @@ export function SkillMarket({
   }
 
   // ── list ───────────────────────────────────────────────────────────────────
+  const onMainnet = `${results.length} ${kind === "skill" ? "SKILL" : "WORKFLOW"}${results.length === 1 ? "" : "S"} ON MAINNET`;
   return (
     <Box flexDirection="column" paddingX={1} borderStyle="round" borderColor={colors.iqViolet}>
-      <Box>
-        <Text bold color={colors.iqMagenta}>❖ skill market</Text>
-        <Text dimColor>   balance {sol(balance)}</Text>
-        <Text dimColor>   </Text>
-        <HeliusBadge status={rpcStatus} />
+      <Box justifyContent="space-between">
+        <Text bold color={colors.bone}>MARKET</Text>
+        <Box>
+          <Text dimColor>{onMainnet}   </Text>
+          <HeliusBadge status={rpcStatus} />
+        </Box>
       </Box>
       {/* tabs */}
       <Box marginTop={1}>
@@ -990,11 +1013,15 @@ export function SkillMarket({
         <Box marginTop={1}><Text color={colors.ok}>{glyph.sparkle} {flash}</Text></Box>
       ) : null}
       <Box marginTop={1}>
-        <Text dimColor>
+        <Band label="buy" note="ONE TX: PAY, MINT YOUR COPY, EQUIP IT." inverted />
+      </Box>
+      <Box justifyContent="space-between">
+        <Text dimColor wrap="truncate-end">
           {typing
             ? "type to search · ↵ run · [tab] skills/workflows · ↓ results · esc close"
-            : "←/→ rotate · ↵ open · [b] buy · [tab] switch · [/] search · [a] agents · [p] publish · [r] rpc · [h] hide owned · [s] sort · esc close"}
+            : "←/→ · ↵ open · [b] buy · [tab] switch · [/] search · [a] agents · [p] publish · [h] hide · [s] sort · esc"}
         </Text>
+        <Text dimColor>{sol(balance)}</Text>
       </Box>
     </Box>
   );

--- a/surfaces/cli/src/views/market/PublishProgressView.tsx
+++ b/surfaces/cli/src/views/market/PublishProgressView.tsx
@@ -4,6 +4,7 @@
 import React from "react";
 import { Box, Text } from "ink";
 import { colors } from "../../theme.js";
+import { Band } from "../../components/Band.js";
 
 export interface PublishProgress {
   phase: "store" | "mint" | "list";
@@ -13,10 +14,12 @@ export interface PublishProgress {
   kind: "skill" | "workflow";
 }
 
-const PHASES: { key: PublishProgress["phase"]; label: string }[] = [
-  { key: "store", label: "storing on-chain" },
-  { key: "mint", label: "minting the NFT" },
-  { key: "list", label: "listing for sale" },
+// design tab 25: three numbered phases, each with a one-line status of what that
+// signature does.
+const PHASES: { key: PublishProgress["phase"]; label: string; sub: string }[] = [
+  { key: "store", label: "STORE", sub: "code-in chunks" },
+  { key: "mint", label: "MINT", sub: "creating token-2022 mint" },
+  { key: "list", label: "LIST", sub: "register price · self mint #1" },
 ];
 
 export function PublishProgressView({ progress }: { progress: PublishProgress | null }) {
@@ -30,19 +33,38 @@ export function PublishProgressView({ progress }: { progress: PublishProgress | 
   // Segmented forge gauge, mirroring the webview's 14-cell bar (unlock-flow design).
   const CELLS = 14;
   const filled = Math.round((overall / 100) * CELLS);
+  const remaining = total && total > signed ? total - signed : null;
   return (
     <Box flexDirection="column" marginTop={1}>
       {PHASES.map((p, i) => (
-        <Text key={p.key} color={i < idx ? colors.ok : i === idx ? colors.iqCyan : colors.dim}>
-          {i < idx ? "✓" : i === idx ? "▸" : "○"} {p.label}
-        </Text>
+        <Box key={p.key} justifyContent="space-between">
+          <Text color={i < idx ? colors.ok : i === idx ? colors.iqCyan : colors.dim} bold={i === idx}>
+            {i < idx ? "✓" : i === idx ? "▸" : "○"} {i + 1} · {p.label}
+          </Text>
+          <Text dimColor>{i < idx ? "done" : i === idx ? p.sub : ""}</Text>
+        </Box>
       ))}
-      <Text>
-        <Text color={colors.iqCyan}>{"▰".repeat(filled)}</Text>
-        <Text color={colors.dim}>{"▱".repeat(CELLS - filled)}</Text>
-        <Text dimColor> {overall}%</Text>
+      <Box marginTop={1}>
+        <Text>
+          <Text color={colors.iqCyan}>{"▰".repeat(filled)}</Text>
+          <Text color={colors.dim}>{"▱".repeat(CELLS - filled)}</Text>
+          <Text dimColor> {overall}%</Text>
+        </Text>
+      </Box>
+      <Text dimColor>
+        {signed > 0
+          ? `${signed}${total ? `/${total}` : ""} SIGNATURES_APPROVED`
+          : "waiting for the first signature…"}
       </Text>
-      <Text dimColor>{signed > 0 ? `${signed}${total ? `/${total}` : ""} signatures approved` : "waiting for the first signature…"}</Text>
+      {remaining ? (
+        <Box marginTop={1}>
+          <Band
+            label="next"
+            note={`APPROVE IN YOUR WALLET · ${remaining} SIGNATURE${remaining === 1 ? "" : "S"} LEFT`}
+            inverted
+          />
+        </Box>
+      ) : null}
     </Box>
   );
 }

--- a/surfaces/cli/src/views/market/SkillDetailView.tsx
+++ b/surfaces/cli/src/views/market/SkillDetailView.tsx
@@ -6,11 +6,21 @@ import { Box, Text } from "ink";
 import type { SkillDetail, Note } from "@iqlabs-official/agent-sdk";
 import { colors, glyph } from "../../theme.js";
 import { ScrollView } from "./ScrollView.js";
+import { Band } from "../../components/Band.js";
 
 export type DetailSub = "main" | "skillText" | "comments";
 
 function noteDate(ts: number): string {
   return new Date(ts).toLocaleDateString();
+}
+
+const SOL = 1_000_000_000;
+function priceLabel(price?: string | null): string {
+  if (!price || price === "0") return "FREE";
+  return `${(Number(price) / SOL).toFixed(3)} SOL`;
+}
+function shortMint(m?: string): string {
+  return m && m.length > 12 ? `${m.slice(0, 6)}…${m.slice(-4)}` : m ?? "";
 }
 
 export function SkillDetailView({
@@ -73,12 +83,17 @@ export function SkillDetailView({
   }
 
   // main
+  const kindWord = (c.type ?? "skill").toUpperCase();
   return (
     <Box flexDirection="column" paddingX={1} borderStyle="round" borderColor={colors.iqViolet}>
-      <Box>
+      <Box justifyContent="space-between">
+        <Text bold color={colors.bone}>{kindWord}</Text>
+        <Text dimColor>{shortMint(c.id)}{c.type === "workflow" ? " · soulbound token-2022" : " · soulbound"}</Text>
+      </Box>
+      <Box marginTop={1}>
         <Text bold color={colors.iqCyan}>{c.name}</Text>
         {firing ? <Text color={colors.iqMagenta}> ✦</Text> : null}
-        <Text dimColor>  {c.type ?? "skill"} · ×{c.supply ?? 0}{c.stars ? ` · ★${c.stars}` : ""}{isOwned ? (disposed ? " · disposed" : " · owned") : ""}</Text>
+        <Text dimColor>  ×{c.supply ?? 0}{c.stars ? ` · ★${c.stars}` : ""}{isOwned ? (disposed ? " · disposed" : " · owned") : ""}</Text>
       </Box>
       {c.description ? <Text>{c.description}</Text> : null}
       {c.category || (c.hashtags && c.hashtags.length) ? (
@@ -112,7 +127,7 @@ export function SkillDetailView({
 
       {detail.repos && detail.repos.length ? (
         <Box flexDirection="column" marginTop={1}>
-          <Text dimColor>used by · <Text color={colors.warn}>★{c.stars ?? detail.repos.reduce((s, r) => s + (r.stars || 0), 0)}</Text></Text>
+          <Band label="used by" note="VERIFIED REPOS · WHERE STARS COME FROM" />
           {detail.repos.map((r) => (
             <Box key={r.url}>
               <Text color={colors.iqCyan}>  {r.owner}/{r.name}</Text>
@@ -135,6 +150,13 @@ export function SkillDetailView({
       </Box>
 
       {flash ? <Box marginTop={1}><Text color={colors.ok}>{glyph.sparkle} {flash}</Text></Box> : null}
+      <Box marginTop={1}>
+        <Band
+          label="buy"
+          note={`${priceLabel(c.price)} · MINTS YOUR COPY, NEVER TRANSFERABLE`}
+          inverted
+        />
+      </Box>
       <Box marginTop={1}>
         <Text dimColor>
           {busy ? "working…" : isOwned


### PR DESCRIPTION
Design tabs **08 (Skill Market)**, **24 (Skill Detail)**, **25 (Publish Forge)** — visual parity on the CLI market screens. The functional stage machine (search / buy / publish / comment / blog) is untouched; this is presentation only.

## New: a shared `Band`

`//LABEL_` on the left, a note on the right, plain or `inverted` (bone-on-ink for the one line a screen shouts — `//BUY_`, `//NEXT_`). One source of truth so every screen's bands line up instead of each re-deriving the padding.

## Screens

```mermaid
flowchart LR
  L["Market list (08)<br/>MARKET · N ON MAINNET<br/>card silhouettes · //BUY_"] -->|↵ open| D["Skill detail (24)<br/>SKILL · mint<br/>//USED BY_ · //BUY_"]
  L -->|[p] publish| P["Publish (25)<br/>1 STORE · 2 MINT · 3 LIST<br/>gauge · //NEXT_"]
  P -->|on chain| M["SKILL MINTED plaque<br/>+ mint address"]
```

- **08**: header reads `MARKET` + `N SKILLS ON MAINNET`; skill chips become card silhouettes (barcode strip + type mark, bold supply count, gold = workflow / grey = skill); `//BUY_ ONE TX: PAY, MINT YOUR COPY, EQUIP IT.` above the footer; balance moved to the footer right.
- **24**: `SKILL` title + short mint; `//USED BY_` band over the verified-repo list; `//BUY_` band with `price · MINTS YOUR COPY, NEVER TRANSFERABLE`.
- **25**: numbered phases `1 · STORE / 2 · MINT / 3 · LIST`, each with a live sub-status; uppercased `N/M SIGNATURES_APPROVED`; `//NEXT_ APPROVE IN YOUR WALLET · N LEFT`; the success screen is now a centered `SKILL MINTED` plaque with the mint address.

## Honesty notes

- The design's `PAYS CREATOR 93.1%` figure is **omitted** — there's no constant in core to source it from, so it isn't fabricated.
- The `↗ EXPLORER` / `TAP TO COPY` affordances are dropped: a terminal can't click, and there's no wired explorer action in the CLI, so a label would be theater. The mint is shown in full so the user's terminal can select it.
- Real PNG card art can't render in a terminal, so cards are text silhouettes.

## Verification

- Typecheck + build pass.
- Offline capture probe: `Band` (both modes) and publish progress render with **zero overflow** at 80 columns.
- CLI-only; core and other surfaces untouched.
