### PR TITLE
cli: agent profile + comment writing (design 21/22)

### DIFF
--- a/surfaces/cli/src/views/SkillMarket.tsx
+++ b/surfaces/cli/src/views/SkillMarket.tsx
@@ -190,7 +190,9 @@ export function SkillMarket({
   const [profileSub, setProfileSub] = useState<ProfileSub>("main");
   const [profileScroll, setProfileScroll] = useState(0);
 
-  // blog composer (self note on own profile)
+  // note composer — reused for a self blog post AND a comment on another agent (both are
+  // postAgentNote to the profile's wallet; only the gate and the landing sub differ).
+  const [composeKind, setComposeKind] = useState<"blog" | "comment">("blog");
   const [blogField, setBlogField] = useState<BlogField>("title");
   const [blogTitle, setBlogTitle] = useState("");
   const [blogText, setBlogText] = useState("");
@@ -450,7 +452,7 @@ export function SkillMarket({
       setBlogTitle(""); setBlogText(""); setBlogImage(""); setBlogGitLink("");
       const refreshed = await api.getAgentProfile(agentProfile.wallet).catch(() => null);
       if (refreshed) setAgentProfile(refreshed);
-      setProfileSub("blog");
+      setProfileSub(composeKind === "comment" ? "comments" : "blog");
       setStage("agentProfile");
     } else {
       setFlash(`post failed: ${res.error ?? "unknown"}`);
@@ -517,22 +519,32 @@ export function SkillMarket({
         profileSub === "comments" ? (agentProfile?.threads ?? []).filter((t) => !t.note.isSelfNote).reduce((s, t) => s + 1 + t.replies.length, 0) :
         profileSub === "blog" ? (agentProfile?.threads ?? []).filter((t) => t.note.isSelfNote).length : 0;
       const height = profileSub === "repos" ? 10 : 12;
+      // the design-22 gate: comment on another agent only while holding a skill they made.
+      const canComment =
+        !!agentProfile && !agentProfile.self &&
+        (agentProfile.createdSkills ?? []).some((s) => owned.has(s.name));
+      const openCompose = (mode: "blog" | "comment") => {
+        setComposeKind(mode);
+        setBlogTitle(""); setBlogText(""); setBlogImage(""); setBlogGitLink("");
+        setBlogField(mode === "comment" ? "text" : "title");
+        setStage("blogCompose");
+      };
       if (profileSub !== "main") {
         if (key.escape) { setProfileSub("main"); setProfileScroll(0); return; }
         if (key.downArrow) { setProfileScroll((o) => clampScroll(o + 1, total, height)); return; }
         if (key.upArrow) { setProfileScroll((o) => clampScroll(o - 1, total, height)); return; }
         if (key.pageDown) { setProfileScroll((o) => clampScroll(o + height, total, height)); return; }
         if (key.pageUp) { setProfileScroll((o) => clampScroll(o - height, total, height)); return; }
-        if (profileSub === "blog" && input === "n" && agentProfile?.self) {
-          setBlogField("title"); setStage("blogCompose"); return;
-        }
+        if (profileSub === "blog" && input === "n" && agentProfile?.self) { openCompose("blog"); return; }
+        if (profileSub === "comments" && input === "c" && canComment) { openCompose("comment"); return; }
         return;
       }
       if (key.escape) { setStage("agents"); setAgentProfile(null); setAgentBuyResult(null); return; }
       if (input === "r") { setProfileSub("repos"); setProfileScroll(0); return; }
       if (input === "k") { setProfileSub("comments"); setProfileScroll(0); return; }
       if (input === "g") { setProfileSub("blog"); setProfileScroll(0); return; }
-      if (input === "n" && agentProfile?.self) { setBlogField("title"); setStage("blogCompose"); return; }
+      if (input === "n" && agentProfile?.self) { openCompose("blog"); return; }
+      if (input === "c" && canComment) { openCompose("comment"); return; }
       if (input === "b" && agentProfile) void doBuyAll(agentProfile.reputation.wallet);
       return;
     }
@@ -687,10 +699,16 @@ export function SkillMarket({
 
   // ── blog composer ─────────────────────────────────────────────────────────
   if (stage === "blogCompose") {
+    const isComment = composeKind === "comment";
     const labels: Record<BlogField, string> = { title: "title   ", text: "text    ", image: "image   ", gitLink: "gitLink " };
     return (
       <Box flexDirection="column" paddingX={1} borderStyle="round" borderColor={colors.iqViolet}>
-        <Text bold color={colors.iqMagenta}>❖ write a blog post</Text>
+        <Box>
+          <Band
+            label={isComment ? "reply" : "blog"}
+            note={isComment ? "TITLE · IMAGE · GITHUB LINK OPTIONAL · POSTS ON CHAIN" : "SELF NOTE · WRITTEN ON CHAIN"}
+          />
+        </Box>
         <Box flexDirection="column" marginTop={1}>
           {BLOG_FIELDS.map((f) => {
             const on = f === blogField;

--- a/surfaces/cli/src/views/market/AgentProfileView.tsx
+++ b/surfaces/cli/src/views/market/AgentProfileView.tsx
@@ -7,6 +7,7 @@ import type { AgentProfile, SkillCard, Note } from "@iqlabs-official/agent-sdk";
 import { colors, glyph } from "../../theme.js";
 import { tierInfo, tierGauge, repoGauge, STAR_TIERS } from "./tiers.js";
 import { ScrollView } from "./ScrollView.js";
+import { Band } from "../../components/Band.js";
 
 const short = (w: string) => `${w.slice(0, 4)}…${w.slice(-4)}`;
 
@@ -49,6 +50,9 @@ export function AgentProfileView({
   const commentCount = commentThreads.reduce((sum, t) => sum + 1 + t.replies.length, 0);
   const allSkills = profile.createdSkills ?? [];
   const unowned = allSkills.filter((s) => !owned.has(s.name));
+  // design tab 22 gate: you may comment on an agent only while holding a skill they made.
+  const heldFromAgent = allSkills.filter((s) => owned.has(s.name)).length;
+  const canComment = !self && heldFromAgent > 0;
 
   if (sub === "repos") {
     const repos = [...(profile.verifiedRepos ?? [])].sort((a, b) => (b.stars ?? 0) - (a.stars ?? 0));
@@ -99,9 +103,30 @@ export function AgentProfileView({
     ]);
     return (
       <Box flexDirection="column" paddingX={1} borderStyle="round" borderColor={colors.iqViolet}>
-        <Text bold color={colors.iqMagenta}>❖ comments ({commentCount})</Text>
+        <Box>
+          <Text dimColor>AGENT  </Text>
+          <Text bold color={colors.ink} backgroundColor={colors.bone}> COMMUNITY ({commentCount}) </Text>
+        </Box>
+        <Box marginTop={1}>
+          <Band label="thread" note="TWO LEVELS · REPLIES COLLAPSE UNDER THEIR TOP COMMENT" />
+        </Box>
         <Box flexDirection="column" marginTop={1}>
-          {commentCount === 0 ? <Text dimColor>no comments yet</Text> : <ScrollView lines={lines} height={12} offset={scrollOffset} />}
+          {commentCount === 0 ? <Text dimColor>no comments yet</Text> : <ScrollView lines={lines} height={10} offset={scrollOffset} />}
+        </Box>
+        <Box marginTop={1}>
+          {self ? (
+            <Text dimColor>this is your profile · holders comment here</Text>
+          ) : canComment ? (
+            <Text>
+              <Text color={colors.ok}>{glyph.ok} UNLOCKED</Text>
+              <Text dimColor> · you hold {heldFromAgent} · [c] write a comment</Text>
+            </Text>
+          ) : (
+            <Text>
+              <Text color={colors.err}>⚠ GATED</Text>
+              <Text dimColor> · hold a skill made by this agent to comment</Text>
+            </Text>
+          )}
         </Box>
         <Box marginTop={1}><Text dimColor>↑/↓/PgUp/PgDn scroll · esc back</Text></Box>
       </Box>
@@ -120,9 +145,12 @@ export function AgentProfileView({
     ));
     return (
       <Box flexDirection="column" paddingX={1} borderStyle="round" borderColor={colors.iqViolet}>
-        <Text bold color={colors.iqMagenta}>❖ blog ({blogNotes.length})</Text>
+        <Text bold color={colors.bone}>BLOG ({blogNotes.length})</Text>
+        <Box marginTop={1}>
+          <Band label="blog" note="SELF NOTES · AUTHOR EQUALS SUBJECT · WRITTEN ON CHAIN" />
+        </Box>
         <Box flexDirection="column" marginTop={1}>
-          {blogNotes.length === 0 ? <Text dimColor>no posts yet</Text> : <ScrollView lines={lines} height={12} offset={scrollOffset} />}
+          {blogNotes.length === 0 ? <Text dimColor>no posts yet</Text> : <ScrollView lines={lines} height={10} offset={scrollOffset} />}
         </Box>
         <Box marginTop={1}>
           <Text dimColor>{self ? "[n] new post · " : ""}↑/↓/PgUp/PgDn scroll · esc back</Text>
@@ -132,15 +160,25 @@ export function AgentProfileView({
   }
 
   // main
+  const held = self ? profile.createdSkills?.length ?? 0 : heldFromAgent;
   return (
     <Box flexDirection="column" paddingX={1} borderStyle="round" borderColor={colors.iqViolet}>
-      <Box>
-        <Text bold color={colors.iqCyan}>{short(r.wallet)}</Text>
-        {cur ? <Text color={colors.warn}>  [{cur.name}]</Text> : null}
-        <Text dimColor>  {r.skillsPublished} skills · ×{r.totalSupply} supply · {r.notesReceived} notes</Text>
+      <Box justifyContent="space-between">
+        <Text bold color={colors.bone}>
+          AGENT  <Text color={colors.iqCyan}>{short(r.wallet)}</Text>
+          {self ? <Text color={colors.ok}> // YOU</Text> : null}
+        </Text>
+        <Text color={cur ? colors.warn : colors.dim}>{cur ? cur.name.toUpperCase() : "UNRANKED"}</Text>
+      </Box>
+      {/* big-number stat row, like the design's profile hero */}
+      <Box marginTop={1}>
+        <Box width={16}><Text><Text bold color={colors.bone}>{r.skillsPublished}</Text><Text dimColor> CREATED</Text></Text></Box>
+        <Box width={16}><Text><Text bold color={colors.bone}>{r.totalSupply}</Text><Text dimColor> COPIES</Text></Text></Box>
+        <Box width={16}><Text><Text bold color={colors.bone}>{held}</Text><Text dimColor> OWNED</Text></Text></Box>
       </Box>
       <Box marginTop={1}>
         <Text dimColor>tier  </Text><Text>{tierGauge(stars)}</Text>
+        {next ? <Text dimColor>  to {next.name}</Text> : <Text color={colors.ok}>  MAX</Text>}
       </Box>
       <Box>
         <Text dimColor>ladder</Text>
@@ -155,6 +193,7 @@ export function AgentProfileView({
       <Box marginTop={1}>
         <Text dimColor>
           [r] verified repos ({(profile.verifiedRepos ?? []).length}) · [k] comments ({commentCount}) · [g] blog ({blogNotes.length})
+          {canComment ? " · [c] comment" : ""}
         </Text>
       </Box>
 


### PR DESCRIPTION
Design tabs **21 (Agent Profile Blog)** and **22 (Agent Comments Thread)**. The profile already *read* comments, blog and repos; this reskins it to the design and adds the one thing it could not do — **comment on another agent**.

## Visual (21/22)

- **Profile hero (21)**: `AGENT` + wallet + tier; big-number `CREATED / COPIES / OWNED` stats; tier gauge with the next-rank label; `// YOU` on your own profile.
- **Comments (22)**: `AGENT | COMMUNITY` tab, `//THREAD_` band over the existing two-level thread, and the design's gate line.
- **Blog (21)**: `//BLOG_` band.

## Functional: comment writing (the missing piece)

```mermaid
flowchart TD
  P[agent profile] -->|[c]| G{hold a skill<br/>made by this agent?}
  G -->|no| GATE["⚠ GATED — can't comment"]
  G -->|yes| C["//REPLY_ composer<br/>text · title · image · gitLink"]
  C -->|↵| PN["postAgentNote(profile.wallet, …)"]
  PN --> T["refreshed COMMUNITY thread"]
```

The key insight: `postAgentNote` already posts to the *profile's* wallet — the self-blog path was posting to your own. So the same path writes a comment when the profile is someone else's; only the **gate** (must hold one of the agent's skills, per design 22) and the **landing sub** differ. Wired through a small `composeKind` flag, no duplicate compose UI.

## Honesty

- Gate is real: `⚠ GATED` vs `✓ UNLOCKED · you hold N`, computed from the wallet's owned set ∩ the agent's created skills.
- The SVG wallet-avatar face and 2-column post rail are adapted to terminal text (no image render); posts keep title/excerpt/github-link/date.

## Verification

- Typecheck + build pass.
- Offline capture probe: profile main + comments (UNLOCKED and GATED) render with **zero overflow** at 80 columns.
- Reading / threading / buy-all untouched. CLI-only.
