### PR TITLE
Core/API glue the CLI design-parity pass needs (parentId, buy error code, airdrop, GitHub trio)

### DIFF
--- a/packages/core/src/chat/marketMessages.ts
+++ b/packages/core/src/chat/marketMessages.ts
@@ -150,7 +150,7 @@ export type MarketEvent =
   | { type: "balance"; lamports: number | null } // wallet SOL balance (null = read failed)
   | { type: "airdropResult"; ok: boolean; lamports?: number; error?: string } // devnet faucet result (lamports = the new balance)
   // GitHub verified-work registration results (issue #93 parity)
-  | { type: "githubStatus"; hasToken: boolean; masked?: string }
+  | { type: "githubStatus"; hasToken: boolean; masked?: string; error?: string } // error = token save failed
   | { type: "workRepoRegistered"; ok: boolean; count?: number; repo?: string; error?: string }
   | { type: "skillActive"; name: string; origin: "nft"; mint: string } // nft skill fired -> casting cue
   | { type: "rpcStatus"; status: RpcStatus } // DAS-ready? which source? (issue #23)

--- a/packages/core/src/chat/session.ts
+++ b/packages/core/src/chat/session.ts
@@ -92,7 +92,7 @@ export interface ChatEnv {
   // owner/name repo against the given skill mints. All three defer to core (rpc.ts token
   // store + verifiedWork.ts). A surface that can't do this simply omits them.
   getGithubStatus?(): Promise<{ hasToken: boolean; masked?: string }>;
-  submitGithubToken?(token: string): Promise<{ hasToken: boolean; masked?: string }>;
+  submitGithubToken?(token: string): Promise<{ hasToken: boolean; masked?: string; error?: string }>; // error = save failed (answered, never thrown)
   registerWorkRepo?(repo: string, skillMints: string[]): Promise<{ ok: boolean; count?: number; repo?: string; error?: string }>;
   // make-skill: publish a new skill from the UI. priceSol is the human SOL string; the
   // host converts to lamports and calls core publishSkill. Returns the new mint on success.

--- a/packages/core/src/chat/ui/webview.ts
+++ b/packages/core/src/chat/ui/webview.ts
@@ -4215,6 +4215,9 @@ export function chatHtml(): string {
       link.href = 'https://github.com/settings/tokens/new?scopes=repo&description=AgentNet';
       link.target = '_blank'; link.rel = 'noopener noreferrer'; link.textContent = 'Create a token ↗';
       const err = document.createElement('div'); err.className = 'rr-err';
+      // a failed save answers githubStatus { hasToken:false, error } — show it here so the
+      // re-rendered form explains the failure instead of looking like a silent reset.
+      if (status && status.error) { err.textContent = status.error; err.style.display = ''; }
       const btn = document.createElement('button'); btn.className = 'rr-btn'; btn.textContent = 'Save token';
       btn.addEventListener('click', () => {
         const t = inp.value.trim(); if (!t) return;

--- a/packages/core/src/skill-market/ingest/env.spec.ts
+++ b/packages/core/src/skill-market/ingest/env.spec.ts
@@ -3,6 +3,7 @@ import { marketplaceEnv } from "./env.js";
 import { publishSkill as corePublishSkill } from "../../nft/skill.js";
 import { publishWorkflow as corePublishWorkflow } from "../../nft/workflow.js";
 import { postAgentNote as corePostAgentNote } from "../../notes/notes.js";
+import { getNetwork } from "../../core/seed.js";
 
 vi.mock("../../nft/skill.js", () => ({
   publishSkill: vi.fn().mockResolvedValue("mockSkillMint"),
@@ -30,6 +31,13 @@ vi.mock("./index.js", () => ({
 vi.mock("../../core/rpc.js", () => ({
   resolveRpcUrl: vi.fn().mockResolvedValue("http://localhost:8899"),
 }));
+
+// Partial mock: getNetwork becomes controllable (the airdrop guard needs a non-devnet
+// answer) while keeping its real devnet default and the rest of the seed module real.
+vi.mock("../../core/seed.js", async (importOriginal) => {
+  const actual = await importOriginal<typeof import("../../core/seed.js")>();
+  return { ...actual, getNetwork: vi.fn(() => "devnet" as const) };
+});
 
 // Partial mock: only the agent-note write + re-read are stubbed; the rest of the
 // notes module stays real so nothing else in env's import graph changes shape.
@@ -156,6 +164,22 @@ describe("skill-market/ingest/env buySkill", () => {
     const res = await env.buySkill("mintX");
 
     expect(res).toEqual({ ok: false, error: "custom program error: 0x1771", code: undefined });
+  });
+});
+
+describe("skill-market/ingest/env airdrop", () => {
+  const mockWallet = { address: "mockWalletAddress" } as any;
+
+  // Mainnet has no faucet, so the guard must answer with an actionable error
+  // before any RPC is attempted (plan tab 26: wire airdrop, devnet only).
+  it("refuses off devnet without touching the connection", async () => {
+    vi.mocked(getNetwork).mockReturnValueOnce("mainnet");
+
+    const env = await marketplaceEnv(mockWallet);
+    const res = await env.airdrop();
+
+    expect(res.ok).toBe(false);
+    expect(res.error).toMatch(/devnet only/);
   });
 });
 

--- a/packages/core/src/skill-market/ingest/env.spec.ts
+++ b/packages/core/src/skill-market/ingest/env.spec.ts
@@ -18,6 +18,15 @@ vi.mock("../../core/chain.js", () => ({
   signerAddress: vi.fn().mockResolvedValue("mockAddress"),
 }));
 
+// The buy path goes through SkillSync.buyAndEquip (buy on-chain + equip locally);
+// stub the class so a test can make the buy fail like a broke wallet does.
+const { buyAndEquip } = vi.hoisted(() => ({ buyAndEquip: vi.fn() }));
+vi.mock("./index.js", () => ({
+  SkillSync: class {
+    buyAndEquip = buyAndEquip;
+  },
+}));
+
 vi.mock("../../core/rpc.js", () => ({
   resolveRpcUrl: vi.fn().mockResolvedValue("http://localhost:8899"),
 }));
@@ -121,6 +130,32 @@ Some skill body`;
       image: undefined,
     }, undefined);
     expect(corePublishWorkflow).not.toHaveBeenCalled();
+  });
+});
+
+describe("skill-market/ingest/env buySkill", () => {
+  const mockWallet = { address: "buyerWallet" } as any;
+
+  // The machine-readable code is what lets a surface open a fund prompt instead of
+  // only toasting the raw chain error (plan tab 26: FUNDING panel on insufficient_funds).
+  it("tags a broke-wallet failure with code insufficient_funds", async () => {
+    buyAndEquip.mockRejectedValueOnce(new Error("Attempt to debit an account but found no record of a prior credit. Logs: []"));
+
+    const env = await marketplaceEnv(mockWallet);
+    const res = await env.buySkill("mintX");
+
+    expect(res.ok).toBe(false);
+    expect(res.code).toBe("insufficient_funds");
+    expect(res.error).toMatch(/Not enough SOL/);
+  });
+
+  it("passes other buy errors through verbatim, uncoded", async () => {
+    buyAndEquip.mockRejectedValueOnce(new Error("custom program error: 0x1771"));
+
+    const env = await marketplaceEnv(mockWallet);
+    const res = await env.buySkill("mintX");
+
+    expect(res).toEqual({ ok: false, error: "custom program error: 0x1771", code: undefined });
   });
 });
 

--- a/packages/core/src/skill-market/ingest/env.spec.ts
+++ b/packages/core/src/skill-market/ingest/env.spec.ts
@@ -4,6 +4,8 @@ import { publishSkill as corePublishSkill } from "../../nft/skill.js";
 import { publishWorkflow as corePublishWorkflow } from "../../nft/workflow.js";
 import { postAgentNote as corePostAgentNote } from "../../notes/notes.js";
 import { getNetwork } from "../../core/seed.js";
+import { saveGithubToken, loadGithubToken, maskedGithubToken } from "../../core/rpc.js";
+import { registerVerifiedWork } from "../../core/verifiedWork.js";
 
 vi.mock("../../nft/skill.js", () => ({
   publishSkill: vi.fn().mockResolvedValue("mockSkillMint"),
@@ -30,6 +32,13 @@ vi.mock("./index.js", () => ({
 
 vi.mock("../../core/rpc.js", () => ({
   resolveRpcUrl: vi.fn().mockResolvedValue("http://localhost:8899"),
+  saveGithubToken: vi.fn(),
+  loadGithubToken: vi.fn().mockResolvedValue(null),
+  maskedGithubToken: vi.fn().mockResolvedValue(null),
+}));
+
+vi.mock("../../core/verifiedWork.js", () => ({
+  registerVerifiedWork: vi.fn(),
 }));
 
 // Partial mock: getNetwork becomes controllable (the airdrop guard needs a non-devnet
@@ -164,6 +173,88 @@ describe("skill-market/ingest/env buySkill", () => {
     const res = await env.buySkill("mintX");
 
     expect(res).toEqual({ ok: false, error: "custom program error: 0x1771", code: undefined });
+  });
+});
+
+describe("skill-market/ingest/env github", () => {
+  const mockWallet = { address: "mockWalletAddress" } as any;
+
+  it("reports no token as hasToken false", async () => {
+    vi.mocked(maskedGithubToken).mockResolvedValue(null);
+
+    const env = await marketplaceEnv(mockWallet);
+    expect(await env.getGithubStatus()).toEqual({ hasToken: false, masked: undefined });
+  });
+
+  it("stores the token and answers with the refreshed mask", async () => {
+    vi.mocked(maskedGithubToken).mockResolvedValue("••••AB12");
+
+    const env = await marketplaceEnv(mockWallet);
+    const res = await env.submitGithubToken("ghp_secret");
+
+    expect(saveGithubToken).toHaveBeenCalledWith("ghp_secret");
+    expect(res).toEqual({ hasToken: true, masked: "••••AB12" });
+  });
+
+  // The dispatcher spreads this result straight into a githubStatus reply with no
+  // catch of its own — a rejection here would be an unhandled rejection in the host
+  // and a modal that hangs on "Saving…" forever.
+  it("answers a failed token save as an error instead of rejecting", async () => {
+    vi.mocked(saveGithubToken).mockRejectedValueOnce(new Error("EACCES: permission denied"));
+
+    const env = await marketplaceEnv(mockWallet);
+    const res = await env.submitGithubToken("ghp_secret");
+
+    expect(res).toEqual({ hasToken: false, masked: undefined, error: "EACCES: permission denied" });
+  });
+
+  // Both surface copies of this flow refuse without a connected wallet;
+  // registerVerifiedWork needs no signature, so the env member must refuse too or a
+  // wallet-less env would commit its placeholder address as the public marker.
+  it("refuses to register work without a connected wallet", async () => {
+    vi.mocked(loadGithubToken).mockResolvedValue({ token: "ghp_secret" });
+
+    const env = await marketplaceEnv({ address: "" } as any);
+    const res = await env.registerWorkRepo("owner/repo", ["mint1"]);
+
+    expect(res).toEqual({ ok: false, error: "Connect a wallet first." });
+    expect(registerVerifiedWork).not.toHaveBeenCalled();
+  });
+
+  it("refuses to register work without a stored token", async () => {
+    vi.mocked(loadGithubToken).mockResolvedValue(null);
+
+    const env = await marketplaceEnv(mockWallet);
+    const res = await env.registerWorkRepo("owner/repo", ["mint1"]);
+
+    expect(res).toEqual({ ok: false, error: "Add a GitHub token first." });
+    expect(registerVerifiedWork).not.toHaveBeenCalled();
+  });
+
+  it("registers the repo with the connected wallet's address", async () => {
+    vi.mocked(loadGithubToken).mockResolvedValue({ token: "ghp_secret" });
+    vi.mocked(registerVerifiedWork).mockResolvedValue({ count: 2, repo: "owner/repo", markerAdded: true });
+
+    const env = await marketplaceEnv(mockWallet);
+    const res = await env.registerWorkRepo("owner/repo", ["mint1", "mint2"]);
+
+    expect(registerVerifiedWork).toHaveBeenCalledWith({
+      token: "ghp_secret",
+      repo: "owner/repo",
+      skillMints: ["mint1", "mint2"],
+      walletAddress: "mockWalletAddress",
+    });
+    expect(res).toEqual({ ok: true, count: 2, repo: "owner/repo" });
+  });
+
+  it("surfaces a registration failure as its message", async () => {
+    vi.mocked(loadGithubToken).mockResolvedValue({ token: "ghp_secret" });
+    vi.mocked(registerVerifiedWork).mockRejectedValue(new Error("Enter a repo as owner/name or a github.com URL."));
+
+    const env = await marketplaceEnv(mockWallet);
+    const res = await env.registerWorkRepo("not a repo", ["mint1"]);
+
+    expect(res).toEqual({ ok: false, error: "Enter a repo as owner/name or a github.com URL." });
   });
 });
 

--- a/packages/core/src/skill-market/ingest/env.spec.ts
+++ b/packages/core/src/skill-market/ingest/env.spec.ts
@@ -2,6 +2,7 @@ import { describe, it, expect, vi, beforeEach } from "vitest";
 import { marketplaceEnv } from "./env.js";
 import { publishSkill as corePublishSkill } from "../../nft/skill.js";
 import { publishWorkflow as corePublishWorkflow } from "../../nft/workflow.js";
+import { postAgentNote as corePostAgentNote } from "../../notes/notes.js";
 
 vi.mock("../../nft/skill.js", () => ({
   publishSkill: vi.fn().mockResolvedValue("mockSkillMint"),
@@ -20,6 +21,17 @@ vi.mock("../../core/chain.js", () => ({
 vi.mock("../../core/rpc.js", () => ({
   resolveRpcUrl: vi.fn().mockResolvedValue("http://localhost:8899"),
 }));
+
+// Partial mock: only the agent-note write + re-read are stubbed; the rest of the
+// notes module stays real so nothing else in env's import graph changes shape.
+vi.mock("../../notes/notes.js", async (importOriginal) => {
+  const actual = await importOriginal<typeof import("../../notes/notes.js")>();
+  return {
+    ...actual,
+    postAgentNote: vi.fn().mockResolvedValue("note-id"),
+    readAgentNotes: vi.fn().mockResolvedValue([]),
+  };
+});
 
 describe("skill-market/ingest/env publish", () => {
   const mockWallet = { address: "mockWalletAddress" } as any;
@@ -109,5 +121,34 @@ Some skill body`;
       image: undefined,
     }, undefined);
     expect(corePublishWorkflow).not.toHaveBeenCalled();
+  });
+});
+
+describe("skill-market/ingest/env postAgentNote", () => {
+  const mockWallet = { address: "mockWalletAddress" } as any;
+
+  // parentId is what threads a reply under its parent note (GH #101); the CLI's
+  // MarketApi passes it as the 6th arg, so it must reach the core write intact.
+  it("forwards parentId to the core write", async () => {
+    const env = await marketplaceEnv(mockWallet);
+    const res = await env.postAgentNote("agentW", "nice work", undefined, undefined, undefined, "note-1");
+
+    expect(res.ok).toBe(true);
+    expect(corePostAgentNote).toHaveBeenCalledWith(
+      expect.anything(),
+      mockWallet,
+      expect.objectContaining({ agentWallet: "agentW", text: "nice work", parentId: "note-1" }),
+    );
+  });
+
+  it("leaves parentId undefined on a top-level post", async () => {
+    const env = await marketplaceEnv(mockWallet);
+    await env.postAgentNote("agentW", "hello");
+
+    expect(corePostAgentNote).toHaveBeenCalledWith(
+      expect.anything(),
+      mockWallet,
+      expect.objectContaining({ agentWallet: "agentW", text: "hello", parentId: undefined }),
+    );
   });
 });

--- a/packages/core/src/skill-market/ingest/env.ts
+++ b/packages/core/src/skill-market/ingest/env.ts
@@ -22,7 +22,8 @@ import { heldSkillCreators } from "../../notes/holdings.js";
 import { claudeSkillsDir } from "../../core/paths.js";
 import { classifySkills, readSkillManifest } from "../registry.js";
 import { readDisposed } from "../equipState.js";
-import { resolveRpcUrl } from "../../core/rpc.js";
+import { resolveRpcUrl, saveGithubToken, loadGithubToken, maskedGithubToken } from "../../core/rpc.js";
+import { registerVerifiedWork } from "../../core/verifiedWork.js";
 import { init as initChain } from "../../core/chain.js";
 import type { AgentProfile, Reputation, SkillCard, SkillDetail, VerifiedRepo } from "../../chat/marketMessages.js";
 import type { Skill } from "../../core/types.js";
@@ -642,6 +643,52 @@ export async function marketplaceEnv(wallet: Wallet) {
         return { ok: true as const, notes };
       } catch (e) {
         return { ok: false as const, error: e instanceof Error ? e.message : String(e) };
+      }
+    },
+
+    // ── GitHub verified-work registration (issue #93) ──
+    // The submitGithubToken/getGithubStatus/registerWorkRepo message types already
+    // exist; these are the env members that answer them, so surfaces can take the
+    // flow from marketplaceEnv instead of re-wiring the core calls themselves
+    // (plans/cli-design-parity.md "Core/API glue needed"; vscode delegates here,
+    // localhost keeps its pre-wallet handlers + clearGithubToken on purpose). The
+    // token is stored by core (rpc.ts, 0600 file, never synced) — only the masked
+    // tail leaves here.
+    async getGithubStatus() {
+      const masked = await maskedGithubToken();
+      return { hasToken: !!masked, masked: masked ?? undefined };
+    },
+
+    // Store the token, answer with the refreshed masked status — the same shape
+    // getGithubStatus returns, so the UI has one render path for both. A failed
+    // save (unwritable tokens dir, full disk) answers as an error instead of
+    // rejecting: the dispatcher spreads this straight into githubStatus, so a
+    // rejection would hang the modal with no reply.
+    async submitGithubToken(token: string) {
+      try {
+        await saveGithubToken(token);
+        const masked = await maskedGithubToken();
+        return { hasToken: !!masked, masked: masked ?? undefined };
+      } catch (e) {
+        return { hasToken: false, masked: undefined, error: e instanceof Error ? e.message : "Saving the token failed." };
+      }
+    },
+
+    // Commit the wallet's PUBLIC-address marker to owner/name, then register the
+    // repo against the given skill mints with the indexer (verifiedWork.ts).
+    async registerWorkRepo(repo: string, skillMints: string[]) {
+      // Same refusal both surface copies give (vscode/localhost). registerVerifiedWork
+      // needs no signature — just the address string — so without this guard an env
+      // built before a wallet is connected would commit whatever address it holds as
+      // the public .agentnet marker and index it as the user's identity.
+      if (!wallet?.address) return { ok: false as const, error: "Connect a wallet first." };
+      try {
+        const stored = await loadGithubToken();
+        if (!stored?.token) return { ok: false as const, error: "Add a GitHub token first." };
+        const res = await registerVerifiedWork({ token: stored.token, repo, skillMints, walletAddress: wallet.address });
+        return { ok: true as const, count: res.count, repo: res.repo };
+      } catch (e) {
+        return { ok: false as const, error: e instanceof Error ? e.message : "Registration failed." };
       }
     },
   };

--- a/surfaces/cli/src/views/SkillMarket.tsx
+++ b/surfaces/cli/src/views/SkillMarket.tsx
@@ -39,6 +39,28 @@ export interface MarketApi {
   ownedSkillMints?(): Promise<Record<string, string>>;
 }
 
+// ── Compile-time parity pins (plans/cli-design-parity.md "Core/API glue needed") ──
+// The api object handed to <SkillMarketView> is marketplaceEnv itself (Chat.tsx), and
+// that assignment checks env → MarketApi. It does NOT check the reverse: dropping an
+// optional param, result field, or member from MarketApi still leaves env assignable,
+// so a revert of the parity widenings would only surface once a consumer (tab 22/26 UI)
+// calls them. These type-level pins make such a revert fail the typecheck here instead.
+// Zero runtime cost — erased on compile.
+type AssertTrue<_T extends true> = never;
+// postAgentNote carries parentId (GH #101 reply threading): a 6th parameter must exist
+// (tuple index [5] is a compile error on a 5-arg signature) and accept a string id.
+type _PinPostAgentNoteParentId = AssertTrue<
+  Parameters<MarketApi["postAgentNote"]>[5] extends string | undefined ? true : false
+>;
+// buySkill surfaces the insufficient_funds classification the FUNDING panel keys off.
+type _PinBuySkillCode = AssertTrue<
+  Awaited<ReturnType<MarketApi["buySkill"]>>["code"] extends "insufficient_funds" | undefined ? true : false
+>;
+// airdrop (devnet faucet) is declared, with the lamports/error result the panel renders.
+type _PinAirdrop = AssertTrue<
+  MarketApi["airdrop"] extends () => Promise<{ ok: boolean; lamports?: number; error?: string }> ? true : false
+>;
+
 type Stage =
   | "list"
   | "detail"

--- a/surfaces/cli/src/views/SkillMarket.tsx
+++ b/surfaces/cli/src/views/SkillMarket.tsx
@@ -19,6 +19,8 @@ export interface MarketApi {
   // (the FUNDING panel / Get devnet SOL) instead of a dead-end error string.
   buySkill(skillId: string, creatorWallet?: string): Promise<{ ok: boolean; slug?: string; error?: string; code?: "insufficient_funds" }>;
   solBalance(): Promise<number | null>;
+  // devnet only: one faucet grant to the connected wallet; lamports = the new balance.
+  airdrop(): Promise<{ ok: boolean; lamports?: number; error?: string }>;
   postNote(skillId: string, skillType: "skill" | "workflow" | undefined, text: string, gitLink?: string): Promise<{ ok: boolean; error?: string }>;
   publishSkill(
     input: { name: string; description: string; text: string; category?: string; hashtags?: string[]; priceSol: string; image?: string },

--- a/surfaces/cli/src/views/SkillMarket.tsx
+++ b/surfaces/cli/src/views/SkillMarket.tsx
@@ -15,7 +15,9 @@ import { PublishProgressView, type PublishProgress } from "./market/PublishProgr
 export interface MarketApi {
   searchSkills(query: string, kind?: "skill" | "workflow", sort?: "supply" | "stars"): Promise<SkillCard[]>;
   getSkillDetail(mint: string): Promise<SkillDetail>;
-  buySkill(skillId: string, creatorWallet?: string): Promise<{ ok: boolean; slug?: string; error?: string }>;
+  // code "insufficient_funds" marks a broke-wallet failure so the UI can offer funding
+  // (the FUNDING panel / Get devnet SOL) instead of a dead-end error string.
+  buySkill(skillId: string, creatorWallet?: string): Promise<{ ok: boolean; slug?: string; error?: string; code?: "insufficient_funds" }>;
   solBalance(): Promise<number | null>;
   postNote(skillId: string, skillType: "skill" | "workflow" | undefined, text: string, gitLink?: string): Promise<{ ok: boolean; error?: string }>;
   publishSkill(

--- a/surfaces/cli/src/views/SkillMarket.tsx
+++ b/surfaces/cli/src/views/SkillMarket.tsx
@@ -25,7 +25,8 @@ export interface MarketApi {
   listAgents(): Promise<Reputation[]>;
   getAgentProfile(wallet: string): Promise<AgentProfile>;
   buyAllSkills(agentWallet: string): Promise<{ ok: boolean; bought: number; failed: number; error?: string }>;
-  postAgentNote(agentWallet: string, text: string, gitLink?: string, title?: string, image?: string): Promise<{ ok: boolean; error?: string }>;
+  // parentId (GH #101): id of the note this replies to; omit for a top-level post.
+  postAgentNote(agentWallet: string, text: string, gitLink?: string, title?: string, image?: string, parentId?: string): Promise<{ ok: boolean; error?: string }>;
   disposeSkill(skillId: string): Promise<{ ok: boolean; slug?: string; error?: string }>;
   reEquipSkill(skillId: string): Promise<{ ok: boolean; slug?: string; error?: string }>;
   disposedSkillMints?(): Promise<Record<string, string>>;

--- a/surfaces/vscode/src/extension.ts
+++ b/surfaces/vscode/src/extension.ts
@@ -35,10 +35,6 @@ import {
   hasDasRpc,
   maskedHeliusKey,
   getNetwork,
-  saveGithubToken,
-  loadGithubToken,
-  maskedGithubToken,
-  registerVerifiedWork,
   TransportApprovalChannel,
   withTimeout,
   chatHtml,
@@ -609,29 +605,13 @@ async function openChat(context: vscode.ExtensionContext, column = vscode.ViewCo
       return { dasReady: await hasDasRpc(), hasKey: !!masked, masked, network: getNetwork() };
     },
     walletAddress: () => wallet?.address ?? null,
-    // GitHub verified-work registration (issue #93 parity). Token is stored locally by core
-    // (rpc.ts, 0600 file — never through the webview); registerVerifiedWork commits the marker
-    // + indexes the repo against the skill mints. Mirrors the localhost surface's handler.
-    getGithubStatus: async () => {
-      const masked = await maskedGithubToken();
-      return { hasToken: !!masked, masked: masked ?? undefined };
-    },
-    submitGithubToken: async (token: string) => {
-      await saveGithubToken(token);
-      const masked = await maskedGithubToken();
-      return { hasToken: !!masked, masked: masked ?? undefined };
-    },
-    registerWorkRepo: async (repo: string, skillMints: string[]) => {
-      try {
-        const stored = await loadGithubToken();
-        if (!stored?.token) return { ok: false, error: "Add a GitHub token first." };
-        if (!wallet?.address) return { ok: false, error: "Connect a wallet first." };
-        const res = await registerVerifiedWork({ token: stored.token, repo, skillMints, walletAddress: wallet.address });
-        return { ok: true, count: res.count, repo: res.repo };
-      } catch (e) {
-        return { ok: false, error: e instanceof Error ? e.message : "Registration failed." };
-      }
-    },
+    // GitHub verified-work registration (issue #93 parity): delegate to marketplaceEnv's
+    // trio like the neighboring market fields, so the token store + marker + indexer flow
+    // has one implementation in core instead of a per-surface copy. openChat only runs
+    // with a connected wallet (same assumption every other market field makes).
+    getGithubStatus: async () => (await marketPromise).getGithubStatus(),
+    submitGithubToken: async (token: string) => (await marketPromise).submitGithubToken(token),
+    registerWorkRepo: async (repo: string, skillMints: string[]) => (await marketPromise).registerWorkRepo(repo, skillMints),
     storageInfo: async () => ({ info: await getStorageInfo(), options: STORAGE_OPTIONS }),
     // passive skill-shopping toggle (issue #21): persisted in config.json by the SDK.
     getSkillShopping: () => getSkillShopping(),

--- a/surfaces/vscode/src/extension.ts
+++ b/surfaces/vscode/src/extension.ts
@@ -586,6 +586,9 @@ async function openChat(context: vscode.ExtensionContext, column = vscode.ViewCo
     buyAllSkills: async (w) => (await marketPromise).buyAllSkills(w),
     postAgentNote: async (w, t, l, ti, im, p) => (await marketPromise).postAgentNote(w, t, l, ti, im, p),
     solBalance: async () => (await marketPromise).solBalance(),
+    // devnet faucet behind the webview's Get-devnet-SOL button; without this the airdrop
+    // request hit the dispatcher's missing-capability guard and silently did nothing.
+    airdrop: async () => (await marketPromise).airdrop(),
     publishSkill: async (input, onProgress) => (await marketPromise).publishSkill(input, onProgress),
     loadOwnedSkills: async () => (await marketPromise).loadOwnedSkills(),
     // RPC config (issue #23): capture the Helius key via a native secret input — it


### PR DESCRIPTION
# The CLI parity plan's four core/API glue items, shipped separately so the design pass stays purely visual

`plans/cli-design-parity.md` lists four items under **"### Core/API glue needed (not just UI)"** (lines 111–117), each blocking a UI tab of the parity redesign. This branch ships exactly those four — one commit each, in the plan's order — plus a fifth commit that pins them at compile time, so the UI pass never dead-ends on a missing core surface. Built to unblock the parity pass — happy to reshape any of it to whatever the UI work wants. No UI, rendering, or layout is touched: the entire CLI diff is interface-declaration lines and type-level pins in `SkillMarket.tsx`.

- **Line 113** — *"`MarketApi.postAgentNote` drop of `parentId` -> add it (core supports)"* [tab 22, reply composer]: `parentId` added as the optional 6th parameter. Core already carries it end-to-end (GH #101 reply threading — `marketplaceEnv` → notes layer); the CLI type was the drop point, so the tab-22 composer could never have passed it.
- **Line 114** — *"`MarketApi.buySkill` drops `code` -> add, detect `insufficient_funds`"* [tabs 26/08/24]: the result type gains `code?: "insufficient_funds"`. The `{code}` field is how the classification already travels through `marketplaceEnv`/`buyResult`; the CLI type dropped it, so a FUNDING panel had nothing to key off.
- **Line 115** — *"Wire `marketplaceEnv.airdrop()` (devnet)"* [tab 26]: `airdrop()` declared as a **required** `MarketApi` member (the CLI's api object *is* `marketplaceEnv`, so the requirement is free), and the missing delegation added in `surfaces/vscode/src/extension.ts` — which un-breaks the webview FundModal's airdrop request that previously hit the dispatcher's missing-capability guard and silently did nothing. The devnet-only guard lives in core.
- **Lines 116–117** — *"GitHub `submitGithubToken`/`getGithubStatus`/`registerWorkRepo`: message types exist but `marketplaceEnv` exposes none -> needs CORE additions"* [tabs 24/26]: the trio becomes `marketplaceEnv` members (`packages/core/src/skill-market/ingest/env.ts`), deferring to the `rpc.ts` token store (0600 file, only the masked tail leaves) and `verifiedWork.ts`. Two contracts hardened while consolidating: `registerWorkRepo` keeps the *"Connect a wallet first."* refusal both surface copies guarded with — `registerVerifiedWork` needs no signature, just the address string, so an env built before a wallet is connected would otherwise commit whatever address it holds as the public `.agentnet` marker and index it as the user's identity; and `submitGithubToken` answers a failed save (unwritable tokens dir, full disk) as `{ hasToken: false, error }` instead of rejecting — the dispatcher spreads the result straight into `githubStatus` with no catch of its own, so a rejection was an unhandled rejection in the host and a modal hanging on "Saving…" forever. `githubStatus` and the `ChatEnv` signature gain the optional `error` field and the webview token form renders it. vscode's hand-rolled copies become 3-line delegations (~20 duplicated lines deleted); localhost keeps its own handlers on purpose (pre-wallet token save + `clearGithubToken`, which has no env member yet) — the env doc comment states exactly that split rather than overclaiming.
- **Pins** — `SkillMarket.tsx` gains three zero-runtime type-level asserts (`Parameters[...][5]` for `parentId`, the `["code"]` index for `insufficient_funds`, an extends-check for `airdrop`). The env→`MarketApi` assignment only checks one direction — dropping an optional widening would still typecheck until a consumer calls it — so the pins make a revert fail `tsc` *here*, today.
- `packages/core/src/skill-market/ingest/env.spec.ts` grows 12 specs beside its existing publish suite: `parentId` forwarding ×2, buy-code classification ×2, airdrop devnet guard ×1, github trio ×7 (status without a token, store + refreshed mask, a failed save answered as an error, the no-wallet and no-token refusals, the registration call shape, error passthrough).

Honest scope note: three of the four plan items were already true inside core — this branch makes the API surface *admit* it (widenings + specs + pins). The behavioral changes live in the airdrop delegation (was a silent no-op in vscode), the github-trio consolidation, and the two hardened trio contracts above (wallet-gated registration, save failures answered instead of thrown).

Verified: `tsc --noEmit` clean for core, cli, and vscode (cli and vscode confirmed clean pre-change too, so the widenings introduced no looseness); `env.spec.ts` passes 15/15 under `AGENTNET_NETWORK=devnet`; all four surface builds pass.

## Relates to

`plans/cli-design-parity.md` §"Core/API glue needed (not just UI)", lines 113–117, serving tabs 22 (Agent Comments reply composer), 24 (Skill Detail `[G] REGISTER WORK`), 26 (Connections + Funding / FUNDING panel), and the tab-08 buy path. Also GH #101 (reply threading) and issue #93 (verified work). This is deliberately *only* the glue: the call sites that branch on `code`, the FUNDING panel, and the reply composer are the parity pass's UI work — built to unblock that pass, and happy to adjust any of these shapes to whatever the UI work wants.

## Risks

**Low.** The widenings are additive-optional — I traced every caller: the CLI's `doBuy`/`doCollectAll` read only `ok`/`error`, the dispatcher's spread targets a union that already carries `code` (and now `error`), and the vscode delegations are covariant-safe. The vscode airdrop delegation activates an existing core path with its own devnet guard. The github delegation drops vscode's local wallet check because the refusal now lives in the env member itself — enforced in one place for every surface that delegates, and spec-pinned. localhost intentionally keeps its own github handlers — its env omits the trio, so the dispatcher's capability guards fall through to localhost's guest-aware handlers exactly as before.

## Background — what & why

The parity plan's biggest tabs each dead-end on a missing core surface: a reply composer with no `parentId` to send, a FUNDING panel with no `insufficient_funds` signal and no `airdrop()` to offer, a REGISTER WORK flow whose message types exist but whose `marketplaceEnv` exposes nothing. Landing the glue first, in its own reviewable branch, means the design pass stays purely visual — and the pins mean the glue can't silently rot while it waits to be consumed.

## Testing — where a reviewer starts + steps

Start at the four new describes in `packages/core/src/skill-market/ingest/env.spec.ts` — they pin the behavior the widened types now advertise (parentId reaching the notes layer, the broke-wallet classification, the mainnet airdrop refusal, the token-store round-trip, the no-wallet and no-token refusals, and the failed save answered as an error rather than thrown).

1. `cd packages/core`
2. `AGENTNET_NETWORK=devnet npx vitest run src/skill-market/ingest/env.spec.ts` → 15/15 pass
3. `npx tsc --noEmit` → clean (repeat in `surfaces/cli` and `surfaces/vscode`)
4. Mutation check: revert any one widening in `SkillMarket.tsx`'s `MarketApi` — `tsc` fails with exactly one error anchored at that widening's pin.

### Code quality

Held to five rules — each verified against this diff, not asserted:

1. **No meaningless wrappers with identical input/output** — ✅ the new env members own real logic: the wallet refusal that keeps an unconnected env from committing an identity marker, the token-store round-trip returning the refreshed masked status (one render path for both submit and status), the failed-save-as-answer contract, the no-token refusal, the indexer call, error mapping. The vscode side is delegation at the host boundary — the established pattern of every neighboring market field — and each delegation *replaced* a full duplicate implementation (github trio) or a silent gap (airdrop); none renames a call.
2. **Scan existing functions first and reuse; never two functions with the same purpose** — ✅ this branch is that rule applied: three near-identical github flows collapse toward one core implementation; `airdrop` reuses the existing env member and its devnet guard rather than growing a second faucet path; the specs extend the existing `env.spec.ts` file and its `rpc.js` mock factory instead of a new harness.
3. **No type variables that won't be reused; inline them** — ✅ one local `AssertTrue` helper serves all three pins and is erased at compile; everything else is inline widening of existing signatures (`error?: string` rides the existing `githubStatus` union member and `ChatEnv` method type) — no new exported types anywhere.
4. **No non-essential parameters** — ✅ `parentId` is the single field reply threading needs and core already serializes; `code` appears only when the classification fires and is typed to the one value the panel keys off; `airdrop()` takes nothing and returns exactly what the FundModal renders; `error` appears only on a failed save and the token form renders it.
5. **Keep responsibilities separated; if the design feels wrong, say so** — ✅ `env.ts` stays the single market-capability surface; surfaces stay transport; the trio's guards live in the env member, not per-surface. Two things said out loud: localhost deliberately keeps its own github handlers (its pre-wallet token save and `clearGithubToken` have no env equivalent yet — a future "disconnect GitHub" wants a small env addition, cheap follow-up; the env doc comment records this split so nobody reads it as an oversight); and until tabs 22–26 land, the trio's only consumer is the dispatcher — that is the point of a glue branch, but naming it so nobody mistakes the coverage.

`tsc --noEmit` clean (core · cli · vscode) · `env.spec.ts` 15/15 (12 new) · pins mutation-verified · no regressions — the failing vitest specs under a default env (rpc/seed/dasSource/skillSource + two stale session slash-command specs) reproduce identically without this branch's changes: pre-existing on `main` (d6a0881) and env-dependent (`seed.ts`'s mainnet flip vs stale devnet specs), zero failures attributable to this branch. Based on latest `main`, merges clean, independent of the other branches.

## Evidence

| Row | Artifact |
|---|---|
| Before/After screenshots | N/A - no UI change to show: the CLI diff is type declarations + compile-time pins, the vscode diff is host-side handler wiring behind existing UI (the one webview line renders an error string into an existing error slot) |
| Video walkthrough (MP4) | N/A - no user-visible flow changes; the one behavioral fix (FundModal airdrop no longer a silent no-op) is a request that previously died in the dispatcher, evidenced by the delegation + core's devnet-guard spec |
| Backend logs | `env.spec.ts` run — 15/15: parentId forwarded to the notes layer (reply + top-level) ×2, `insufficient_funds` classification (broke wallet vs other failure) ×2, airdrop refused off-devnet ×1, github trio (status masked-tail, token save round-trip, failed save answered as `{ hasToken:false, error }`, no-wallet refusal, no-token refusal, register success, register error) ×7, plus the 3 pre-existing publish specs |
| Frontend logs | N/A - the only client-side change is one line rendering `githubStatus.error` in the existing token form; the contract beneath it is spec-pinned at the env boundary |
| Real-LLM trajectory | N/A - no agent, model, or prompt changes; API-surface glue for the parity plan |
| Domain artifacts | The compile-time pins are the artifact: reverting any one widening on this branch yields exactly one `tsc` error anchored at its pin (mutation-verified per-widening), so the plan's glue cannot silently regress before the UI pass consumes it |
