### PR TITLE
Bring the session index to the webview and vscode surfaces (completes #146's open decision)

### DIFF
--- a/packages/core/src/account/login.ts
+++ b/packages/core/src/account/login.ts
@@ -75,6 +75,30 @@ export async function setSkillShopping(on: boolean): Promise<void> {
   await writeFile(configFile(), JSON.stringify({ ...prev, skillShopping: on }, null, 2));
 }
 
+// On-chain session index toggle (plans/offchain-session-sync.md §4-5). Same raw-key
+// pattern as skillShopping, but the default is OFF and consent is PER WALLET (a map
+// of address → true): indexing a session writes a real Solana transaction — fees,
+// and a signature prompt on web wallets — so a CLI keypair opting in must not drag
+// a Phantom wallet sharing this device's config into surprise prompts. Consumed by
+// account/sessionIndex.ts (every write path gates on it) and the surfaces' toggles.
+export async function getSessionIndex(wallet: string): Promise<boolean> {
+  const raw = await readRawConfig();
+  const map = raw.sessionIndex;
+  return typeof map === "object" && map !== null && (map as Record<string, unknown>)[wallet] === true;
+}
+
+export async function setSessionIndex(wallet: string, on: boolean): Promise<void> {
+  await ensureDir(rootDir());
+  const prev = await readRawConfig();
+  const map = typeof prev.sessionIndex === "object" && prev.sessionIndex !== null
+    ? (prev.sessionIndex as Record<string, unknown>)
+    : {};
+  await writeFile(
+    configFile(),
+    JSON.stringify({ ...prev, sessionIndex: { ...map, [wallet]: on } }, null, 2),
+  );
+}
+
 // First-run setup: record the chosen backend and (for gdrive) run Google sign-in.
 // `openBrowser` is injected by the surface (only used for gdrive).
 export async function initialize(

--- a/packages/core/src/account/sessionIndex.spec.ts
+++ b/packages/core/src/account/sessionIndex.spec.ts
@@ -1,0 +1,204 @@
+import { describe, it, expect, vi, beforeEach, afterEach } from "vitest";
+import { mkdtempSync, rmSync, readFileSync } from "node:fs";
+import { join } from "node:path";
+import { tmpdir } from "node:os";
+import { ensureTable, writeRow, readRows } from "../core/chain.js";
+import { SESSION_COLUMNS } from "../core/seed.js";
+import { setSessionIndex, getSessionIndex } from "./login.js";
+import {
+  indexNewSession,
+  listChainSessions,
+  sessionIndexStatus,
+  backfillSessionIndex,
+} from "./sessionIndex.js";
+import type { Wallet } from "../runtime/contract.js";
+
+// The chain layer is fully mocked: these tests pin the GATING (opt-in, dedup,
+// best-effort, truncation refusal) and the row/table shapes handed to it — the
+// layer chain.spec.ts already covers. resolveRpcUrl is mocked so the lazy init
+// never probes a key.
+vi.mock("../core/chain.js", () => ({
+  init: vi.fn(),
+  ensureTable: vi.fn().mockResolvedValue(null),
+  writeRow: vi.fn().mockResolvedValue("txSig"),
+  readRows: vi.fn().mockResolvedValue([]),
+}));
+vi.mock("../core/rpc.js", () => ({
+  resolveRpcUrl: vi.fn().mockResolvedValue("https://api.devnet.solana.com"),
+}));
+
+const wallet = { address: "walletA" } as unknown as Wallet;
+let home: string;
+
+beforeEach(() => {
+  home = mkdtempSync(join(tmpdir(), "agentnet-test-"));
+  process.env.AGENTNET_HOME = home;
+  vi.mocked(ensureTable).mockClear().mockResolvedValue(null);
+  vi.mocked(writeRow).mockClear().mockResolvedValue("txSig");
+  vi.mocked(readRows).mockClear().mockResolvedValue([]);
+});
+
+afterEach(() => {
+  delete process.env.AGENTNET_HOME;
+  rmSync(home, { recursive: true, force: true });
+});
+
+describe("sessionIndex toggle", () => {
+  it("defaults OFF — absent flag is not consent to pay for transactions", async () => {
+    expect(await getSessionIndex("walletA")).toBe(false);
+  });
+
+  it("consent is PER WALLET — one wallet's opt-in never covers another", async () => {
+    await setSessionIndex("walletA", true);
+    expect(await getSessionIndex("walletA")).toBe(true);
+    expect(await getSessionIndex("walletB")).toBe(false);
+    await setSessionIndex("walletA", false);
+    expect(await getSessionIndex("walletA")).toBe(false);
+  });
+});
+
+describe("indexNewSession", () => {
+  it("does nothing while the wallet's toggle is off", async () => {
+    expect(await indexNewSession(wallet, "s1", "claude")).toBe(false);
+    expect(writeRow).not.toHaveBeenCalled();
+    expect(ensureTable).not.toHaveBeenCalled();
+  });
+
+  it("writes one owner-gated row with the Session shape and NO title", async () => {
+    await setSessionIndex("walletA", true);
+    expect(await indexNewSession(wallet, "s1", "codex")).toBe(true);
+    expect(ensureTable).toHaveBeenCalledWith(wallet, "mysessions:walletA", SESSION_COLUMNS, "sessionId", {
+      writers: ["walletA"],
+    });
+    const row = JSON.parse(vi.mocked(writeRow).mock.calls[0][2]);
+    expect(row.sessionId).toBe("s1");
+    expect(row.modelType).toBe("codex");
+    expect(row.createdAt).toBeGreaterThan(0);
+    expect(row.updatedAt).toBe(row.createdAt);
+    expect("title" in row).toBe(false); // titles stay inside the encrypted blob
+  });
+
+  it("is idempotent via the local cache — a restart never re-pays the tx", async () => {
+    await setSessionIndex("walletA", true);
+    await indexNewSession(wallet, "s1", "claude");
+    expect(await indexNewSession(wallet, "s1", "claude")).toBe(false);
+    expect(writeRow).toHaveBeenCalledTimes(1);
+    const cache = JSON.parse(readFileSync(join(home, "chain-index", "walletA.json"), "utf8"));
+    expect(cache.indexed).toEqual(["s1"]);
+  });
+
+  it("swallows chain failures and leaves the cache unmarked so a retry can succeed", async () => {
+    await setSessionIndex("walletA", true);
+    vi.mocked(writeRow).mockRejectedValueOnce(new Error("rpc down"));
+    expect(await indexNewSession(wallet, "s1", "claude")).toBe(false); // no throw
+    expect(await indexNewSession(wallet, "s1", "claude")).toBe(true); // retried, now cached
+    expect(writeRow).toHaveBeenCalledTimes(2);
+  });
+});
+
+describe("listChainSessions", () => {
+  it("drops malformed rows and keeps the OLDEST of a duplicated id (rows arrive newest-first)", async () => {
+    vi.mocked(readRows).mockResolvedValue([
+      { sessionId: "a", modelType: "codex", createdAt: 9, updatedAt: 9 }, // newer duplicate echo
+      { sessionId: "a", modelType: "claude", createdAt: 1, updatedAt: 2 }, // the original create
+      { modelType: "claude" }, // no id
+      { sessionId: "b", modelType: "weird", createdAt: "3", updatedAt: null },
+    ]);
+    const { sessions, truncated } = await listChainSessions("walletA");
+    expect(truncated).toBe(false);
+    expect(sessions).toEqual([
+      { sessionId: "a", modelType: "claude", createdAt: 1, updatedAt: 2 },
+      { sessionId: "b", modelType: "claude", createdAt: 3, updatedAt: 0 },
+    ]);
+  });
+
+  it("flags a full read window as truncated", async () => {
+    vi.mocked(readRows).mockResolvedValue(
+      Array.from({ length: 1000 }, (_, i) => ({ sessionId: `s${i}`, modelType: "claude", createdAt: i, updatedAt: i })),
+    );
+    expect((await listChainSessions("walletA")).truncated).toBe(true);
+  });
+});
+
+describe("sessionIndexStatus / backfillSessionIndex", () => {
+  it("splits chain rows into held-here vs chain-only", async () => {
+    vi.mocked(readRows).mockResolvedValue([
+      { sessionId: "here", modelType: "claude", createdAt: 1, updatedAt: 1 },
+      { sessionId: "elsewhere", modelType: "claude", createdAt: 2, updatedAt: 2 },
+    ]);
+    const st = await sessionIndexStatus("walletA", ["here", "local-only"]);
+    expect(st.onChain).toHaveLength(2);
+    expect(st.chainOnly.map((s) => s.sessionId)).toEqual(["elsewhere"]);
+    expect(st.truncated).toBe(false);
+  });
+
+  it("backfill refuses while the toggle is off — the gate lives in core, not the surface", async () => {
+    await expect(backfillSessionIndex(wallet, [])).rejects.toThrow(/off for this wallet/);
+    expect(writeRow).not.toHaveBeenCalled();
+  });
+
+  it("backfill writes only sessions neither the chain NOR the cache knows", async () => {
+    await setSessionIndex("walletA", true);
+    // "c" was written by THIS device moments ago; the gateway view lags and
+    // doesn't serve it yet — the cache must stop a duplicate paid row.
+    await indexNewSession(wallet, "c", "claude");
+    vi.mocked(writeRow).mockClear();
+    vi.mocked(readRows).mockResolvedValue([
+      { sessionId: "a", modelType: "claude", createdAt: 1, updatedAt: 1 },
+    ]);
+    const r = await backfillSessionIndex(wallet, [
+      { sessionId: "a", title: "t", cli: "claude", ts: 5 },
+      { sessionId: "b", title: "t2", cli: "codex", ts: 6 },
+      { sessionId: "c", title: "t3", cli: "claude", ts: 7 },
+    ]);
+    expect(r).toEqual({ written: 1, already: 2 });
+    expect(writeRow).toHaveBeenCalledTimes(1);
+    const row = JSON.parse(vi.mocked(writeRow).mock.calls[0][2]);
+    expect(row.sessionId).toBe("b");
+    expect("title" in row).toBe(false);
+    // the cache repaired itself from chain truth for "a" too
+    const cache = JSON.parse(readFileSync(join(home, "chain-index", "walletA.json"), "utf8"));
+    expect(cache.indexed.sort()).toEqual(["a", "b", "c"]);
+  });
+
+  it("backfill refuses a truncated chain view instead of minting duplicates", async () => {
+    await setSessionIndex("walletA", true);
+    vi.mocked(readRows).mockResolvedValue(
+      Array.from({ length: 1000 }, (_, i) => ({ sessionId: `s${i}`, modelType: "claude", createdAt: i, updatedAt: i })),
+    );
+    await expect(
+      backfillSessionIndex(wallet, [{ sessionId: "old", title: "t", cli: "claude", ts: 1 }]),
+    ).rejects.toThrow(/partial view/);
+    expect(writeRow).not.toHaveBeenCalled();
+  });
+
+  it("rejects a concurrent backfill for the same wallet — two runs would double-pay", async () => {
+    await setSessionIndex("walletA", true);
+    let release!: () => void;
+    vi.mocked(writeRow).mockImplementationOnce(
+      () => new Promise((res) => { release = () => res("txSig"); }),
+    );
+    const first = backfillSessionIndex(wallet, [{ sessionId: "b", title: "t", cli: "codex", ts: 6 }]);
+    await vi.waitFor(() => expect(writeRow).toHaveBeenCalled());
+    await expect(
+      backfillSessionIndex(wallet, [{ sessionId: "b", title: "t", cli: "codex", ts: 6 }]),
+    ).rejects.toThrow(/already running/);
+    release();
+    expect(await first).toEqual({ written: 1, already: 0 });
+  });
+
+  it("keeps rows already paid for in the cache even when a later write throws", async () => {
+    await setSessionIndex("walletA", true);
+    vi.mocked(writeRow)
+      .mockResolvedValueOnce("txSig")
+      .mockRejectedValueOnce(new Error("rpc died mid-run"));
+    await expect(
+      backfillSessionIndex(wallet, [
+        { sessionId: "b", title: "t", cli: "codex", ts: 6 },
+        { sessionId: "d", title: "t", cli: "claude", ts: 7 },
+      ]),
+    ).rejects.toThrow(/rpc died/);
+    const cache = JSON.parse(readFileSync(join(home, "chain-index", "walletA.json"), "utf8"));
+    expect(cache.indexed).toEqual(["b"]); // paid row remembered; failed one retryable
+  });
+});

--- a/packages/core/src/account/sessionIndex.ts
+++ b/packages/core/src/account/sessionIndex.ts
@@ -1,0 +1,215 @@
+// On-chain session index (plans/offchain-session-sync.md §4-5) — the `mysessions`
+// half of session sync. Storage already carries the encrypted blobs across devices;
+// this publishes the LIST ("these sessionIds belong to this wallet") so a brand-new
+// device can DISCOVER its sessions before any cloud storage is connected.
+//
+// Deliberately minimal on-chain (the plan's whole point):
+//   - one row per NEW sessionId, written once at creation — updates never touch the
+//     chain (integrity lives in the blob's authenticated encryption, not a hash)
+//   - row shape = the `Session` type (core/types.ts); `title` stays off-chain —
+//     it lives inside the encrypted blob, and a table row is public forever
+//   - writers=[owner] ON OUR CREATE. The table PDA derives from the public hint
+//     alone, so a squatter who creates it FIRST owns the writer list — see the
+//     open finding in the PR: real enforcement needs the contract to bind table
+//     creation to the hint's wallet. Until then a squatted table means writes
+//     fail (contained below) and rows stay what they always are: untrusted hints.
+//
+// Everything here is OPT-IN PER WALLET (config.json `sessionIndex` map — see
+// login.ts) because a row write is a real Solana transaction: it costs fees and,
+// on a web wallet, pops a signature prompt; one device-global flag would let a
+// CLI keypair's opt-in surprise-prompt a Phantom wallet on the same machine.
+// The write paths are best-effort: an RPC hiccup or a signerless wallet (the
+// localhost guest) must never break the chat session they ride on. Chain-only
+// entries are DISCOVERY hints, never openable rows — opening a blobless id would
+// start writing fresh pages under it and collide with the real pages when that
+// storage later connects.
+
+import { readFile, writeFile } from "node:fs/promises";
+import { Connection } from "@solana/web3.js";
+import { init as initChain, ensureTable, writeRow, readRows } from "../core/chain.js";
+import { mysessionsHint, SESSION_COLUMNS } from "../core/seed.js";
+import { resolveRpcUrl } from "../core/rpc.js";
+import { chainIndexDir, chainIndexFile, ensureDir } from "../core/paths.js";
+import { getSessionIndex } from "./login.js";
+import type { Session } from "../core/types.js";
+import type { SessionMeta, Wallet } from "../runtime/contract.js";
+
+// Read window for the wallet's row list. The gateway pages 100/call under this and
+// the SDK fallback's getSignaturesForAddress caps near 1000, so past this point a
+// read may be silently missing OLDER rows. Every consumer that dedups paid writes
+// against the list must honor `truncated` — writing against a partial view is how
+// permanent duplicate rows (and fees) happen.
+const READ_LIMIT = 1000;
+
+// The runtime may never have touched the chain layer (a chat session needs no RPC),
+// so every entry point routes through this lazy init. Memoized: resolveRpcUrl probes
+// the stored Helius key with a live call, and one probe per process is plenty.
+let chainReady: Promise<void> | null = null;
+function connectChain(): Promise<void> {
+  return (chainReady ??= (async () => {
+    initChain(new Connection(await resolveRpcUrl(), "confirmed"));
+  })());
+}
+
+// ── local dedup cache (chain-index/{wallet}.json) ───────────────────────────
+// Which sessionIds this device already wrote. The hot path (session creation)
+// trusts it to skip a chain read, and backfill trusts it ALONGSIDE the chain
+// read: the gateway's view can lag its own notify, so "not on chain yet" is not
+// "never written". The chain remains the source of truth — a lost cache costs a
+// redundant check, never a lost session.
+
+async function readCache(wallet: string): Promise<Set<string>> {
+  try {
+    const raw = JSON.parse(await readFile(chainIndexFile(wallet), "utf8")) as { indexed?: unknown };
+    return new Set(Array.isArray(raw.indexed) ? raw.indexed.filter((v): v is string => typeof v === "string") : []);
+  } catch {
+    return new Set();
+  }
+}
+
+async function writeCache(wallet: string, indexed: Set<string>): Promise<void> {
+  await ensureDir(chainIndexDir());
+  await writeFile(chainIndexFile(wallet), JSON.stringify({ indexed: [...indexed] }, null, 2));
+}
+
+// One `mysessions` row (the plan's create-time write). Caller gates + catches.
+async function writeSessionRow(
+  wallet: Wallet,
+  sessionId: string,
+  cli: "claude" | "codex",
+  ts: number,
+): Promise<void> {
+  const hint = mysessionsHint(wallet.address);
+  await ensureTable(wallet, hint, SESSION_COLUMNS, "sessionId", { writers: [wallet.address] });
+  const row: Session = { sessionId, modelType: cli, createdAt: ts, updatedAt: ts };
+  await writeRow(wallet, hint, JSON.stringify(row));
+}
+
+/**
+ * Record a freshly-created session on the wallet's on-chain list. Fire-and-forget
+ * from the runtime: every guard failure (toggle off for THIS wallet, guest wallet
+ * without a signer, RPC down, a squatted table rejecting the write) resolves false
+ * and the chat continues untouched. The cache file makes this idempotent without a
+ * chain read, so an engine restart never re-pays the tx.
+ */
+export async function indexNewSession(
+  wallet: Wallet,
+  sessionId: string,
+  cli: "claude" | "codex",
+): Promise<boolean> {
+  try {
+    if (!sessionId || !(await getSessionIndex(wallet.address))) return false;
+    const cached = await readCache(wallet.address);
+    if (cached.has(sessionId)) return false;
+    await connectChain();
+    await writeSessionRow(wallet, sessionId, cli, Date.now());
+    cached.add(sessionId);
+    await writeCache(wallet.address, cached);
+    return true;
+  } catch (e) {
+    console.warn("[session-index] skipped:", e instanceof Error ? e.message : e);
+    return false;
+  }
+}
+
+/**
+ * The wallet's published session list. Read-only (gateway-first, free), no signer.
+ * Chain rows are untrusted input: malformed entries are dropped, and on a duplicate
+ * id the OLDEST row wins — both feeds return rows newest-first, so the LAST
+ * occurrence is the original create-time write and any later echo is ignored.
+ * `truncated` means the window filled and OLDER rows may be missing: display-only
+ * consumers may shrug, but paid writes must not dedup against a partial view.
+ */
+export async function listChainSessions(
+  walletAddress: string,
+): Promise<{ sessions: Session[]; truncated: boolean }> {
+  await connectChain();
+  const rows = await readRows(mysessionsHint(walletAddress), { limit: READ_LIMIT });
+  const byId = new Map<string, Session>();
+  for (const r of rows) {
+    const id = typeof r.sessionId === "string" ? r.sessionId : "";
+    if (!id) continue;
+    byId.set(id, {
+      sessionId: id,
+      modelType: r.modelType === "codex" ? "codex" : "claude",
+      createdAt: Number(r.createdAt) || 0,
+      updatedAt: Number(r.updatedAt) || 0,
+      ...(typeof r.title === "string" && r.title ? { title: r.title } : {}),
+    });
+  }
+  return { sessions: [...byId.values()], truncated: rows.length >= READ_LIMIT };
+}
+
+export interface SessionIndexStatus {
+  enabled: boolean;
+  /** every row the wallet has published (up to the read window) */
+  onChain: Session[];
+  /** rows with no blob in this device's storage view — "connect the storage that holds them" */
+  chainOnly: Session[];
+  /** the read window filled — counts are floors, not totals */
+  truncated: boolean;
+}
+
+/**
+ * The discovery read (plan §5.2): what does the chain say this wallet has, and
+ * which of those does this device NOT hold a blob for? `localIds` comes from the
+ * caller's listSessions — storage stays the authority on what is openable.
+ */
+export async function sessionIndexStatus(
+  walletAddress: string,
+  localIds: Iterable<string>,
+): Promise<SessionIndexStatus> {
+  const enabled = await getSessionIndex(walletAddress);
+  const { sessions: onChain, truncated } = await listChainSessions(walletAddress);
+  const have = new Set(localIds);
+  return { enabled, onChain, chainOnly: onChain.filter((s) => !have.has(s.sessionId)), truncated };
+}
+
+// One backfill per wallet at a time, process-wide. Two concurrent runs would each
+// read a chain snapshot that predates the other's writes and double-pay every row —
+// re-entry (a double-tapped /sessionsync) must fail loudly, not fork.
+const backfillRunning = new Set<string>();
+
+/**
+ * One-shot catch-up: publish every session this device holds that neither the
+ * chain list NOR the local cache knows (sessions created before indexing was
+ * turned on — including on other devices, which is why the chain read matters).
+ * Explicit-trigger only — the same contract as StorageAdapter.backfill: never on
+ * passive startup. Refuses on a truncated chain view: with older rows invisible,
+ * "missing" can't be told from "not fetched", and guessing mints paid duplicates.
+ */
+export async function backfillSessionIndex(
+  wallet: Wallet,
+  sessions: SessionMeta[],
+): Promise<{ written: number; already: number }> {
+  if (!(await getSessionIndex(wallet.address))) {
+    throw new Error("session sync is off for this wallet");
+  }
+  if (backfillRunning.has(wallet.address)) {
+    throw new Error("a backfill is already running for this wallet");
+  }
+  backfillRunning.add(wallet.address);
+  const cached = await readCache(wallet.address);
+  let written = 0;
+  try {
+    const { sessions: chainSessions, truncated } = await listChainSessions(wallet.address);
+    if (truncated) {
+      throw new Error(`chain list exceeds the ${READ_LIMIT}-row read window — refusing to backfill against a partial view`);
+    }
+    const onChain = new Set(chainSessions.map((s) => s.sessionId));
+    for (const s of sessions) {
+      if (onChain.has(s.sessionId) || cached.has(s.sessionId)) {
+        cached.add(s.sessionId); // repair the cache from chain truth as we pass
+        continue;
+      }
+      await writeSessionRow(wallet, s.sessionId, s.cli, s.ts);
+      cached.add(s.sessionId);
+      written++;
+    }
+  } finally {
+    backfillRunning.delete(wallet.address);
+    // rows already paid for this run stay cached even when a later one threw
+    await writeCache(wallet.address, cached).catch(() => {});
+  }
+  return { written, already: sessions.length - written };
+}

--- a/packages/core/src/chat/session.spec.ts
+++ b/packages/core/src/chat/session.spec.ts
@@ -3,11 +3,26 @@
 // the toggle (claude q.interrupt / codex child.kill), killing the turn the user was
 // watching. The fix is lazy-restage: keep the running handle, re-spawn on the NEXT
 // send carrying the live sessionId so the turn finishes and the new mode applies next.
-import { describe, it, expect, vi } from "vitest";
+import { describe, it, expect, vi, beforeEach } from "vitest";
 import { createChatSession } from "./session.js";
 import { mkdtemp, readFile, rm } from "node:fs/promises";
 import { join } from "node:path";
 import { tmpdir } from "node:os";
+
+// The sessionIndex dispatcher case is the only consumer of these two modules here.
+// Mock them whole: the real ones reach for the chain (solana web3 + config files),
+// and the case's contract — who gets called, with what, and what the reply echoes —
+// is exactly what these tests pin down.
+vi.mock("../account/login.js", () => ({
+  getSessionIndex: vi.fn(async () => false),
+  setSessionIndex: vi.fn(async () => {}),
+}));
+vi.mock("../account/sessionIndex.js", () => ({
+  backfillSessionIndex: vi.fn(async () => ({ written: 0, already: 0 })),
+  sessionIndexStatus: vi.fn(async () => ({ enabled: false, onChain: [], chainOnly: [], truncated: false })),
+}));
+import { getSessionIndex, setSessionIndex } from "../account/login.js";
+import { backfillSessionIndex, sessionIndexStatus } from "../account/sessionIndex.js";
 
 function fakeHandle(id: string, cli: "claude" | "codex") {
   const usageCbs: Array<(n: number, window?: number) => void> = [];
@@ -50,7 +65,7 @@ const waitForNotice = async (transport: any, text: string) => {
   throw new Error(`notice "${text}" was never sent`);
 };
 
-function harness(opts: { cwd?: string; ownedSkills?: string[]; googleCredsConfigured?: boolean } = {}) {
+function harness(opts: { cwd?: string; ownedSkills?: string[]; googleCredsConfigured?: boolean; signingWallet?: () => any } = {}) {
   const handles: ReturnType<typeof fakeHandle>[] = [];
   const startSession = vi.fn(async (opts: any) => {
     const h = fakeHandle("sess-" + handles.length, opts.cli);
@@ -67,6 +82,9 @@ function harness(opts: { cwd?: string; ownedSkills?: string[]; googleCredsConfig
     walletAddress: () => null,
     storageInfo: async () => ({ info: {}, options: [], googleCredsConfigured: opts.googleCredsConfigured }),
     ownedSkills: opts.ownedSkills ? async () => opts.ownedSkills : undefined,
+    // absent by default: the guest surface (localhost without a wallet) offers no
+    // signingWallet at all, which is its own case in the sessionIndex tests below.
+    signingWallet: opts.signingWallet,
   };
   const chat = createChatSession(startSessionRuntime(startSession), transport as any, env);
   return { handles, startSession, fromUI, chat, transport };
@@ -366,7 +384,7 @@ describe("chat/session — slash commands", () => {
 
     fromUI({ type: "slashCommand", command: "resume" });
     await flush();
-    expect(transport.send).toHaveBeenCalledWith({ type: "sessions", list: [], activeId: undefined, cloud: "none" });
+    expect(transport.send).toHaveBeenCalledWith({ type: "sessions", list: [], activeId: undefined, running: [], cloud: "none" });
     expect(transport.send).toHaveBeenCalledWith({ type: "notice", text: "Resume: open a session from History." });
   });
 
@@ -400,14 +418,21 @@ describe("chat/session — slash commands", () => {
     const { fromUI, transport } = harness({ ownedSkills: ["clean-code"] });
 
     fromUI({ type: "slashCommand", command: "skills" });
-    await flush();
-    expect(transport.send).toHaveBeenCalledWith({
+    // ownedSkillsMsg lazy-imports skillSource.js (a heavy module graph — seconds on a
+    // cold vitest worker), so the reply can land long after any fixed flush — poll on
+    // real time like waitForNotice does. `meta` is best-effort display data read from
+    // whatever catalog cache the machine has, so pin the contract fields and leave it free.
+    for (let i = 0; i < 500; i++) {
+      if (transport.send.mock.calls.some((c: any[]) => c[0]?.type === "ownedSkills")) break;
+      await new Promise((r) => setTimeout(r, 10));
+    }
+    expect(transport.send).toHaveBeenCalledWith(expect.objectContaining({
       type: "ownedSkills",
       names: ["clean-code"],
       mints: {},
       disposedMints: {},
       workflowMints: [],
-    });
+    }));
   });
 
   it("/review and /mcp route to the active engine handle", async () => {
@@ -448,5 +473,117 @@ describe("chat/session — slash commands", () => {
     } finally {
       await rm(cwd, { recursive: true, force: true });
     }
+  });
+});
+
+// The on-chain session index round-trip (plans/offchain-session-sync.md §4-5): the
+// dispatcher owns the whole flow, hosts only supply the SIGNING wallet. Every row
+// write is a PAID Solana transaction, so the contracts pinned here — the wallet
+// gate, 'on' running the one-shot backfill, 'off' never touching the chain, errors
+// echoing the config-read toggle — are the ones a regression would turn into
+// surprise prompts, duplicate fees, or a lying switch.
+describe("chat/session — on-chain session index", () => {
+  const wallet = { address: "WaLLetAddr111", signMessage: async () => new Uint8Array() };
+  const chainRow = (id: string) => ({ sessionId: id, modelType: "claude" as const, createdAt: 0, updatedAt: 0 });
+
+  beforeEach(() => {
+    vi.mocked(getSessionIndex).mockReset().mockResolvedValue(true);
+    vi.mocked(setSessionIndex).mockReset().mockResolvedValue(undefined);
+    vi.mocked(backfillSessionIndex).mockReset().mockResolvedValue({ written: 0, already: 0 });
+    vi.mocked(sessionIndexStatus).mockReset().mockResolvedValue({ enabled: true, onChain: [], chainOnly: [], truncated: false });
+  });
+
+  const statusMsgs = (transport: any) =>
+    transport.send.mock.calls.map((c: any[]) => c[0]).filter((m: any) => m?.type === "sessionIndexStatus");
+
+  // the chain work runs off the pump, so the reply lands asynchronously — poll for it
+  const waitForStatus = async (transport: any) => {
+    for (let i = 0; i < 200; i++) {
+      const got = statusMsgs(transport);
+      if (got.length) return got[got.length - 1];
+      await new Promise((r) => setTimeout(r, 0));
+    }
+    throw new Error("sessionIndexStatus was never sent");
+  };
+
+  it("stays silent on a surface with no signingWallet hook (guest can't sign or pay)", async () => {
+    const { fromUI, transport } = harness(); // env.signingWallet absent entirely
+    fromUI({ type: "sessionIndex", action: "on" });
+    await flush();
+    expect(statusMsgs(transport)).toHaveLength(0);
+    expect(setSessionIndex).not.toHaveBeenCalled();
+    expect(backfillSessionIndex).not.toHaveBeenCalled();
+    expect(sessionIndexStatus).not.toHaveBeenCalled();
+  });
+
+  it("stays silent when signingWallet() returns null (localhost guest key)", async () => {
+    const { fromUI, transport } = harness({ signingWallet: () => null });
+    fromUI({ type: "sessionIndex", action: "status" });
+    await flush();
+    expect(statusMsgs(transport)).toHaveLength(0);
+    expect(sessionIndexStatus).not.toHaveBeenCalled();
+  });
+
+  it("'status' reports the chain counts without toggling config or writing rows", async () => {
+    vi.mocked(sessionIndexStatus).mockResolvedValue({
+      enabled: true,
+      onChain: [chainRow("a"), chainRow("b")],
+      chainOnly: [chainRow("b")],
+      truncated: true,
+    });
+    const { fromUI, transport } = harness({ signingWallet: () => wallet });
+    fromUI({ type: "sessionIndex", action: "status" });
+    const msg = await waitForStatus(transport);
+    expect(msg).toEqual({ type: "sessionIndexStatus", enabled: true, listed: 2, elsewhere: 1, truncated: true, written: undefined });
+    expect(sessionIndexStatus).toHaveBeenCalledWith(wallet.address, []);
+    expect(setSessionIndex).not.toHaveBeenCalled();
+    expect(backfillSessionIndex).not.toHaveBeenCalled(); // a paid write on a status read = money
+  });
+
+  it("'on' flips the per-wallet config AND runs the one-shot backfill (CLI parity)", async () => {
+    vi.mocked(backfillSessionIndex).mockResolvedValue({ written: 3, already: 2 });
+    const { fromUI, transport } = harness({ signingWallet: () => wallet });
+    fromUI({ type: "sessionIndex", action: "on" });
+    const msg = await waitForStatus(transport);
+    expect(setSessionIndex).toHaveBeenCalledWith(wallet.address, true);
+    expect(backfillSessionIndex).toHaveBeenCalledWith(wallet, []);
+    expect(msg.written).toBe(3);
+    expect(msg.error).toBeUndefined();
+  });
+
+  it("'off' confirms from config alone — no chain read, no error even with RPC down", async () => {
+    // chain fully dark: if 'off' touched it, the reply would carry an error
+    vi.mocked(sessionIndexStatus).mockRejectedValue(new Error("rpc unreachable"));
+    vi.mocked(backfillSessionIndex).mockRejectedValue(new Error("rpc unreachable"));
+    const { fromUI, transport } = harness({ signingWallet: () => wallet });
+    fromUI({ type: "sessionIndex", action: "off" });
+    const msg = await waitForStatus(transport);
+    expect(setSessionIndex).toHaveBeenCalledWith(wallet.address, false);
+    expect(msg).toEqual({ type: "sessionIndexStatus", enabled: false });
+    expect(sessionIndexStatus).not.toHaveBeenCalled();
+    expect(backfillSessionIndex).not.toHaveBeenCalled();
+  });
+
+  it("a failed action reports its reason with the toggle re-read from config", async () => {
+    vi.mocked(backfillSessionIndex).mockRejectedValue(new Error("a backfill is already running for this wallet"));
+    vi.mocked(getSessionIndex).mockResolvedValue(true); // config says on — the switch must stay truthful
+    const { fromUI, transport } = harness({ signingWallet: () => wallet });
+    fromUI({ type: "sessionIndex", action: "backfill" });
+    const msg = await waitForStatus(transport);
+    expect(msg).toEqual({ type: "sessionIndexStatus", enabled: true, error: "a backfill is already running for this wallet" });
+  });
+
+  it("chain work runs OFF the pump: a hung RPC read never blocks later messages", async () => {
+    vi.mocked(sessionIndexStatus).mockImplementation(() => new Promise(() => {})); // never resolves
+    const { fromUI, transport } = harness({ signingWallet: () => wallet });
+    fromUI({ type: "sessionIndex", action: "status" });
+    fromUI({ type: "slashCommand", command: "permissions" });
+    await flush();
+    // the strictly-ordered queue must have moved past the hung chain read
+    expect(transport.send).toHaveBeenCalledWith({
+      type: "notice",
+      text: expect.stringContaining("Current permission mode"),
+    });
+    expect(statusMsgs(transport)).toHaveLength(0); // still hung, still silent — and that's fine
   });
 });

--- a/packages/core/src/chat/session.ts
+++ b/packages/core/src/chat/session.ts
@@ -11,12 +11,14 @@
 // reading a workspace cwd, persisting the "onboarded" flag, opening external URLs.
 // Those are injected as `env` callbacks so this file stays platform-free.
 
-import type { AgentRuntime, SessionHandle } from "../runtime/contract.js";
+import type { AgentRuntime, SessionHandle, Wallet } from "../runtime/contract.js";
 import type { ApprovalChannel } from "../runtime/approval/channel.js";
 import type { SkillCard, MarketRequest } from "./marketMessages.js";
 import { access, writeFile } from "node:fs/promises";
 import { join } from "node:path";
 import type { ChatModelOption } from "./modelOptions.js";
+import { getSessionIndex, setSessionIndex } from "../account/login.js";
+import { backfillSessionIndex, sessionIndexStatus } from "../account/sessionIndex.js";
 
 // Format a token count with thousands separators (e.g. 167000 → "167,000") for the
 // /context breakdown notice.
@@ -54,6 +56,12 @@ export interface ChatEnv {
   disconnectWallet?(): Promise<void>;
   openCloud?(kind: string, location?: string): Promise<void>;
   walletAddress(): string | null; // for the "My Wallet" view
+  // On-chain session index (plans/offchain-session-sync.md §4-5): the dispatcher owns the
+  // whole sessionIndex round-trip (core API + the runtime's session list) and only needs
+  // the wallet that SIGNS the row writes — each one is a real Solana transaction. Return
+  // null when the host has no such wallet (the localhost guest key signs messages, never
+  // transactions); the sessionIndex message then goes unanswered, matching its wallet-gated UI.
+  signingWallet?(): Wallet | null;
   storageInfo(): Promise<{ info: unknown; options: unknown; googleCredsConfigured?: boolean }>; // header storage pill
   // marketplace (issue #17): search + buy need the wallet + a chain connection, which
   // are host-held (the extension owns them), so they're delegated like wallet/cloud.
@@ -709,6 +717,51 @@ export function createChatSession(
       case "disconnectWallet": await env.disconnectWallet?.(); break;
       case "openCloud":       await env.openCloud?.(m.kind, m.location); break;
       case "wallet":          transport.send({ type: "wallet", address: env.walletAddress() }); break;
+      // ── on-chain session index (plans/offchain-session-sync.md §4-5): the wallet's
+      // opt-in `mysessions` list, same contract as the CLI's /sessionsync. Guarded on a
+      // SIGNING wallet — the localhost guest can't sign (or pay for) a row write, so its
+      // message goes unanswered, matching the wallet gate on the UI row. `on` runs the
+      // one-shot backfill immediately (CLI parity: the list starts complete instead of
+      // only covering sessions created after the flip). A failed action (backfill
+      // re-entry, truncated chain view, RPC down) reports its reason with the toggle
+      // state re-read from config, so the switch stays truthful.
+      //
+      // The chain work runs OFF the pump (fire-and-forget, CLI parity again): this
+      // dispatcher processes messages strictly in order, and `on`/`backfill` mean one
+      // real Solana transaction per unindexed session — on the localhost surface each
+      // one round-trips a UI signing prompt with a minutes-scale timeout. Awaiting
+      // that here would freeze every queued message (chat sends, stops, session
+      // opens) behind wallet prompts; even `status` does a chain read that stalls the
+      // queue for the RPC timeout when the endpoint is slow. Backfill re-entry is
+      // rejected inside backfillSessionIndex, so overlapping requests fail loudly
+      // instead of double-paying.
+      case "sessionIndex": {
+        const w = env.signingWallet?.();
+        if (!w) break;
+        void (async () => {
+          try {
+            if (m.action === "off") {
+              // Config-only: turning OFF is the safety exit and must neither depend on
+              // nor report chain health — the CLI's `off` skips the chain the same way.
+              // (The status line loses its counts until the next read; that beats
+              // painting an error over an action that fully succeeded.)
+              await setSessionIndex(w.address, false);
+              transport.send({ type: "sessionIndexStatus", enabled: false });
+              return;
+            }
+            if (m.action === "on") await setSessionIndex(w.address, true);
+            const mine = await rt.listSessions();
+            const written = m.action === "on" || m.action === "backfill"
+              ? (await backfillSessionIndex(w, mine)).written
+              : undefined;
+            const st = await sessionIndexStatus(w.address, mine.map((s) => s.sessionId));
+            transport.send({ type: "sessionIndexStatus", enabled: st.enabled, listed: st.onChain.length, elsewhere: st.chainOnly.length, truncated: st.truncated, written });
+          } catch (e) {
+            transport.send({ type: "sessionIndexStatus", enabled: await getSessionIndex(w.address).catch(() => false), error: e instanceof Error ? e.message : String(e) });
+          }
+        })();
+        break;
+      }
       // ── marketplace: search → buy → install (delegated to the host) ──
       // payload typed via the shared contract (marketMessages.ts) so a wrong field
       // is caught here, not at runtime on some surface.

--- a/packages/core/src/chat/ui/webview.ts
+++ b/packages/core/src/chat/ui/webview.ts
@@ -1750,6 +1750,18 @@ export function chatHtml(): string {
       </div>
       <div id="rpcHint" class="muted small" style="display:none;margin-top:3px"></div>
     </div>
+    <!-- on-chain session index (plans/offchain-session-sync.md §4-5): the wallet's opt-in
+         mysessions list, mirroring the CLI's /sessionsync. The hint carries the consent
+         framing (a listing is a real tx) until the wallet opts in. -->
+    <div class="wmSection">
+      <div class="wmLabel">Session sync</div>
+      <div class="wmStorage">
+        <span id="ssyncState" class="muted">…</span>
+        <button id="ssyncBtn" class="link" style="display:none"></button>
+        <button id="ssyncBackfillBtn" class="link" style="display:none">backfill</button>
+      </div>
+      <div id="ssyncHint" class="muted small" style="display:none;margin-top:3px">lists each new session on-chain so other devices can find it · a real (tiny) solana tx per listing · turning on lists your existing sessions right away</div>
+    </div>
     <div class="wmItem" id="openWalletPage">Wallet page</div>
     <div class="wmItem" id="walletSkills"><span class="wand">${WAND_SVG}</span> Skills <span class="soon" id="walletSkillCount" style="display:none"></span><span class="wmCaret" id="walletSkillCaret">▸</span></div>
     <!-- inline, scrollable list of the skills THIS wallet owns. No buy / no navigation —
@@ -4563,7 +4575,10 @@ export function chatHtml(): string {
   document.getElementById('walletPill').addEventListener('click', (e) => {
     e.stopPropagation();
     toggleMenu(walletMenu, 'wallet');
-    if (walletMenu.style.display !== 'none') vscode.postMessage({ type: 'getBalance' }); // refresh funds on open
+    if (walletMenu.style.display !== 'none') {
+      vscode.postMessage({ type: 'getBalance' }); // refresh funds on open
+      vscode.postMessage({ type: 'sessionIndex', action: 'status' }); // refresh session-sync state on open
+    }
   });
   document.getElementById('openWalletPage').addEventListener('click', () => { closeMenus(); if (myWalletAddress) showProfile(myWalletAddress); else showView('wallet'); });
   // click outside closes any open menu
@@ -4764,6 +4779,40 @@ export function chatHtml(): string {
     vscode.postMessage({ type: 'setSkillShopping', on: next });
   });
   vscode.postMessage({ type: 'getSkillShopping' }); // hydrate the switch on load
+
+  // ---- on-chain session sync (wallet menu): mirrors the CLI's /sessionsync ----
+  // Status is fetched on wallet-menu open (a status read hits the chain — never polled).
+  // turn on = flip consent + one-shot backfill in one action (the host echoes truth back);
+  // the hint under the row carries the "real transaction" framing until the wallet opts in.
+  const ssyncState = document.getElementById('ssyncState');
+  const ssyncBtn = document.getElementById('ssyncBtn');
+  const ssyncBackfillBtn = document.getElementById('ssyncBackfillBtn');
+  const ssyncHint = document.getElementById('ssyncHint');
+  let ssyncOn = false;
+  function renderSessionIndex(m) {
+    ssyncOn = !!m.enabled;
+    if (m.error) {
+      ssyncState.textContent = (ssyncOn ? 'on' : 'off') + ' · ' + m.error;
+    } else {
+      const parts = [ssyncOn ? 'on' : 'off', (m.listed || 0) + ' listed'];
+      if (m.elsewhere) parts.push(m.elsewhere + ' on other devices');
+      if (m.truncated) parts.push('list truncated');
+      if (m.written) parts.push('+' + m.written + ' published');
+      ssyncState.textContent = parts.join(' · ');
+    }
+    ssyncBtn.textContent = ssyncOn ? 'turn off' : 'turn on';
+    ssyncBtn.style.display = '';
+    ssyncBackfillBtn.style.display = ssyncOn ? '' : 'none';
+    ssyncHint.style.display = ssyncOn ? 'none' : '';
+  }
+  ssyncBtn.addEventListener('click', () => {
+    ssyncState.textContent = ssyncOn ? 'turning off…' : 'publishing…';
+    vscode.postMessage({ type: 'sessionIndex', action: ssyncOn ? 'off' : 'on' });
+  });
+  ssyncBackfillBtn.addEventListener('click', () => {
+    ssyncState.textContent = 'backfilling…';
+    vscode.postMessage({ type: 'sessionIndex', action: 'backfill' });
+  });
 
   // ---- Markets full-screen view (same contract, marketplace design) ----
   const mktSearch = document.getElementById('mktSearch');
@@ -5491,6 +5540,7 @@ export function chatHtml(): string {
     else if (m.type === 'skillActive' && m.origin === 'nft' && m.mint) flashSkill(m.name, m.mint);
     else if (m.type === 'rpcStatus') renderRpcStatus(m.status);
     else if (m.type === 'skillShopping') setShopToggle(m.on);
+    else if (m.type === 'sessionIndexStatus') renderSessionIndex(m);
     else if (m.type === 'searchResults') {
       lastMarketResults = m.results || [];
       renderMarketResults(m.results);          // the full Markets view (search lives here now)

--- a/packages/core/src/core/paths.ts
+++ b/packages/core/src/core/paths.ts
@@ -184,6 +184,20 @@ export function skillStateFile(wallet: string): string {
   return join(skillStateDir(), `${wallet}.json`);
 }
 
+// ── on-chain session index (account/sessionIndex.ts): which sessionIds this device
+// already wrote to the wallet's `mysessions` table. Purely a tx-saving dedup cache —
+// the chain is the source of truth and this is recomputable from it, so like
+// cli-map.json it stays local and is never synced.
+
+export function chainIndexDir(): string {
+  return join(rootDir(), "chain-index");
+}
+
+/** This wallet's "already indexed on-chain" sessionId cache. Local, never synced. */
+export function chainIndexFile(wallet: string): string {
+  return join(chainIndexDir(), `${wallet}.json`);
+}
+
 /** Ensure a directory exists (mkdir -p) with 0o700 so only the owner can enter. */
 export async function ensureDir(dir: string): Promise<void> {
   await mkdir(dir, { recursive: true, mode: 0o700 });

--- a/packages/core/src/core/seed.ts
+++ b/packages/core/src/core/seed.ts
@@ -207,3 +207,18 @@ export const REVIEW_COLUMNS = [
   "timestamp",
   "meta",
 ];
+
+// Columns for the per-wallet `mysessions` table (mysessionsHint above); the row
+// shape is the `Session` type in core/types.ts. `title` is declared so a wallet
+// MAY publish one, but the shipped writer never does — titles live inside the
+// encrypted session blobs, and a table row is public forever (the plan's "omit
+// if sensitive", applied as the default). `meta` mirrors REVIEW_COLUMNS' escape
+// hatch: columns are fixed at table creation, so the superset must exist now.
+export const SESSION_COLUMNS = [
+  "sessionId",
+  "modelType",
+  "createdAt",
+  "updatedAt",
+  "title",
+  "meta",
+];

--- a/packages/core/src/index.ts
+++ b/packages/core/src/index.ts
@@ -151,9 +151,20 @@ export {
   getStorageInfo,
   getSkillShopping,
   setSkillShopping,
+  getSessionIndex,
+  setSessionIndex,
   saveGoogleCreds,
   hasGoogleCreds,
 } from "./account/login.js";
+// on-chain session index (plans/offchain-session-sync.md): the opt-in `mysessions`
+// writer + the discovery reads a surface builds its "sessions elsewhere" hint from.
+export {
+  indexNewSession,
+  listChainSessions,
+  sessionIndexStatus,
+  backfillSessionIndex,
+} from "./account/sessionIndex.js";
+export type { SessionIndexStatus } from "./account/sessionIndex.js";
 export { STORAGE_OPTIONS } from "./account/storage/adapter.js";
 export type { StorageConfig, StorageKind } from "./account/storage/adapter.js";
 export { manualStorage } from "./account/storage/manual.js";

--- a/packages/core/src/runtime/index.ts
+++ b/packages/core/src/runtime/index.ts
@@ -8,6 +8,7 @@ import { randomUUID } from "node:crypto";
 import { Connection } from "@solana/web3.js";
 import { spawnCli } from "./spawn.js";
 import { SessionStore } from "../account/store.js";
+import { indexNewSession } from "../account/sessionIndex.js";
 import { prepareResume } from "./inject/index.js";
 import { getDeviceProfile, buildDeviceNotice } from "../core/device.js";
 import { MemorySync, updateSkillsSection } from "../memory/index.js";
@@ -216,6 +217,11 @@ export function createRuntime(
         if (sessionId) return;
         sessionId = id;
         void flush();
+        // A fresh session just got its permanent id — publish it to the wallet's
+        // on-chain `mysessions` list (writeRow once per NEW sessionId; updates
+        // never touch the chain). Opt-in + best-effort inside indexNewSession;
+        // ephemeral sessions never leave this process.
+        if (!opts.ephemeral) void indexNewSession(wallet, id, opts.cli);
       });
       cli.onMessage((m: ChatMessage) => emit(m));
       // only nft skills get the casting cue; read fresh so same-session buys light up.
@@ -335,6 +341,9 @@ export function createRuntime(
       await store.fork(sessionId, newId, base, opts?.upTo);
       const forked = (await store.listMine()).find((s) => s.sessionId === newId);
       if (!forked) throw new Error("fork did not land in the session list");
+      // A fork mints its canonical id HERE (no CLI spawn, so no onSessionId) —
+      // publish it like any other new session. Same opt-in + best-effort gate.
+      void indexNewSession(wallet, newId, forked.cli);
       return forked;
     },
 

--- a/surfaces/cli/src/commands.ts
+++ b/surfaces/cli/src/commands.ts
@@ -27,6 +27,7 @@ export const SLASH_COMMANDS: SlashCmd[] = [
   { name: "btw", desc: "side-channel question without interrupting session", args: "<question>" },
   { name: "wallet", desc: "show wallet address" },
   { name: "storage", desc: "view/change where sessions save (connect or reconnect cloud)" },
+  { name: "sessionsync", desc: "on-chain session list (opt-in)", args: "status|on|off|backfill" },
   { name: "logout", desc: "sign out of cloud storage (back to local-only)" },
   { name: "iq", desc: "a random IQ fact" },
   { name: "dance", desc: "Iggy dances" },

--- a/surfaces/cli/src/views/Chat.tsx
+++ b/surfaces/cli/src/views/Chat.tsx
@@ -12,6 +12,10 @@ import { useFrameLoop } from "../hooks/useFrameLoop.js";
 import {
   getStorageInfo,
   disconnectCloud,
+  getSessionIndex,
+  setSessionIndex,
+  sessionIndexStatus,
+  backfillSessionIndex,
   getCodexApiKey,
   STORAGE_OPTIONS,
   type StorageKind,
@@ -986,6 +990,48 @@ export function Chat({
         // point for connect / reconnect (a dead gdrive token surfaces via the status
         // line's "reconnect needed" chip, which points here).
         setShowCloud(true);
+        return;
+      case "sessionsync":
+        // The opt-in on-chain `mysessions` list: a wallet-owned index of sessionIds so
+        // a NEW device can discover its sessions before any cloud storage is connected.
+        // Blobs stay in storage — chain-only entries are hints, not openable rows.
+        // Every row write is a real (tiny) Solana tx, which is why this is opt-in and
+        // why `on` runs the one-shot backfill right away: the list starts complete
+        // instead of only covering sessions created after the flip.
+        void (async () => {
+          const sub = arg.trim().toLowerCase();
+          try {
+            if (sub === "off") {
+              await setSessionIndex(wallet.address, false);
+              setNotice("session sync off · new sessions stay unlisted (existing rows are permanent)");
+              return;
+            }
+            if (sub === "on" || sub === "backfill") {
+              if (sub === "on") await setSessionIndex(wallet.address, true);
+              else if (!(await getSessionIndex(wallet.address))) {
+                setNotice("session sync is off — /sessionsync on first");
+                return;
+              }
+              setNotice(sub === "on" ? "session sync on · publishing your session list…" : "backfilling…");
+              // backfill itself rejects re-entry + a truncated chain view — those
+              // surface through the catch below as the notice, nothing to guard here.
+              const r = await backfillSessionIndex(wallet, await runtime.listSessions());
+              setNotice(
+                `session sync ${sub === "on" ? "on · " : ""}listed ${r.written} session${r.written === 1 ? "" : "s"} on-chain (${r.already} already there)`,
+              );
+              return;
+            }
+            const mine = await runtime.listSessions();
+            const st = await sessionIndexStatus(wallet.address, mine.map((s) => s.sessionId));
+            const elsewhere = st.chainOnly.length
+              ? ` · ${st.chainOnly.length} on other devices (connect their storage to open)`
+              : "";
+            const partial = st.truncated ? " · list truncated" : "";
+            setNotice(`session sync ${st.enabled ? "on" : "off"} · ${st.onChain.length} listed on-chain${elsewhere}${partial}`);
+          } catch (e) {
+            setNotice(`session sync: ${e instanceof Error ? e.message : "failed"}`);
+          }
+        })();
         return;
       case "logout":
         // Sign out of cloud: disconnectCloud drops the token + storage kind (keeps creds

--- a/surfaces/localhost/src/index.ts
+++ b/surfaces/localhost/src/index.ts
@@ -1001,6 +1001,10 @@ function attachChat(id: string, c: Client, rt: AgentRuntime) {
         ? await (codexModelOptionsPromise ??= listCodexModelOptions().then((r) => r.options).catch(() => null))
         : await (claudeModelOptionsPromise ??= listClaudeModelOptions(process.cwd()).catch(() => null)),
     walletAddress: () => walletAddress,
+    // Signing wallet for the dispatcher's on-chain session index round-trip: only a
+    // CONNECTED wallet qualifies — the guest key can't sign (or pay for) a row write.
+    // External wallets sign via the UI round-trip, so each listing prompts there.
+    signingWallet: () => (walletAddress && wallet ? wallet : null),
     storageInfo: async () => ({ info: await getStorageInfo(), options: STORAGE_OPTIONS, googleCredsConfigured: await hasGoogleCreds() }),
     connectCloud: async (cfg) => {
       if (wallet && walletAddress) {

--- a/surfaces/vscode/src/extension.ts
+++ b/surfaces/vscode/src/extension.ts
@@ -606,6 +606,9 @@ async function openChat(context: vscode.ExtensionContext, column = vscode.ViewCo
       return { dasReady: await hasDasRpc(), hasKey: !!masked, masked, network: getNetwork() };
     },
     walletAddress: () => wallet?.address ?? null,
+    // Signing wallet for the dispatcher's on-chain session index round-trip. The local
+    // keypair signs in-process, so listing costs only the tx fee — no prompt here.
+    signingWallet: () => wallet,
     // GitHub verified-work registration (issue #93 parity). Token is stored locally by core
     // (rpc.ts, 0600 file — never through the webview); registerVerifiedWork commits the marker
     // + indexes the repo against the skill mints. Mirrors the localhost surface's handler.

--- a/surfaces/webview/src/chat/Sessions.tsx
+++ b/surfaces/webview/src/chat/Sessions.tsx
@@ -118,7 +118,7 @@ function StorageOption({ active, title, subtitle, onClick }: { active: boolean; 
   );
 }
 
-type SettingsMode = "list" | "configure" | "connect" | "gdrive" | "custom" | "helius" | "github" | "engines";
+type SettingsMode = "list" | "configure" | "connect" | "gdrive" | "custom" | "helius" | "github" | "engines" | "sessionsync";
 
 export function Sessions({
   onClose,
@@ -151,6 +151,11 @@ export function Sessions({
   const [busy, setBusy] = useState(false);
   const [bgExec, setBgExec] = useState(backgroundExecEnabled());
   const [screenOffExec, setScreenOffExec] = useState(screenOffExecEnabled());
+
+  // Session sync actions round-trip through the chain; hold the controls until the
+  // dispatcher's sessionIndexStatus echo (or its error) lands and clears this.
+  const [syncBusy, setSyncBusy] = useState(false);
+  useEffect(() => { setSyncBusy(false); }, [state.sessionIndex]);
 
   // Engine versions are fetched ON DEMAND only: once per app session, the first time AI
   // Connections opens (the server re-pushes fresh numbers after an update). No polling,
@@ -400,6 +405,20 @@ export function Sessions({
                 subtitle={cloudConnected ? `${info?.account ?? (info?.kind === "gdrive" ? "Google Drive" : "Custom Cloud")}${cloudSync ? ` · ${cloudSync.ok ? "synced" : "sync error"}` : ""}` : "Local only"}
                 icon={<svg width="22" height="22" viewBox="0 0 22 22" fill="none" stroke="currentColor" strokeWidth="1.55" strokeLinecap="round" strokeLinejoin="round"><path d="M4 7.5c0-1.4 3.1-2.5 7-2.5s7 1.1 7 2.5S14.9 10 11 10 4 8.9 4 7.5Z" /><path d="M4 7.5v7c0 1.4 3.1 2.5 7 2.5s7-1.1 7-2.5v-7" /><path d="M4 11c0 1.4 3.1 2.5 7 2.5s7-1.1 7-2.5" /></svg>}
               />
+              {/* On-chain session index (plans/offchain-session-sync.md §4-5): opt-in
+                  per-wallet session list so other devices can discover sessions before
+                  any cloud storage is connected. Wallet-gated like Storage — listing
+                  costs real transactions, so a guest has nothing to toggle. */}
+              <ProgressiveMenuRow
+                reason="sync"
+                unlocked={!!state.walletAddress}
+                onUnlocked={() => { send({ type: "sessionIndex", action: "status" }); setSettingsMode("sessionsync"); }}
+                label="Session sync"
+                subtitle={state.walletAddress
+                  ? `On-chain list${state.sessionIndex ? ` · ${state.sessionIndex.enabled ? "on" : "off"}` : ""}`
+                  : "Connect a wallet to list sessions on-chain"}
+                icon={<svg width="22" height="22" viewBox="0 0 22 22" fill="none" stroke="currentColor" strokeWidth="1.55" strokeLinecap="round" strokeLinejoin="round"><path d="M9.5 12.5a3.5 3.5 0 0 0 5 0l3-3a3.5 3.5 0 0 0-5-5l-1.6 1.6" /><path d="M12.5 9.5a3.5 3.5 0 0 0-5 0l-3 3a3.5 3.5 0 0 0 5 5l1.6-1.6" /></svg>}
+              />
               <MenuRow
                 label="Market RPC"
                 subtitle={state.rpcStatus?.hasKey ? `${state.rpcStatus.network} · ${state.rpcStatus.masked}` : "Helius key recommended"}
@@ -529,6 +548,68 @@ export function Sessions({
             <SettingsSubHeader title="GitHub" onBack={() => setSettingsMode("configure")} />
             <div className="flex-1 overflow-y-auto flex flex-col gap-4">
               <ConnectGithub onDone={() => setSettingsMode(rootMode)} />
+            </div>
+          </div>
+        ) : settingsMode === "sessionsync" ? (
+          /* On-chain session index: toggle + one-shot backfill + the discovery status.
+             The consent copy below the switch carries the same "real transaction"
+             framing as the CLI's /sessionsync (opt-in, fees, signing prompts). */
+          <div className="flex flex-col h-full">
+            <SettingsSubHeader title="Session sync" onBack={() => setSettingsMode("configure")} />
+            <div className="flex-1 space-y-0.5 overflow-y-auto">
+              <button
+                onClick={() => {
+                  if (!state.sessionIndex || syncBusy) return;
+                  setSyncBusy(true);
+                  send({ type: "sessionIndex", action: state.sessionIndex.enabled ? "off" : "on" });
+                }}
+                disabled={!state.sessionIndex || syncBusy}
+                role="switch"
+                aria-checked={!!state.sessionIndex?.enabled}
+                className="flex w-full items-center gap-3.5 rounded-2xl px-2.5 py-3 text-left transition enabled:active:bg-[color:var(--an-bg-2)] disabled:cursor-not-allowed disabled:opacity-50"
+              >
+                <span className="flex h-7 w-7 shrink-0 items-center justify-center" style={{ color: state.sessionIndex?.enabled ? "var(--an-green)" : "var(--an-fg-dim)" }}>
+                  <svg width="22" height="22" viewBox="0 0 22 22" fill="none" stroke="currentColor" strokeWidth="1.55" strokeLinecap="round" strokeLinejoin="round"><path d="M9.5 12.5a3.5 3.5 0 0 0 5 0l3-3a3.5 3.5 0 0 0-5-5l-1.6 1.6" /><path d="M12.5 9.5a3.5 3.5 0 0 0-5 0l-3 3a3.5 3.5 0 0 0 5 5l1.6-1.6" /></svg>
+                </span>
+                <span className="min-w-0 flex-1">
+                  <span className="an-term-mono block text-[1.12rem] font-bold uppercase leading-tight" style={{ color: "var(--an-fg)" }}>On-chain list</span>
+                  <span className="block text-[0.72rem] leading-tight" style={{ color: "var(--an-fg-mute)" }}>
+                    {!state.sessionIndex ? "Checking…" : syncBusy ? "Working…" : state.sessionIndex.enabled ? "New sessions are listed for your other devices" : "New sessions stay unlisted"}
+                  </span>
+                </span>
+                <Toggle on={!!state.sessionIndex?.enabled} />
+              </button>
+              <p className="px-2.5 pb-1 text-[0.68rem] leading-snug" style={{ color: "var(--an-fg-mute)" }}>
+                Publishes each new session's id (never its content) so your other devices can find it. Every listing is a real Solana transaction: a small fee, and a signing prompt on web wallets. Turning it on lists your existing sessions right away.
+              </p>
+              {state.sessionIndex && (
+                <p className="an-term-mono px-2.5 pt-2 text-[11px] font-bold uppercase" style={{ color: "var(--an-fg-dim)", letterSpacing: "0.5px" }}>
+                  {`${state.sessionIndex.listed ?? 0} listed · ${state.sessionIndex.elsewhere ?? 0} on other devices${state.sessionIndex.truncated ? " · list truncated" : ""}`}
+                </p>
+              )}
+              {typeof state.sessionIndex?.written === "number" && (
+                <p className="px-2.5 pt-1 text-[0.72rem]" style={{ color: "var(--an-green)" }}>
+                  Listed {state.sessionIndex.written} session{state.sessionIndex.written === 1 ? "" : "s"} on-chain
+                </p>
+              )}
+              {state.sessionIndex?.error && (
+                <p className="px-2.5 pt-1 text-[0.72rem]" style={{ color: "var(--an-red, #e55)" }}>{state.sessionIndex.error}</p>
+              )}
+              {!!state.sessionIndex?.elsewhere && (
+                <p className="px-2.5 pt-1 text-[0.68rem] leading-snug" style={{ color: "var(--an-fg-mute)" }}>
+                  Sessions on other devices open once their storage is connected here.
+                </p>
+              )}
+              {state.sessionIndex?.enabled && (
+                <button
+                  disabled={syncBusy}
+                  onClick={() => { setSyncBusy(true); send({ type: "sessionIndex", action: "backfill" }); }}
+                  className="an-term-mono mx-2.5 mt-3 text-[11px] font-bold uppercase tracking-wide transition active:opacity-70 disabled:cursor-not-allowed disabled:opacity-40"
+                  style={{ color: "var(--an-green)", border: "1px solid color-mix(in srgb, var(--an-green) 45%, var(--an-line))", padding: "8px 12px" }}
+                >
+                  {syncBusy ? "Working" : "Backfill older sessions"}
+                </button>
+              )}
             </div>
           </div>
         ) : settingsMode === "engines" ? (

--- a/surfaces/webview/src/state/store.tsx
+++ b/surfaces/webview/src/state/store.tsx
@@ -145,6 +145,10 @@ export interface State {
   agentsLoading: boolean;
   githubStatus: { hasToken: boolean; masked?: string } | null;
   workRepoResult: { ok: boolean; count?: number; repo?: string; error?: string; at: number } | null;
+  // on-chain session index: the last `sessionIndexStatus` from the server. null until the
+  // Session sync screen first requests it (a status read hits the chain, never fetched
+  // passively). See protocol.ts for the field semantics.
+  sessionIndex: { enabled: boolean; listed?: number; elsewhere?: number; truncated?: boolean; written?: number; error?: string } | null;
   modeByCli: Record<Cli, string>;
 }
 
@@ -216,6 +220,7 @@ const initialState: State = {
   agentsLoading: false,
   githubStatus: null,
   workRepoResult: null,
+  sessionIndex: null,
   isCompacting: false,
   modeByCli: {
     claude: "acceptEdits",
@@ -633,6 +638,8 @@ function reducer(state: State, ev: Action): State {
       return state;
     case "githubStatus":
       return { ...state, githubStatus: { hasToken: ev.hasToken, masked: ev.masked } };
+    case "sessionIndexStatus":
+      return { ...state, sessionIndex: { enabled: ev.enabled, listed: ev.listed, elsewhere: ev.elsewhere, truncated: ev.truncated, written: ev.written, error: ev.error } };
     case "__loadingAgents":
       return { ...state, agentsLoading: true };
     case "__loadingAgentProfile":

--- a/surfaces/webview/src/transport/protocol.ts
+++ b/surfaces/webview/src/transport/protocol.ts
@@ -114,6 +114,11 @@ export type ClientMessage =
   | { type: "connectCloud"; kind: string; location?: string; authHeader?: string }
   | { type: "disconnectCloud" }
   | { type: "openCloud"; kind: string; location?: string }
+  // on-chain session index (plans/offchain-session-sync.md §4-5): the wallet's opt-in
+  // `mysessions` list. status reads the current state; on/off flip the per-wallet consent
+  // (each listing is a real Solana transaction; `on` also runs the one-shot backfill);
+  // backfill re-runs the catch-up for sessions created before the flip.
+  | { type: "sessionIndex"; action: "status" | "on" | "off" | "backfill" }
   // passive skill-shopping toggle (issue #21)
   | { type: "getSkillShopping" }
   | { type: "setSkillShopping"; on: boolean }
@@ -212,6 +217,11 @@ export type ServerMessage =
   | { type: "cloudSync"; status: { ok: boolean; error?: string } | null }
   | { type: "wallet"; address: string | null }
   | { type: "skillShopping"; on: boolean }
+  // answers `sessionIndex`: listed = rows the wallet published (up to the read window);
+  // elsewhere = rows with no blob on this device ("connect their storage to open");
+  // truncated = the window filled, so counts are floors; written = rows a just-run
+  // backfill paid for. A failed action sets only `enabled` (re-read from config) + `error`.
+  | { type: "sessionIndexStatus"; enabled: boolean; listed?: number; elsewhere?: number; truncated?: boolean; written?: number; error?: string }
   | { type: "approval"; req: ApprovalRequest }
   // authoritative replay of every approval still parked server-side (answers "resendApprovals")
   | { type: "approvalsSnapshot"; reqs: ApprovalRequest[] }


### PR DESCRIPTION
# The on-chain session index reaches the webview and vscode surfaces, so cross-device discovery isn't CLI-only

#146 shipped the `mysessions` on-chain index (plans/offchain-session-sync.md §4–5) with a CLI surface (`/sessionsync`) and deliberately left one decision open: *"whether the webview drawer should grow the same toggle once the CLI shape settles."* The shape settled — this PR answers that decision. The webview (browser/Android) and vscode surfaces get the same opt-in, the same consent framing, and the same status line, all through **one dispatcher round-trip** so the index policy stays in core with zero duplication. And it matters most exactly here: a phone is the archetypal "second device" the index exists for. No CLI view/layout files are touched — the CLI screens belong to the design-parity pass.

- `surfaces/webview/src/transport/protocol.ts` — two new union members: a `sessionIndex` request (`status | on | off | backfill`) and its `sessionIndexStatus` result (`enabled`, plus optional `listed` / `elsewhere` / `truncated` / `written` / `error`), each field documented at the declaration.
- `packages/core/src/chat/session.ts` — one dispatcher case beside the cloud actions, calling core's `setSessionIndex` / `backfillSessionIndex` / `sessionIndexStatus` directly. Hosts supply only the new optional `ChatEnv.signingWallet()` — the wallet that can *sign transactions*, distinct from `walletAddress()` (display): the localhost guest key signs messages, never transactions, so it returns null and the paid toggle can never reach an unsignable wallet. `on` runs the one-shot backfill (CLI parity: the list starts complete). `off` is the safety exit — config-only, confirms immediately, no chain read, so a dead RPC can never paint an error over an action that fully succeeded. A failed action reports its reason with the toggle state **re-read from config**, so the switch stays truthful. The chain work runs *off* the strictly-ordered pump (fire-and-forget, CLI parity again): `on`/`backfill` mean one real Solana transaction per unindexed session — behind a UI signing prompt per row on localhost — and awaiting that in the dispatcher would freeze every queued message (chat sends, stops, session opens) behind wallet prompts. Backfill re-entry is rejected in core, so overlapping requests fail loudly instead of double-paying.
- `surfaces/webview/src/chat/Sessions.tsx` + `store.tsx` — a wallet-gated `ProgressiveMenuRow` ("Session sync · On-chain list") in the drawer settings, matching the Storage row idiom, opening a sub-screen: toggle carrying the real-transaction consent copy (fees + signing prompts, id-only — never content, and that turning on lists existing sessions right away), one-shot "Backfill older sessions", and the "N listed · M on other devices" status line. Store gains `state.sessionIndex` + its reducer case; controls hold (`syncBusy`) until the dispatcher's echo lands.
- `packages/core/src/chat/ui/webview.ts` (the vscode-hosted webview) — a minimal "Session sync" section in the wallet menu: status line, lowercase turn on/off + backfill links, and a consent hint shown until opted in that carries the *full* disclosure the other two surfaces give — per-listing tx cost, id-only, and "turning on lists your existing sessions right away" — so `on`'s immediate one-shot backfill never surprises anyone on any surface. Hydrated on wallet-menu open (one line added to the existing `getBalance`-on-open hook), never polled — a status read hits the chain.
- Hosts: `surfaces/vscode/src/extension.ts` returns the local keypair (signs in-process — listing costs only the tx fee); `surfaces/localhost/src/index.ts` returns the *connected* wallet only, never the guest.
- `packages/core/src/chat/session.spec.ts` — a 7-test "on-chain session index" describe on the file's existing mock-transport harness: absent hook / null wallet stay silent, `status` never writes a paid row, `on` flips config and runs the one-shot backfill, `off` confirms from config with the chain dark, a failed action echoes the config-read toggle, and a hung RPC never blocks later dispatch. Also repairs the file's two stale slash-command specs (the sessions feed grew `running`, ownedSkills grew `meta` + lazy-import latency) so its suite runs green.

Verified: `tsc --noEmit` clean for core, localhost, and vscode; `session.spec.ts` + `sessionIndex.spec.ts` pass 44/44 and the full core suite passes 277/277 under `AGENTNET_NETWORK=devnet` (the specs' pinned default); all four surface builds pass (webview vite, localhost/vscode/cli tsup).

## Relates to

#146 — completes the open decision it flagged ("whether the webview drawer should grow the same toggle once the CLI shape settles"); the branch carries #146's commit beneath this one, so this PR shows two commits until #146 lands and then collapses to just the surface work (rebased or not — it merges clean either way, verified against `6ab2fb2`). Happy to hold it until #146 is decided so you're only reading one diff. Implements the cross-surface half of `plans/offchain-session-sync.md` §4–5. Deliberately stays out of the CLI screens the design-parity plan is reworking.

## Risks

**Low.** Additive protocol messages; the dispatcher case is inert unless a host supplies `signingWallet` *and* the UI sends the message. The paid-write machinery itself is #146's core layer, unchanged here — this case never writes on `status`, never touches the chain on `off`, and inherits core's re-entry/truncation/dedup guards on `on`/`backfill`. The one behavior worth naming: chain work is fire-and-forget off the dispatcher pump precisely so a slow RPC or a stack of signing prompts can't stall chat dispatch — the spec pins that with a hung-RPC test.

## Background — what & why

The index exists so a brand-new device can *learn what sessions its wallet owns* before any cloud storage is configured — and after #146, only the CLI could opt in or see "N on other devices." The devices where that discovery actually matters — a phone, a fresh vscode install — had no surface for it. One dispatcher case gives all webview-transport surfaces the identical contract without a second copy of the index policy.

## Testing — where a reviewer starts + steps

Start at the "on-chain session index" describe in `packages/core/src/chat/session.spec.ts` — it drives the real dispatcher over the mock transport with the core index API mocked, so every consent/paid-write contract is pinned at the message boundary.

1. `cd packages/core`
2. `AGENTNET_NETWORK=devnet npx vitest run src/chat/session.spec.ts src/account/sessionIndex.spec.ts` → 44/44 pass (full core suite: 277/277)
3. `npx tsc --noEmit` → clean (repeat in `surfaces/localhost`, `surfaces/vscode`)
4. Mutation check: reverting the `session.ts` case fails the two behavior-change tests; the other five guard the contracts (guest silence, status-never-writes, off-with-chain-dark, truthful error echo, hung-RPC non-blocking).
5. Consent-copy check: all three surfaces disclose the same three facts before opt-in — per-listing tx cost, id-only (never content), and that turning on backfills existing sessions immediately (React sub-screen copy, vscode `ssyncHint`, CLI `/sessionsync`).

### Code quality

Held to five rules — each verified against this diff, not asserted:

1. **No meaningless wrappers with identical input/output** — ✅ `signingWallet()` is not `walletAddress()` renamed: one is a display string, the other the transaction-capable `Wallet` or null — on localhost they *disagree* (a guest has an address but returns null here), and that disagreement is the gate. The dispatcher case calls the core index API directly; no forwarding layer was added anywhere.
2. **Scan existing functions first and reuse; never two functions with the same purpose** — ✅ the case reuses #146's core API unchanged (`setSessionIndex` / `backfillSessionIndex` / `sessionIndexStatus`); the React screen reuses `ProgressiveMenuRow` / `Toggle` / `SettingsSubHeader`; the vscode menu reuses the `wmSection` idiom and adds one line to the existing menu-open hook; the tests join the file's existing mock-transport harness. The index policy exists in exactly one place.
3. **No type variables that won't be reused; inline them** — ✅ both protocol messages are inline union members; `store.tsx`'s `sessionIndex` state is typed inline; the only type import added to `session.ts` is the existing `Wallet`.
4. **No non-essential parameters** — ✅ the request carries only `action`; every optional response field renders on at least one surface (`listed`/`elsewhere`/`truncated` on both, `written` as the backfill acknowledgment, `error` alongside the config-read `enabled` so the switch stays truthful). `signingWallet` is optional so hosts without the capability change nothing.
5. **Keep responsibilities separated; if the design feels wrong, say so** — ✅ index policy in `core/account`, the round-trip in the dispatcher, hosts supplying one capability, UIs rendering one message. Said-so: a `sessionIndex` request arriving with *no* signing wallet is silently unanswered. Safe today — I verified both UIs wallet-gate the row (the React row via `ProgressiveMenuRow`, and vscode chat panels only exist while a wallet is set) — but the invariant lives in UI gating; if a future surface un-gates it, the protocol should answer with a self-describing error instead. Flagging it rather than pretending the protocol is self-defending.

`tsc --noEmit` clean (core, localhost, vscode — the webview package's 8 TS6133 are byte-identical pre-existing on `main`; its vite build is the gate and passes) · session + sessionIndex specs 44/44, full core suite 277/277 · no regressions — the rpc/seed/dasSource/skillSource vitest failures under a default env are pre-existing on `main` and env-dependent (green under `AGENTNET_NETWORK=devnet`; without it, `seed.ts`'s mainnet flip vs stale devnet specs). Based on `main` (d6a0881) + #146's commit; merges clean.

## Evidence

| Row | Artifact |
|---|---|
| Before/After screenshots | 📎 *(attached on this PR)* webview drawer: locked "Session sync" row for guests → unlocked row → sub-screen with consent copy, toggle off→on, and the "N listed · M on other devices" line; vscode wallet menu: "Session sync" section hint (with the backfill disclosure) → status after turn-on |
| Video walkthrough (MP4) | N/A - two short click flows fully shown by the screenshots; the behavior beneath each click is spec-pinned at the message boundary |
| Backend logs | `session.spec.ts` "on-chain session index" describe 7/7 (guest silence, status-never-writes, on = consent + one-shot backfill, off-with-chain-dark, truthful error echo, hung-RPC non-blocking) + `sessionIndex.spec.ts` 14/14; full core suite 277/277 under `AGENTNET_NETWORK=devnet` |
| Frontend logs | N/A - both UIs are a pure render of the single `sessionIndexStatus` message; the only client state is `store.tsx`'s reducer case, driven end-to-end by the dispatcher spec at the transport boundary |
| Real-LLM trajectory | N/A - no agent, model, or prompt changes; protocol + dispatcher + surface wiring |
| Domain artifacts | The paid-write safety contracts are executable: `status` never writes a row, `off` completes with the chain dark, overlapping backfills are rejected in core, and a guest can never trigger a transaction. The consent copy is uniform across all three surfaces, including the immediate-backfill disclosure. The on-chain layer beneath is #146's live devnet + mainnet proofs (`writers=[owner]` enforcement, real row writes) — untouched by this PR |
