### PR TITLE
cli: insufficient-funds panel on buy confirm (design 26)

### DIFF
--- a/surfaces/cli/src/views/SkillMarket.tsx
+++ b/surfaces/cli/src/views/SkillMarket.tsx
@@ -902,22 +902,45 @@ export function SkillMarket({
   // ── confirm ────────────────────────────────────────────────────────────────
   if (stage === "confirm") {
     const card = detail?.card ?? selected;
+    // design tab 26 funding gate: know before signing whether the wallet can afford it.
+    const priceLamports = card?.price && card.price !== "0" ? Number(card.price) : 0;
+    const insufficient = balance != null && priceLamports > 0 && balance < priceLamports;
     return (
-      <Box flexDirection="column" paddingX={1} borderStyle="round" borderColor={colors.warn}>
+      <Box flexDirection="column" paddingX={1} borderStyle="round" borderColor={insufficient ? colors.err : colors.warn}>
         <Text bold color={colors.warn}>confirm purchase</Text>
         <Box marginTop={1} flexDirection="column">
           <Text>{card?.name}</Text>
           <Text dimColor>{card?.description}</Text>
           <Box marginTop={1}>
-            <Text dimColor>supply </Text><Text>×{card?.supply ?? 0}</Text>
-            <Text dimColor>   your balance </Text><Text>{sol(balance)}</Text>
+            <Text dimColor>price </Text><Text>{priceLamports ? sol(priceLamports) : "FREE"}</Text>
+            <Text dimColor>   supply </Text><Text>×{card?.supply ?? 0}</Text>
+            <Text dimColor>   your balance </Text>
+            <Text color={insufficient ? colors.err : undefined}>{sol(balance)}</Text>
           </Box>
           <Text dimColor>this signs an on-chain transaction and can't be undone</Text>
         </Box>
-        <Box marginTop={1}>
-          <Text color={colors.warn}>buy "{card?.name}"?  </Text>
-          <Text dimColor>[y] yes · [n] no</Text>
-        </Box>
+        {insufficient ? (
+          <Box marginTop={1} flexDirection="column">
+            <Band label="fund" note="INSUFFICIENT FUNDS" inverted />
+            <Text dimColor>
+              this buy needs {sol(priceLamports)}. you have {sol(balance)}.
+            </Text>
+            <Text>
+              <Text dimColor>send SOL to </Text>
+              <Text color={colors.iqCyan}>{walletAddr}</Text>
+            </Text>
+            <Box marginTop={1}>
+              <Text dimColor>fund the wallet, then </Text>
+              <Text color={colors.warn}>[y] retry</Text>
+              <Text dimColor> · [n] back</Text>
+            </Box>
+          </Box>
+        ) : (
+          <Box marginTop={1}>
+            <Text color={colors.warn}>buy "{card?.name}"?  </Text>
+            <Text dimColor>[y] yes · [n] no</Text>
+          </Box>
+        )}
       </Box>
     );
   }


### PR DESCRIPTION
Design tab **26 (Connections and Funding)** — the funding half, which is the part that maps honestly to a terminal.

The purchase confirm showed the balance but never checked it against the price, so a broke wallet only found out when the on-chain buy failed. It now compares up front:

- When `balance < price`, the confirm box turns **red** and shows the design's funding panel: `//FUND_ INSUFFICIENT FUNDS`, *'this buy needs X. you have Y.'*, and the wallet address to send SOL to, with `[y]` to retry once funded.
- The price is now shown alongside supply/balance in every confirm, not just on failure.

## Scope / honesty

The design's own `//GAP_` band states: *'github work and funding exist on mobile and vscode. the terminal has neither.'* Faithful to that:

- **Devnet airdrop** (`env.airdrop`, devnet-only, and not exposed on the CLI's `MarketApi`) is **not** faked — the address-to-fund path is the honest terminal equivalent.
- The **github-connect** row and the full unified connections screen (cloud/rpc/claude/codex rows) are out of scope here; RPC already has its own `/rpc` panel, and the rest live in the account view.

Verified: typecheck + build pass. CLI-only; reuses the shared `Band`.