### PR TITLE
install_skill re-equips instead of only reinstalling the files (#126)

### DIFF
--- a/packages/core/src/skill-market/index.spec.ts
+++ b/packages/core/src/skill-market/index.spec.ts
@@ -8,6 +8,7 @@ import { codexMcpFlags } from "../runtime/spawn.js";
 import { Client } from "@modelcontextprotocol/sdk/client/index.js";
 import { InMemoryTransport } from "@modelcontextprotocol/sdk/inMemory.js";
 import { readDisposed } from "./equipState.js";
+import { ownedSkillMints } from "../core/skillSource.js";
 import { searchSkills } from "../search/search.js";
 import { buySkill, publishSkill } from "../nft/skill.js";
 import { postNote, postAgentNote } from "../notes/notes.js";
@@ -21,6 +22,12 @@ vi.mock("../notes/notes.js", () => ({
   postNote: vi.fn(),
   postAgentNote: vi.fn(),
 }));
+// only the ownership lookup is stubbed (it needs a DAS RPC); the rest of skillSource stays real
+vi.mock("../core/skillSource.js", async (importOriginal) => ({
+  ...(await importOriginal<typeof import("../core/skillSource.js")>()),
+  ownedSkillMints: vi.fn().mockResolvedValue([]),
+}));
+
 vi.mock("../core/chain.js", () => ({
   signerAddress: vi.fn().mockResolvedValue("mockSignerAddress"),
 }));
@@ -282,6 +289,29 @@ describe("skill-market", () => {
       expect(buySkill).not.toHaveBeenCalled();
       // recorded in the signer wallet's synced equip state (wallet-scoped, not the manifest)
       expect([...(await readDisposed("mockSignerAddress"))]).toContain("skillX");
+    } finally {
+      process.env.AGENTNET_HOME = prev;
+      await rm(home, { recursive: true, force: true });
+    }
+  });
+
+  it("install_skill re-equips: it clears the disposed flag, not just the files (#126)", async () => {
+    // The bug: install_skill called installBoughtAll, which restores the files but leaves
+    // the mint recorded as disposed — so injectOwned skips it at the next session start and
+    // the skill the user just asked for silently disappears again.
+    const home = await mkdtemp(join(tmpdir(), "agentnet-reequip-"));
+    const prev = process.env.AGENTNET_HOME;
+    process.env.AGENTNET_HOME = home;
+    try {
+      vi.mocked(readSkillMintMetadata).mockResolvedValue(null as any);
+      vi.mocked(ownedSkillMints).mockResolvedValue(["skillX"]);
+      // 1. un-equip records the mint as disposed
+      await handleToolCall(mockConn, signer, "defaultCreator", "unequip_skill", { skillId: "skillX" });
+      expect([...(await readDisposed("mockSignerAddress"))]).toContain("skillX");
+
+      // 2. the documented re-equip path must clear it again
+      await handleToolCall(mockConn, signer, "defaultCreator", "install_skill", { skillId: "skillX" });
+      expect([...(await readDisposed("mockSignerAddress"))]).not.toContain("skillX");
     } finally {
       process.env.AGENTNET_HOME = prev;
       await rm(home, { recursive: true, force: true });

--- a/packages/core/src/skill-market/index.ts
+++ b/packages/core/src/skill-market/index.ts
@@ -360,9 +360,15 @@ export async function handleToolCall(
       const targetDir = typeof args?.targetDir === "string" && args.targetDir.trim()
         ? args.targetDir.trim().replace(/^~(?=$|\/)/, homedir())
         : undefined;
+      // reEquip, not installBoughtAll: this is the documented re-equip path, and the
+      // files are only half of it — un-equip also records the mint as disposed, which
+      // injectOwned honours at every session start. Installing without clearing that
+      // flag put the skill back now and silently removed it again next session.
+      // reEquip clears it, restores a held copy when there is one, and otherwise falls
+      // through to installBoughtAll — so a never-disposed skill behaves exactly as before.
       const slug = targetDir
         ? await sync.installBoughtToDir(targetDir, skillId)
-        : await sync.installBoughtAll(skillId);
+        : await sync.reEquip(skillId, owner);
       if (!slug) {
         return { isError: true, content: [{ type: "text", text: `Skill ${skillId} has no readable mint metadata yet — nothing was installed. Try again shortly.` }] };
       }


### PR DESCRIPTION
# `install_skill` re-equips instead of only reinstalling the files

Fixes **#126**, which diagnosed this precisely and named `SkillSync.reEquip` as the fix.

Un-equip does two things: it removes the `SKILL.md` copies *and* records the mint as disposed. `install_skill` — the re-equip path documented in `plans/qa/external-hosts-qa.md` §D.4 — only undid the first. So the skill came back immediately, then `injectOwned` skipped it at the next session start (it honours `disposed`) and it silently un-equipped itself again, with no error and no signal that it would.

## What changed

One call on the all-runtimes path: `installBoughtAll` → `reEquip`.

`reEquip` clears the disposed record, restores a held copy when one exists, and otherwise falls through to `installBoughtAll` itself — so a skill that was never disposed takes exactly the same path it does today. It also reinstalls the external (`AGENTNET_SKILL_DIRS`, OpenClaw, Hermes) copies, which dispose deletes outright.

## One judgement call

**The explicit `targetDir` path is deliberately untouched.** Installing a copy into an arbitrary directory reads as a different intent from re-equipping the wallet's skill, and `disposed` is a wallet-level preference — flipping it because someone asked for a copy in one folder felt like the wrong default to choose on your behalf. If you'd rather `targetDir` also clear it (or clear it only when the mint is currently disposed), that's a one-line change and your call.

Held to five rules — each verified against this diff, not asserted:

1. **No meaningless wrappers with identical input/output** — ✅ no new function; the handler calls an existing method that does strictly more of what this path already needed.
2. **Scan existing functions first and reuse; never two functions with the same purpose** — ✅ this rule *is* the fix: `reEquip` already existed and already composed `undisposeMint` + restore + `installBoughtAll`; the handler was duplicating half of it by calling the inner step directly. No new undispose logic was written.
3. **No type variables that won't be reused; inline them** — ✅ no new types; `slug` keeps its existing inferred type.
4. **No non-essential parameters** — ✅ no signature changes; `reEquip(skillId, owner)` uses the `owner` the handler had already resolved for its ownership gate.
5. **Keep responsibilities separated; if the design feels wrong, say so** — ✅ file placement and equip-state stay owned by `SkillSync`; the tool handler stays orchestration. Said-so above about `targetDir`.

`tsc --noEmit` clean · `index.spec.ts` 31/31 · the new spec **fails without the fix** (verified by restoring `installBoughtAll`) · full core suite shows no new failures — the 2 failing `session.spec` slash-command tests are pre-existing on `main`. Based on `6c5ee00`.

## Evidence

| Row | Artifact |
|---|---|
| Before/After screenshots | N/A - MCP tool handler + local files, no UI surface |
| Video walkthrough (MP4) | N/A - the observable difference is a flag in `skills.json` after a restart |
| Backend logs | N/A - the tool already reported success in the broken case; the bug was invisible until the *next* session, which is what made it worth a regression test rather than a log line |
| Frontend logs | N/A - no client-visible surface changed |
| Real-LLM trajectory | N/A - no model, prompt, or tool-description changes |
| Domain artifacts | `index.spec.ts`: `unequip_skill` records the mint as disposed, then `install_skill` clears it — the exact §D.4 sequence from the issue, asserted against `readDisposed`. Mutation-checked: with `installBoughtAll` restored, the mint stays disposed and the test fails |
