### PR TITLE
Resolve a skill's real creator for buy_skill instead of the buyer's own wallet (#125)

### DIFF
--- a/packages/core/src/skill-market/index.spec.ts
+++ b/packages/core/src/skill-market/index.spec.ts
@@ -41,6 +41,9 @@ describe("skill-market", () => {
     signer = Keypair.generate();
     vi.clearAllMocks();
     resetBlogPostRateLimitForTests();
+    // buy_skill resolves the creator from the catalog when it isn't passed (#125), so the
+    // buy tests need a catalog entry; individual tests override this where they care.
+    vi.mocked(searchSkills).mockResolvedValue([{ id: "skill1", creator: "skillCreator111" }] as any);
   });
 
   it("exposes the marketplace tool set (incl. unequip_skill and post_blog)", () => {
@@ -136,6 +139,8 @@ describe("skill-market", () => {
     // workflows + equip. Resolve it (null = plain skill, nothing to install) so the equip
     // path is a clean no-op instead of crashing on a non-promise mock.
     vi.mocked(readSkillMintMetadata).mockResolvedValue(null as any);
+    // creatorWallet omitted -> resolved from the catalog (see beforeEach). It used to fall
+    // back to the connected wallet, which the program rejects with ConstraintHasOne (#125).
     const result = await handleToolCall(mockConn, signer, "defaultCreator", "buy_skill", { skillId: "skill1" });
     expect(result.content[0].text).toContain("Purchased skill");
     expect(result.content[0].text).toContain("mockTxSig");
@@ -145,8 +150,18 @@ describe("skill-market", () => {
     expect(buySkill).toHaveBeenCalledWith(mockConn, signer, {
       skillId: "skill1",
       buyerWallet: "mockSignerAddress",
-      creatorWallet: "defaultCreator",
+      creatorWallet: "skillCreator111",
     });
+  });
+
+  it("buy_skill refuses when the creator cannot be resolved, instead of sending a doomed tx (#125)", async () => {
+    vi.mocked(readSkillMintMetadata).mockResolvedValue(null as any);
+    vi.mocked(searchSkills).mockResolvedValue([] as any); // skill not in the catalog
+    const result = await handleToolCall(mockConn, signer, "defaultCreator", "buy_skill", { skillId: "ghost1" });
+    expect(result.isError).toBe(true);
+    expect(result.content[0].text).toContain("Could not resolve the creator");
+    // the buyer's own address must never be substituted into the creator slot
+    expect(buySkill).not.toHaveBeenCalled();
   });
 
   it("should handle buy_skill errors", async () => {

--- a/packages/core/src/skill-market/index.ts
+++ b/packages/core/src/skill-market/index.ts
@@ -186,7 +186,7 @@ export const SKILL_TOOLS: { name: string; description: string; schema: z.ZodRawS
       "Purchase and equip a skill from the marketplace. Requires a prior verify_skill pass for the same skillId this session, AND the user's explicit confirmation of the spend.",
     schema: {
       skillId: z.string().describe("The base58 mint address of the skill to buy."),
-      creatorWallet: z.string().optional().describe("The wallet address of the skill creator (to receive payment). If unknown, leave undefined."),
+      creatorWallet: z.string().optional().describe("The skill creator's wallet address (receives payment). Optional: omit it and the creator is resolved from the marketplace catalog. Pass it only if you already have it from a search_skills result."),
     },
   },
   {
@@ -263,6 +263,22 @@ export function getAgentNetTools() {
 // wrapped at each call site so a closed transport never fails the tool.
 export type MarketEmit = (e: import("../chat/marketMessages.js").MarketEvent) => void;
 
+/**
+ * The wallet that published `skillId`, read from the same catalog `search_skills` serves
+ * (indexer when there's no DAS key, DAS otherwise). buy_item needs it for the program's
+ * has_one on config.creator, and it is NOT in the mint metadata — the catalog is where a
+ * caller would have gotten it anyway. Returns null when the skill isn't in the catalog,
+ * so the caller can refuse instead of sending a transaction that cannot succeed.
+ */
+async function skillCreator(conn: Connection, skillId: string): Promise<string | null> {
+  let source;
+  if (!(await loadHeliusKey())) {
+    try { source = indexerSource(getIndexerUrl()); } catch { source = undefined; }
+  }
+  const skills = await searchSkills(conn, { source }).catch(() => [] as Awaited<ReturnType<typeof searchSkills>>);
+  return skills.find((s) => s.id === skillId)?.creator ?? null;
+}
+
 export async function handleToolCall(
   conn: Connection,
   signer: SignerInput,
@@ -322,7 +338,22 @@ export async function handleToolCall(
     // Price is read from the item's on-chain config (set at publish) — the client doesn't
     // pass it, so it can't be forged. buyAndEquip is the SAME buy+install path the human UI
     // uses, so the agent's purchase is actually equipped (SKILL.md written), not just owned.
-    const creatorWallet = (args?.creatorWallet as string) || defaultCreatorWallet;
+    //
+    // The creator must be the SKILL's creator: buy_item carries it into the program's
+    // has_one on config.creator. Defaulting to the connected wallet put the BUYER there,
+    // so every buy that omitted creatorWallet — which the tool's own description invited —
+    // failed on-chain with ConstraintHasOne. Resolve it from the same catalog search_skills
+    // reads, and refuse rather than send a transaction that cannot succeed.
+    let creatorWallet = (args?.creatorWallet as string) || "";
+    if (!creatorWallet) {
+      creatorWallet = (await skillCreator(conn, skillId)) ?? "";
+      if (!creatorWallet) {
+        return {
+          isError: true,
+          content: [{ type: "text", text: `Could not resolve the creator of ${skillId} from the marketplace catalog, and the creator is required on-chain. Run search_skills to find the skill (its result includes the creator), then pass creatorWallet explicitly.` }],
+        };
+      }
+    }
     try {
       const { txSig, slug } = await new SkillSync(conn).buyAndEquip(signer, skillId, creatorWallet);
       // Mirror the UI buy: fire buyResult so the webview shows the celebration + toast even


### PR DESCRIPTION
# Resolve a skill's real creator for `buy_skill` instead of the buyer's own wallet

Fixes **#125**, which pinned the root cause exactly: `buy_item` carries the creator into the program's `has_one` on `config.creator`, but when `creatorWallet` was omitted the handler fell back to `defaultCreatorWallet` — wired to the *connected* wallet's address — so the buyer landed in the creator slot and the transaction failed with `ConstraintHasOne`. As the issue notes, the tool's own description invited exactly that omission, so in practice this blocked the buy flow for any caller that didn't thread the field through by hand.

## What changed

- **The creator is resolved, never substituted.** When `creatorWallet` isn't passed, it's read from the same catalog `search_skills` serves — the indexer when there's no Helius key, DAS when there is — using the identical source selection that handler already uses. The mint metadata doesn't carry the creator, so the catalog is where a caller would have gotten it anyway (issue option 2).
- **A skill that isn't in the catalog is refused, not guessed.** Rather than build a transaction that cannot succeed, the tool returns an actionable message pointing at `search_skills` (whose results include the creator). The buyer's own address is never placed in the creator slot again.
- **The description no longer instructs the failing behaviour** — it now says omitting the field is fine and resolves server-side, and to pass it only if you already have it from a search result.

## Judgement calls, offered rather than decided

- **The now-unused `defaultCreatorWallet` parameter is left in place.** Line 325 was its only consumer, so the issue's option 2 ("drop the parameter entirely") is the natural follow-up — but removing it touches `handleToolCall`, both server wrappers, two call sites and ~25 call sites in the existing spec. That felt like a separate, mechanical PR rather than noise inside a bug fix. Happy to do it next if you want it gone.
- **`searchSkills` is a catalog scan, not a by-mint lookup**, because no by-mint helper exists in core today. If you'd rather add one (the indexer can serve it directly), the resolution point is a single function.

## A note on the existing test

`should handle buy_skill tool call` asserted `creatorWallet: "defaultCreator"` reaching `buySkill` — i.e. it pinned the buggy default. It now asserts the resolved creator instead, and a new test covers the refusal path. Flagging that explicitly since changing an existing assertion deserves to be visible rather than buried in a diff.

Held to five rules — each verified against this diff, not asserted:

1. **No meaningless wrappers with identical input/output** — ✅ `skillCreator` isn't a pass-through: it owns the source selection, the catalog scan, the id match, and the null-on-miss contract the caller depends on.
2. **Scan existing functions first and reuse; never two functions with the same purpose** — ✅ reuses `searchSkills` + `indexerSource` + `loadHeliusKey` exactly as the `search_skills` handler does, rather than adding a second catalog path; no new fetch layer, no new dependency.
3. **No type variables that won't be reused; inline them** — ✅ no new types; the return is `Promise<string | null>` and the catalog element type is inferred from `searchSkills`.
4. **No non-essential parameters** — ✅ `skillCreator(conn, skillId)` takes only what the lookup needs; no signature changes anywhere else.
5. **Keep responsibilities separated; if the design feels wrong, say so** — ✅ resolution lives in one helper, the handler keeps orchestration, and `buySkill` still receives an explicit creator. Said-so above: leaving the dead parameter and using a full catalog scan are both deliberate, both improvable, and both yours to call.

`tsc --noEmit` clean · `index.spec.ts` 31/31 · both new/changed assertions **fail without the fix** (verified by restoring the old fallback) · full core suite shows no new failures — the 2 failing `session.spec` slash-command tests are pre-existing on `main`. Based on `6c5ee00`.

## Evidence

| Row | Artifact |
|---|---|
| Before/After screenshots | N/A - MCP tool handler, no UI surface |
| Video walkthrough (MP4) | N/A - the behaviour is a resolved argument and an on-chain outcome; covered by the logs and tests |
| Backend logs | The failure mode is the one quoted in #125: `AnchorError caused by account: config. Error Code: ConstraintHasOne`, Left = the skill's real creator, Right = the buyer's own wallet. This change makes the Left/Right match by construction; when the creator can't be found, no transaction is built at all |
| Frontend logs | N/A - no client-visible surface changed; the `buyResult` events are unchanged |
| Real-LLM trajectory | N/A - no model or prompt changes beyond the corrected tool description, which is what an agent reads before calling |
| Domain artifacts | `index.spec.ts`: with `creatorWallet` omitted, `buySkill` now receives the catalog's creator (not the connected wallet); with the skill absent from the catalog, the tool errors and `buySkill` is never called. Mutation-checked — restoring the old fallback fails both |
