### PR TITLE
Drop the bigint binding warning from the CLI's startup output (#164)

### DIFF
--- a/surfaces/cli/tsup.config.ts
+++ b/surfaces/cli/tsup.config.ts
@@ -31,6 +31,6 @@ export default defineConfig({
   // file), but this call site only uses it to fail its native-binding lookup gracefully
   // (already-tolerated: see the "bigint: Failed to load bindings" warning on every launch).
   banner: {
-    js: "#!/usr/bin/env node\nimport { createRequire as __ar_cr } from 'module';\nimport { fileURLToPath as __ar_ftp } from 'url';\nimport { dirname as __ar_dn } from 'path';\nconst require = __ar_cr(import.meta.url);\nconst exports = {};\nconst __filename = __ar_ftp(import.meta.url);\nconst __dirname = __ar_dn(__filename);",
+    js: "#!/usr/bin/env node\nimport { createRequire as __ar_cr } from 'module';\nimport { fileURLToPath as __ar_ftp } from 'url';\nimport { dirname as __ar_dn } from 'path';\nconst require = __ar_cr(import.meta.url);\nconst exports = {};\nconst __filename = __ar_ftp(import.meta.url);\nconst __dirname = __ar_dn(__filename);\nif (!process.env.AGENTNET_DEBUG) { const __ar_w = console.warn.bind(console); console.warn = (...a) => { if (typeof a[0] === 'string' && a[0].startsWith('bigint: Failed to load bindings')) return; __ar_w(...a); }; }",
   },
 });


### PR DESCRIPTION
# Drop the bigint binding warning from the CLI's startup output

Reported in #164. `bigint-buffer` `console.warn`s at module load when its native binding isn't built — harmless, it falls back to pure JS — but the line reaches the terminal on **every** command: `agentnet --version`, `agentnet doctor`, and first run. A fresh `npm i -g` therefore opens with what reads like a broken install:

```
$ agentnet --version
bigint: Failed to load bindings, pure JS will be used (try npm run rebuild?)
0.1.2
```

## Why the existing suppression can't catch it

`quietDiagnosticsToFile()` already names this exact case in its comment, and its approach is right — it just can't fire in time. It runs inside `launch()`, and ESM evaluates **every import in `index.tsx` before any of its body**; `@solana/web3.js` pulls in `bigint-buffer` during that phase, so the warning is emitted while `console.warn` is still the real one. Nothing inside the module is early enough.

## What changed

The `tsup` banner is the only code that runs before the bundle's imports, so the filter goes there — beside the `__filename` shim that exists for the *same* native-binding lookup, and whose comment already documented this warning as tolerated.

It is deliberately narrow: it drops exactly the one known string and passes everything else through, so no real warning can be swallowed, and `AGENTNET_DEBUG` keeps even this one.

Held to five rules — each verified against this diff, not asserted:

1. **No meaningless wrappers with identical input/output** — ✅ no new module or function; one guarded reassignment appended to the banner that already exists.
2. **Scan existing functions first and reuse; never two functions with the same purpose** — ✅ I first tried a side-effect module and it did **not** survive bundling (the ordering guarantee is lost once esbuild inlines it), which is exactly why this belongs in the banner rather than as a second suppression mechanism competing with `quietDiagnosticsToFile()`. That one still owns runtime diagnostics; this only covers what happens before it can exist.
3. **No type variables that won't be reused; inline them** — ✅ none; the banner is plain JS.
4. **No non-essential parameters** — ✅ no signatures touched anywhere.
5. **Keep responsibilities separated; if the design feels wrong, say so** — ✅ a build-time concern fixed at build time. Said-so: filtering a dependency's output by string match is inherently a little brittle — if `bigint-buffer` rewords its message this silently stops matching (failing open, back to today's behaviour). The alternatives are vendoring or shipping a prebuilt binding, both heavier than the problem. Your call.

`tsc --noEmit` clean · verified on the **bundled** artifact, not just `tsx` — `node dist/cli.js doctor` prints the warning on `main` and doesn't with this change, while `AGENTNET_DEBUG=1` still shows it. Based on `6c5ee00`.

## Evidence

| Row | Artifact |
|---|---|
| Before/After screenshots | N/A - terminal output, quoted in full below |
| Video walkthrough (MP4) | N/A - the change is one line of output appearing or not |
| Backend logs | **Before** (`node dist/cli.js doctor` on `main`): `bigint: Failed to load bindings, pure JS will be used (try npm run rebuild?)` then `claude: ok`. **After**: `claude: ok` first. **With `AGENTNET_DEBUG=1`**: the warning is back |
| Frontend logs | N/A - no UI surface |
| Real-LLM trajectory | N/A - build config only |
| Domain artifacts | Verified against the bundled output (`dist/cli.js`), which is what npm ships — an earlier attempt that only worked under `tsx` was discarded for exactly that reason |
