### PR TITLE
Stop a comma in an option label from splitting one answer into several

### DIFF
--- a/surfaces/vscode/src/approvalNotify.ts
+++ b/surfaces/vscode/src/approvalNotify.ts
@@ -49,6 +49,7 @@ export interface CardSurface {
 }
 
 const SENTINEL = "Write my own answer…"; // the "custom input" row in a pick list
+const SEP = "\x1f"; // unit separator — joins list selections; a label will not contain it
 
 // ── low-level: run a tool, never reject. Resolves exit code + stdout/stderr; flags a missing
 // binary (ENOENT) so Linux can fall back zenity -> kdialog -> none. An aborted run (focus came
@@ -174,13 +175,18 @@ const macPrompter: Prompter = {
     const items = options.map((o) => `"${macEsc(o.label)}"`);
     if (allowCustom) items.push(`"${macEsc(SENTINEL)}"`);
     const multiClause = multi ? " with multiple selections allowed" : "";
+    // osascript PRINTS a list ", "-joined, so a label containing ", " is indistinguishable from
+    // two selections: {"Yes, proceed", "Deny"} prints `Yes, proceed, Deny` and parses as three.
+    // Coerce to text under the unit separator instead — the same one the zenity list uses. A
+    // cancelled dialog is `false`, and `false as text` is still "false", so that check is intact.
     const r = await osa(
-      `choose from list {${items.join(", ")}} with title "AgentNet" with prompt "${macEsc(question)}"${multiClause}`,
+      `set AppleScript's text item delimiters to (ASCII character 31)\n` +
+        `return (choose from list {${items.join(", ")}} with title "AgentNet" with prompt "${macEsc(question)}"${multiClause}) as text`,
       signal,
     );
     const out = r.stdout.trim();
     if (r.code !== 0 || out === "false" || out === "") return null;
-    let selected = out.split(", ");
+    let selected = out.split(SEP).filter(Boolean);
     let text: string | undefined;
     if (allowCustom && selected.indexOf(SENTINEL) >= 0) {
       selected = selected.filter((s) => s !== SENTINEL);
@@ -199,7 +205,6 @@ const macPrompter: Prompter = {
 // execFile passes args as literal argv (no shell), so option labels need no escaping. zenity's
 // exit codes carry the answer: 0 = OK/primary; 1 = Cancel/closed OR an --extra-button (whose
 // label prints to stdout); so OK vs extra-button vs closed are all distinguishable.
-const SEP = "\x1f"; // unit separator — a list value is very unlikely to contain it
 const zenityPrompter: Prompter = {
   async askMain({ title, body, danger }, signal) {
     const r = await run(


### PR DESCRIPTION
# Stop a comma in an option label from splitting one answer into several

Found while running the **published** extension (marketplace `iqlabs.agentnet-vscode` 0.1.6, downloaded as a VSIX and installed into a clean profile), not while reading source.

`macPrompter.askChoice`'s pick-list branch reads its result with `out.split(", ")`. But osascript **prints** an AppleScript list comma-joined, so a label containing `", "` is indistinguishable from two separate selections:

```
$ osascript -e 'return {"Yes, proceed", "Deny"}'
Yes, proceed, Deny
```

That parses as **three** selections, none of which is a real option. A *single* pick breaks too - `"Yes, proceed"` comes back as `["Yes", "proceed"]`.

It matters because of where the value goes: `showPopup` returns it as `questionResponses[].selected`, and `NotifyingApprovalChannel` injects that as if the webview card had been clicked. So the agent is handed option labels the user never chose, and nothing anywhere reports an error.

`AskUserQuestion` labels are model-written, and "Yes, proceed" / "No, cancel" is an ordinary shape for them, so this isn't a contrived input.

## What changed

Coerce the result to text under the unit separator rather than letting osascript print a list:

```applescript
set AppleScript's text item delimiters to (ASCII character 31)
return (choose from list {…}) as text
```

`SEP` is the constant your zenity list already uses; it moves up beside `SENTINEL` now that two backends share it. A cancelled dialog is `false`, and `false as text` is still `"false"`, so the existing cancel check is untouched - verified, not assumed.

**Only macOS was affected.** zenity already splits on `SEP`; kdialog uses `--separate-output` and splits on newlines, which a label cannot contain there; the Windows list also splits on newlines, which `psEsc` strips out of labels. I checked the whole repo for the same shape: `split(", ")` appears exactly once, and this was it.

## Evidence

Real `osascript` runs on macOS 15 (Darwin 25.5.0), old parser vs new, same input:

| User actually selects | `main` parses as | this PR parses as |
|---|---|---|
| `["Yes, proceed", "Deny"]` | ❌ `['Yes', 'proceed', 'Deny']` | ✅ `['Yes, proceed', 'Deny']` |
| `["Yes, proceed"]` | ❌ `['Yes', 'proceed']` | ✅ `['Yes, proceed']` |
| `["x, y, z"]` | ❌ `['x', 'y', 'z']` | ✅ `['x, y, z']` |
| `["Approve", "Deny"]` | ✅ `['Approve', 'Deny']` | ✅ `['Approve', 'Deny']` |
| `["Write my own answer…"]` | ✅ (sentinel unaffected) | ✅ |
| cancelled | `false` | `false` (unchanged) |

The generated script was also syntax-checked with `osacompile` across labels containing quotes, backslashes, newlines and commas - all valid, so `macEsc` still holds under the new wrapper.

Held to five rules - each verified against this diff, not asserted:

1. **No meaningless wrappers with identical input/output** - ✅ no new function or module; one call site rewritten and one constant moved.
2. **Scan existing functions first and reuse; never two functions with the same purpose** - ✅ this is the rule that picked the fix. `SEP` already existed for the zenity list, so the macOS path now joins the same way instead of inventing a second delimiter convention. I searched the repo for other `split(", ")` uses first; there were none.
3. **No type variables that won't be reused; inline them** - ✅ no types added or changed.
4. **No non-essential parameters** - ✅ `askChoice`'s signature is untouched; the `Prompter` seam is unchanged, so the other three backends are byte-identical.
5. **Keep responsibilities separated; if the design feels wrong, say so** - ✅ the parsing fix stays inside the one backend that had the bug. Said-so, and it's the reason this PR has a table instead of a spec: **`surfaces/vscode` has no test harness at all** - no `test` script, no test devDependency, 0 spec files, while `packages/core` has 259 tests. So I verified by running the real thing and pasted the transcript. Your `Prompter` interface is already a clean injection seam and `showPopup`'s tiering (1 question → askChoice, ≥2 → route, tool → askMain/askReason loop) would test well through it. I did **not** add vitest to that package unasked - say the word and it's a separate small PR.

`tsc --noEmit` clean; `tsup` build succeeds and the change is present in the emitted `dist/extension.js`. Rebased onto and verified at `4219832`.

## Evidence table

| Row | Artifact |
|---|---|
| Before/After screenshots | N/A - the dialog is a native OS pick list; the defect is in how its result is parsed, shown as the before/after transcript above |
| Video walkthrough (MP4) | N/A - same |
| Backend logs | The `osascript` transcript above, run on macOS, both parsers against identical input |
| Frontend logs | N/A - the corrupted value is injected into the webview channel, not produced by it |
| Real-LLM trajectory | N/A - no model in the path; the trigger is any `AskUserQuestion` option label containing `", "` |
| Domain artifacts | `osacompile` syntax check of the generated AppleScript across quote/backslash/newline/comma labels; whole-repo scan confirming `split(", ")` occurred exactly once; confirmation the other three backends are unaffected |
