### PR TITLE
Bound the gateway ETag caches with an LRU

### DIFF
--- a/packages/core/src/core/chain.spec.ts
+++ b/packages/core/src/core/chain.spec.ts
@@ -160,6 +160,64 @@ describe("core/chain", () => {
       expect(secondUrl).toContain("before=cur1"); // cursor threaded into page 2
       vi.unstubAllGlobals();
     });
+
+    // One ETag entry per distinct (pda, limit, before) page, each holding a whole decoded
+    // page — so a long-lived host browsing a marketplace must not grow it forever. Both the
+    // cap and its recency order are observable from out here: a cached URL sends
+    // `If-None-Match`, an evicted one doesn't.
+    const ETAG_MAX = 200;
+    /** Stands in for the gateway: 200 + ETag on a fresh page, 304 with no body once the
+     *  client's `If-None-Match` still matches — the path the cache exists to take. */
+    const cachingFetch = () => {
+      const issued = new Map<string, string>();
+      return vi.fn().mockImplementation((url: string, init?: any) => {
+        const sent = init?.headers?.["If-None-Match"];
+        if (sent !== undefined && sent === issued.get(url)) {
+          return Promise.resolve({ ok: false, status: 304 }); // unchanged — no body
+        }
+        const etag = `etag-${issued.size}`;
+        issued.set(url, etag);
+        return Promise.resolve({
+          ok: true,
+          status: 200,
+          headers: { get: (h: string) => (h.toLowerCase() === "etag" ? etag : null) },
+          json: async () => ({ rows: [{ id: url }], nextCursor: null }),
+        });
+      });
+    };
+    /** Read the page keyed by `before`; resolves to the `If-None-Match` sent, or null on a miss. */
+    const readPage = async (fetchMock: any, before: string) => {
+      await readRows("reviews:agent:w", { limit: 1, before });
+      const init = fetchMock.mock.calls.at(-1)[1];
+      return init?.headers?.["If-None-Match"] ?? null;
+    };
+
+    it("evicts the oldest ETag entry past the cap instead of growing without bound", async () => {
+      const fetchMock = cachingFetch();
+      vi.stubGlobal("fetch", fetchMock);
+
+      for (let i = 0; i <= ETAG_MAX; i++) await readPage(fetchMock, `bound${i}`); // one over
+
+      expect(await readPage(fetchMock, `bound${ETAG_MAX}`)).toBeTruthy(); // newest still cached
+      expect(await readPage(fetchMock, "bound0")).toBeNull(); // oldest was dropped
+      // and the entry that survived still serves its rows off the 304 the gateway answered with
+      const reused = await readRows("reviews:agent:w", { limit: 1, before: `bound${ETAG_MAX}` });
+      expect(reused).toHaveLength(1);
+      vi.unstubAllGlobals();
+    });
+
+    it("evicts by least-recently-used, so a page still being polled survives", async () => {
+      const fetchMock = cachingFetch();
+      vi.stubGlobal("fetch", fetchMock);
+
+      for (let i = 0; i < ETAG_MAX; i++) await readPage(fetchMock, `lru${i}`); // exactly full
+      await readPage(fetchMock, "lru0"); // re-read the oldest — now the most recent
+      await readPage(fetchMock, "lruNew"); // one over the cap
+
+      expect(await readPage(fetchMock, "lru1")).toBeNull(); // the stale one went instead
+      expect(await readPage(fetchMock, "lru0")).toBeTruthy(); // the polled one stayed
+      vi.unstubAllGlobals();
+    });
   });
 
   describe("inscriptionSigOf / itemMetadataUri", () => {

--- a/packages/core/src/core/chain.ts
+++ b/packages/core/src/core/chain.ts
@@ -214,12 +214,40 @@ export async function writeRow(
 // Lets a re-read of the same page send `If-None-Match`; on a 304 the gateway
 // skips re-sending the body and we reuse the cached page. Turns polling loops
 // (a thread refreshing) from "re-decode every row" into "one conditional GET".
-// Unbounded is fine in practice — one entry per distinct (pda, limit, before)
-// page, and the set of live tables a session touches is small.
-// ponytail: plain Map, no LRU. Add eviction if a long-lived host ever churns
-// through thousands of tables.
+// One entry per distinct (pda, limit, before) page. A short-lived process touches few
+// tables, but a long-lived host (the localhost surface, an MCP server) keeps running while
+// a user browses the marketplace, and each entry holds a whole decoded page — so the map
+// is bounded: past ETAG_CACHE_MAX the least-recently-used entry is dropped. Eviction only
+// costs a re-fetch, because a miss sends no `If-None-Match` and the gateway answers 200
+// with a fresh body.
+const ETAG_CACHE_MAX = 200;
+
+/** Bounded LRU over the ETag caches. Map preserves insertion order, so the first key is
+ *  the oldest; re-inserting on read moves an entry to the end. Both caches want exactly
+ *  this and nothing more, so it lives here rather than as a general utility. */
+class EtagCache<V> {
+  private readonly entries = new Map<string, V>();
+
+  get(url: string): V | undefined {
+    const hit = this.entries.get(url);
+    if (hit === undefined) return undefined;
+    this.entries.delete(url); // re-insert so recency is the map's own order
+    this.entries.set(url, hit);
+    return hit;
+  }
+
+  set(url: string, value: V): void {
+    this.entries.delete(url);
+    this.entries.set(url, value);
+    if (this.entries.size > ETAG_CACHE_MAX) {
+      const oldest = this.entries.keys().next().value;
+      if (oldest !== undefined) this.entries.delete(oldest);
+    }
+  }
+}
+
 type GwPage = { rows: Row[]; nextCursor?: string | null };
-const rowsEtagCache = new Map<string, { etag: string; page: GwPage }>();
+const rowsEtagCache = new EtagCache<{ etag: string; page: GwPage }>();
 
 async function readRowsViaGateway(pda: PublicKey, options?: ReadOptions): Promise<Row[]> {
   const want = options?.limit ?? 100;
@@ -258,7 +286,7 @@ async function readRowsViaGateway(pda: PublicKey, options?: ReadOptions): Promis
 // readRowsViaGateway. Throws on any non-2xx so the caller falls back to reading
 // flat rows + grouping locally (threadReplies).
 export type GatewayThread = { op: Row; replies: Row[]; totalReplies: number };
-const threadsEtagCache = new Map<string, { etag: string; threads: GatewayThread[] }>();
+const threadsEtagCache = new EtagCache<{ etag: string; threads: GatewayThread[] }>();
 
 async function readThreadsViaGateway(pda: PublicKey, limit: number): Promise<GatewayThread[]> {
   const url = `${gatewayUrl()}/table/${pda.toBase58()}/threads?limit=${limit}`;


### PR DESCRIPTION
# Bound the gateway ETag caches with an LRU

Picks up the `ponytail` note on the cache in `core/chain.ts` (it arrived with the #101 threading-cache work in `72c6cb9`):

> `// ponytail: plain Map, no LRU. Add eviction if a long-lived host ever churns through thousands of tables.`

The comment above it says unbounded is fine because "the set of live tables a session touches is small", and for the CLI that's true: a command runs and exits. But two surfaces don't exit. The localhost server and an MCP server both stay up while a user browses the marketplace, and every distinct `(pda, limit, before)` page adds an entry that holds a **whole decoded page**, not just an ETag string. That's the case the note anticipated.

## What changed

`rowsEtagCache` and `threadsEtagCache` both become an `EtagCache<V>`, a `Map` with two extra lines. A `Map` already keeps insertion order, so the first key is the oldest; reading re-inserts, and writing past `ETAG_CACHE_MAX` (200) drops the first key.

Eviction is free in the sense that matters: a miss simply sends no `If-None-Match`, and the gateway answers 200 with a fresh body. Nothing downstream can tell the difference except by making one more request.

## Tests

Two specs, each pinning one property, both driven through the public `readRows`. Nothing reaches into module state, so the cache stays private:

- **the cap**: 201 distinct pages, then the newest still sends `If-None-Match` and the oldest doesn't
- **LRU, not FIFO**: fill to exactly 200, re-read the oldest, add one more; the re-read page survives and the one behind it is dropped

The fetch mock answers **304** when the client's `If-None-Match` still matches, which is what the gateway actually does, so this is also the first test to exercise the 304-reuse branch that has been there since #101.

Mutation-checked, both directions:

| mutation | result |
|---|---|
| (as written) | 22/22 pass |
| delete the eviction (unbounded again) | **both** new specs fail |
| delete the re-insert on read (FIFO) | only the **LRU** spec fails |

That second row is the point: a test that passed under FIFO wasn't testing recency, it was testing the cap twice. The first version of this spec did exactly that and was rewritten.

Held to five rules, each verified against this diff, not asserted:

1. **No meaningless wrappers with identical input/output** - `get`/`set` are not pass-throughs; `get` reorders and `set` evicts. I did add and then **remove** an `etagCacheSizesForTests()` export and the `size` getter behind it once the specs proved the bound from the outside; that pair would have been exactly this rule's failure case.
2. **Scan existing functions first and reuse; never two functions with the same purpose** - I searched `packages/core/src` for an existing cache/LRU/eviction helper before writing one; there is none. Both call sites use this single class rather than each growing its own eviction, which is the duplication the rule is guarding against.
3. **No type variables that won't be reused; inline them** - the one type parameter `V` is reused by both instantiations (`{etag, page}` and `{etag, threads}`), which is why it's generic rather than two classes. No new named types; `GwPage` predates this change (also from `72c6cb9`) and is untouched.
4. **No non-essential parameters** - no signature in the file changed. `EtagCache` takes no options; the cap is a module constant because nothing needs a second value, and a `max` parameter with one caller would fail this rule.
5. **Keep responsibilities separated; if the design feels wrong, say so** - the class sits next to the caches it serves rather than in a shared util, because a general-purpose LRU with one consumer is speculative. Said-so, two things. **200 is a number I picked**, sized so a marketplace browse doesn't churn while the memory stays bounded; if you have a real figure from the localhost surface, change the constant and the specs still hold. And this removes the `ponytail` marker; if those markers are tracked anywhere outside the source, say the word and I'll restore it with the resolution noted instead.

`tsc --noEmit` clean. Based on `4219832`.

On the suite, measured both ways in the same worktree so the comparison is real:

| | Test Files | Tests |
|---|---|---|
| unmodified `4219832` | 5 failed \| 38 passed | **6 failed \| 276 passed (282)** |
| this branch | 5 failed \| 38 passed | **6 failed \| 278 passed (284)** |

Exactly +2 tests, both passing, and the same 6 failures before and after. Those 6 are pre-existing and unrelated: three are `rpc.spec`/`seed.spec` asserting a devnet default while `core/seed.ts` reads `NETWORK = "mainnet"`, two are `chat/session.spec`, one is a `store` re-key spec. I haven't touched any of them. Happy to send the seed/devnet one as its own change if it's useful.

## Evidence

| Row | Artifact |
|---|---|
| Before/After screenshots | N/A - no UI surface; the change is invisible except in memory |
| Video walkthrough (MP4) | N/A - same |
| Backend logs | The suite table above: baseline 6 failed / 276 passed (282), this branch 6 failed / 278 passed (284), measured in the same worktree with plain `vitest run` and no env overrides |
| Frontend logs | N/A - no UI surface |
| Real-LLM trajectory | N/A - a cache bound, no model in the path |
| Domain artifacts | The mutation matrix above; each row was run, not reasoned about |
