### PR TITLE
Don't mark onboarding complete until a runtime actually exists

### DIFF
--- a/surfaces/vscode/src/extension.ts
+++ b/surfaces/vscode/src/extension.ts
@@ -141,14 +141,26 @@ export function activate(context: vscode.ExtensionContext) {
 // Storage model: LOCAL is always on; a CLOUD is an optional mirror you can add now
 // or later. So onboarding is shown only on the very first run (a one-time flag),
 // NOT based on whether a cloud is configured — local-only is a valid finished state.
+// boot() must never reject: it is started unawaited from activate(), from the open/new-chat
+// commands, and from the sidebar's not-yet-booted fallback paths, so a rejection here is an
+// unhandled promise and the extension simply does nothing (no panel, no error). The configured branch has two real failure modes: an
+// unreadable/invalid keypair (localWallet throws) and a saved cloud choice that no longer
+// builds (connect -> buildStorage throws, e.g. a custom endpoint with no URL). Catch both
+// HERE, once, so no call site has to. The flag is deliberately left set: a transient
+// failure must not cost a working install its straight-to-chat launch, and onboarding
+// re-arms the flag itself. Onboarding owns the retry / keep-local choice from here.
 async function boot(context: vscode.ExtensionContext) {
-  const seen = context.globalState.get<boolean>("onboarded");
-  if (seen) {
-    wallet = (await localWallet()).wallet;
-    runtime = await connect(wallet, cloudStatusCb); // local always works; mirrors cloud if connected
-    openChat(context);
-  } else {
-    openOnboarding(context);
+  try {
+    if (context.globalState.get<boolean>("onboarded")) {
+      wallet = (await localWallet()).wallet;
+      runtime = await connect(wallet, cloudStatusCb); // local always works; mirrors cloud if connected
+      openChat(context);
+    } else {
+      openOnboarding(context);
+    }
+  } catch (e) {
+    vscode.window.showErrorMessage(`Couldn't start AgentNet: ${errorMessage(e)}`);
+    openOnboarding(context); // always a way forward, never a silent no-op
   }
   void refreshSidebar(); // reflect wallet/session state (or the onboard CTA) in the sidebar
 }
@@ -299,38 +311,52 @@ function openOnboarding(context: vscode.ExtensionContext) {
   );
   panel.webview.html = onboardingHtml();
 
-  // Finish onboarding → mark seen, build runtime (local always; cloud if `cfg`), go to chat.
-  // Cloud connect can fail (missing Google client id, cancelled OAuth, network). We must NOT
-  // silently demote the user's cloud choice to local-only — cloud-vs-local is a choice they
-  // made in the UI, not ours to override on error. So on failure surface it and let THEM pick:
-  // retry, or explicitly keep local. Dismissing leaves them in onboarding (panel stays; never
-  // freeze, never auto-decide). Only a clean cloud connect — or no cloud chosen — proceeds.
-  // (A throwing initialize(), not the RPC key, was the original "stuck on the Helius screen":
-  // storage + rpc submit as one message, so it froze the last screen; that freeze is gone.)
-  // The RPC key is saved fire-and-forget so a slow/failing write can't gate entry, and lands
-  // before connect() so the market's first RPC read sees it.
+  // Finish onboarding → build runtime (local always; cloud if `cfg`), mark seen, go to chat.
+  // Setup can fail (missing Google client id, cancelled OAuth, network, a custom endpoint
+  // with no URL). We must NOT silently demote the user's cloud choice to local-only —
+  // cloud-vs-local is a choice they made in the UI, not ours to override on error. So on
+  // failure surface it and let THEM pick: retry, or explicitly keep local. Dismissing leaves
+  // them in onboarding (panel stays; never freeze, never auto-decide).
+  // initialize() and connect() are ONE attempt under ONE try: initialize only validates and
+  // persists the choice, connect is what actually builds the backend, so a config that
+  // initialize accepts (any `custom` location, including "") can still throw one line later.
+  // connect() outside the try was the permanent strand: the seen flag was already written,
+  // so the panel hung AND every later launch re-took boot()'s configured branch and died the
+  // same way, with ~/.agentnet/config.json the only way out. The flag is now written only
+  // once a runtime exists, which is the only thing it was ever meant to claim.
+  // The RPC key is saved fire-and-forget so a slow/failing write can't gate entry, and it is
+  // issued BEFORE the awaited connect() so that connect's own round-trips are the window the
+  // write lands in (b22dd96's ordering). Saving it before setup succeeds is independent of the
+  // storage choice, and the "maybe later" path already saves it unconditionally.
   async function finish(cfg?: StorageConfig, heliusKey?: string) {
-    if (cfg) {
-      try {
-        await initialize(cfg, openExternal); // connect a cloud mirror (interactive for gdrive)
-      } catch (e) {
-        const RETRY = "Retry cloud connect";
-        const LOCAL = "Keep on this device only";
-        const pick = await vscode.window.showErrorMessage(
-          `Cloud connect failed: ${errorMessage(e)}`, { modal: true }, RETRY, LOCAL,
-        );
-        if (pick === RETRY) return finish(cfg, heliusKey); // re-attempt the same choice
-        if (pick !== LOCAL) return; // dismissed → stay in onboarding, do NOT auto-local
-        // else: user explicitly chose local-only → fall through and finish local
-      }
-    }
-    await context.globalState.update("onboarded", true);
     const key = heliusKey?.trim();
     if (key) void saveHeliusKey(key).catch((e) =>
       vscode.window.showWarningMessage(
         `Couldn't save the Marketplace RPC key: ${errorMessage(e)}. Add it later from the wallet menu → RPC.`,
       ));
-    runtime = await connect(wallet!, cloudStatusCb);
+    try {
+      if (cfg) await initialize(cfg, openExternal); // record the choice (interactive for gdrive)
+      runtime = await connect(wallet!, cloudStatusCb); // builds the cloud adapter: can throw
+    } catch (e) {
+      const RETRY = "Retry";
+      const LOCAL = "Keep on this device only";
+      const pick = await vscode.window.showErrorMessage(
+        `Couldn't finish setup: ${errorMessage(e)}`, { modal: true }, RETRY, LOCAL,
+      );
+      if (pick === RETRY) return finish(cfg, heliusKey); // re-attempt the same choice
+      if (pick !== LOCAL) return; // dismissed → stay in onboarding, do NOT auto-local
+      // Explicit local-only. The failing cloud choice may already be on disk (initialize
+      // persisted it, or it was there before), and connect() reads it back regardless of
+      // `cfg` — so drop it, then finish through the exact path the "maybe later" button
+      // takes. This is also what un-bricks an install already stranded by the old flow.
+      // Guarded: this runs inside the webview message handler, whose promise nobody awaits,
+      // so a throw here would strand the panel again — the very bug this change removes.
+      await disconnectCloud().catch((err) =>
+        vscode.window.showWarningMessage(`Couldn't clear the saved cloud choice: ${errorMessage(err)}`),
+      );
+      return finish(undefined, heliusKey);
+    }
+    await context.globalState.update("onboarded", true);
     panel.dispose();
     openChat(context);
   }


### PR DESCRIPTION
# Don't mark onboarding complete until a runtime actually exists

`finish()` writes `globalState "onboarded" = true` and then calls `connect()` outside the try. When `connect()` throws, the onboarding panel never disposes, chat never opens, nothing is shown, and because the flag is already set every later launch takes `boot()`'s configured branch and throws the same way. Deleting `~/.agentnet/config.json` by hand is the only exit.

It is reachable by clicking, not by contrivance: on the storage screen choose **Custom (S3 / WebDAV / HTTP)**, leave the URL box blank (nothing validates it), then finish the RPC screen. `initialize()` accepts the config because it only records the choice; `connect()` throws one line later building the adapter.

## What changed

`initialize()` and `connect()` now sit under one try, and the flag is written only once a runtime exists, which is the only thing it ever claimed. That ordering is the whole fix.

The failure path reuses the modal you wrote in `8fa5454` rather than inventing new error UI: **Retry**, or **Keep on this device only**, which drops the saved cloud choice and finishes local. Dismissing leaves the user in onboarding. That local branch also un-bricks an install already stranded by the old flow, since it clears the config that `connect()` keeps reading back.

`boot()` gets a catch once rather than at its call sites. It is started unawaited from `activate()`, from the open/new-chat commands, and from the sidebar's not-yet-booted fallback paths (seven call sites in all), so a throw was an unhandled rejection and the extension simply did nothing: no panel, no error. It now reports and reopens onboarding. The flag is deliberately left set there, so a transient failure does not cost a working install its straight-to-chat launch.

Two smaller things, both deliberate:

- The RPC key write stays where `b22dd96` put it, issued **before** the awaited `connect()`, so connect's own round-trips remain the window it lands in. An earlier draft of this change let it slide below `connect()`, which silently removed that window; the comment now describes what the code actually guarantees rather than more.
- `disconnectCloud()` in the catch is guarded. It runs inside the webview message handler, whose promise nobody awaits, so an unwritable `~/.agentnet` would have rejected there and stranded the panel again, which is the exact bug this removes.

Held to five rules, argued against this diff:

1. **No meaningless wrappers with identical input/output** - no new function, module, or indirection. The change is where two existing calls sit relative to a `try` and one flag write.
2. **Scan existing functions first and reuse; never two functions with the same purpose** - the error path reuses your `8fa5454` modal and the existing `finish(undefined, ...)` local path rather than adding a second recovery flow. I checked whether `boot`'s call sites each needed a catch; they do not, one in `boot` covers all seven.
3. **No type variables that won't be reused; inline them** - none added.
4. **No non-essential parameters** - no signature changed. `finish` keeps its two parameters and recurses with them.
5. **Keep responsibilities separated; if the design feels wrong, say so** - said so, two things. First, **this fixes the VS Code symptom, not the root cause.** The onboarding panel can still persist `{kind:"custom", location:""}`, and the CLI hits the same dead end from that config with no recovery path. The real fix is probably rejecting a blank `custom` location in the validate-before-write guard in `login.ts`, beside the storage-kind check. I kept it out of this PR because it is a different surface and a different responsibility, but say the word and it is a two-line follow-up. Second, **Retry recurses rather than loops.** Depth is bounded by how many times a human clicks a modal, so it cannot spin, but a `while` would be the honest shape if you would rather have it.

`tsc --noEmit` clean on the vscode surface, `tsup` builds. Core suite unchanged at **6 failed | 276 passed (282)**, identical to unmodified `4219832` (the 6 are pre-existing: 3 rpc/seed devnet-vs-mainnet, 2 chat/session, 1 store re-key).

## Evidence

| Row | Artifact |
|---|---|
| Before/After screenshots | N/A - the defect is the absence of UI. Before: nothing renders and no error appears. After: a modal with Retry / Keep on this device only |
| Video walkthrough (MP4) | N/A - same |
| Backend logs | Typecheck 0 errors; `tsup` build success; core suite 6 failed / 276 passed, matching baseline exactly |
| Frontend logs | N/A - no webview code changed |
| Real-LLM trajectory | N/A - onboarding path, no model involved |
| Domain artifacts | Reachability traced by hand through `initialize()` to `buildStorage()` for a blank `custom` location; all seven of `boot()`'s unawaited call sites enumerated (activate, two commands, four sidebar fallbacks) to confirm one catch covers them |
