### PR TITLE
Reopen the keypair the user picked, instead of falling back to the Solana default

### DIFF
--- a/surfaces/vscode/src/extension.ts
+++ b/surfaces/vscode/src/extension.ts
@@ -144,7 +144,12 @@ export function activate(context: vscode.ExtensionContext) {
 async function boot(context: vscode.ExtensionContext) {
   const seen = context.globalState.get<boolean>("onboarded");
   if (seen) {
-    wallet = (await localWallet()).wallet;
+    // Reopen the SAME keypair the user picked in onboarding. Without the stored path this
+    // fell back to the Solana CLI default, which either generated a brand new wallet or
+    // adopted the developer's personal key — a different address, so every session page
+    // (encrypted to the wallet) stopped decrypting and was skipped. Never onboarded on
+    // this machine → undefined → localWallet keeps its own default.
+    wallet = (await localWallet(context.globalState.get<string>("keypairPath"))).wallet;
     runtime = await connect(wallet, cloudStatusCb); // local always works; mirrors cloud if connected
     openChat(context);
   } else {
@@ -346,8 +351,14 @@ function openOnboarding(context: vscode.ExtensionContext) {
         break;
       case "connectWallet": {
         try {
-          const r = await localWallet(m.path); // load AT path; create only if missing
+          // The webview path box is plain text with no shell, so a typed "~/keys/id.json"
+          // arrives literally and node would make a directory actually named "~". Expand it
+          // the way install_skill already expands a user-typed targetDir.
+          const r = await localWallet(m.path.replace(/^~(?=$|\/)/, homedir()));
           wallet = r.wallet;
+          // Remember the RESOLVED path so the next launch reopens this exact keypair
+          // instead of falling back to the Solana CLI default (see boot).
+          await context.globalState.update("keypairPath", r.path);
           panel.webview.postMessage({
             type: "walletConnected",
             address: r.address,


### PR DESCRIPTION
# Reopen the keypair the user picked, instead of falling back to the Solana default

Onboarding lets the user type any keypair path. `finish()` uses it once, `const r = await localWallet(m.path)`, and never records it. On the next launch `boot()` calls `localWallet()` with no argument, and `localWallet(path?)` resolves an absent argument to `solanaDefaultKeypairPath()`. `grep` for `globalState` in `extension.ts` finds only the `onboarded` key, and the extension contributes no configuration, so nothing else holds it either.

Two outcomes, both silent, and the second is the common one:

- **Default path empty**: a brand new keypair is generated and written there unprompted. Different address.
- **Default path already holds a Solana CLI key**, which is true on most developer machines: that unrelated personal key is loaded and becomes the agent wallet. Different address, and a key that may hold real funds is now the agent identity without anyone asking.

Either way the session key changes, because it is derived from the wallet. Previously saved pages then fail to decrypt and are skipped without an error, by design, at `store.ts:337-341`:

```
// A page encrypted with a DIFFERENT wallet key (e.g. after reconnecting a new keypair)
// can't be decrypted; skip it instead of failing the whole list
```

So the user comes back to an app with no chat history and no visible skill ownership, having done nothing. The onboarding copy promises the opposite: *"This keypair is your wallet. The same wallet = the same key that decrypts your sessions on any device."*

The keypair FILE is never overwritten. It is simply never read again, so the wallet is recoverable by re-entering the path.

## What changed

Three lines of behaviour in one file.

`boot()` passes the stored path through: `localWallet(context.globalState.get<string>("keypairPath"))`. No new parameter is needed because `localWallet(path?)` already takes an optional path and already falls back to the default on `undefined`, so a stored-or-missing value flows straight in and a machine that never onboarded behaves exactly as before.

The `connectWallet` handler records `r.path`, the RESOLVED path from the load, rather than the raw typed string, so what gets stored is exactly what was opened.

It also expands a leading `~`. The webview path box is plain text with no shell, so a typed `~/keys/id.json` arrives literally and node would create a directory actually named `~`. This mirrors the expansion `install_skill` already does on a user-typed target directory.

Held to five rules, argued against this diff:

1. **No meaningless wrappers with identical input/output** - no function added. One value stored, one value read back.
2. **Scan existing functions first and reuse; never two functions with the same purpose** - reuses `localWallet`'s existing optional-path parameter and its existing default fallback rather than adding a resolver; reuses the `globalState` mechanism already used for `onboarded`; and reuses the `~` expansion approach already used for skill install targets rather than inventing a path helper.
3. **No type variables that won't be reused; inline them** - none added. `LoadResult.path` already existed and is now simply used.
4. **No non-essential parameters** - no signature changed anywhere.
5. **Keep responsibilities separated; if the design feels wrong, say so** - said so, two things. First, **a stored path can go stale**: the file could be moved or deleted between launches, and `loadOrCreateWallet` throws on an invalid keypair. In `boot()` that throw is currently unguarded, so this fix is safest alongside the onboarding-strand PR, which adds that catch. Standalone it is still strictly better than today, because today's fallback is silent and wrong rather than loud. Second, **this stores the path per machine, not per wallet.** If you would rather it live in `~/.agentnet/config.json` so every surface reopens the same keypair rather than just VS Code, that is a different and probably better design, and I would rather you pick it than assume it.

`tsc --noEmit` clean, `tsup` builds. Core suite unchanged at **6 failed | 276 passed (282)**, identical to unmodified `4219832`.

## Evidence

| Row | Artifact |
|---|---|
| Before/After screenshots | N/A - the defect is an address changing between launches, quoted below as a run record |
| Video walkthrough (MP4) | N/A - same |
| Backend logs | Sandboxed repro against the real source with `HOME` overridden, both branches. Empty default: `[launch 1] address = ACgQPH3P... created = true` then `[launch 2] address = 4kwy49jV... created = true` (`same wallet across launches? false`). Populated default: `[launch 2] address = fMJUu9NU... created = false`, i.e. the pre-existing personal key silently adopted. The onboarded file was verified intact in both runs |
| Frontend logs | N/A - no webview code changed |
| Real-LLM trajectory | N/A - onboarding path, no model involved |
| Domain artifacts | `~/.config/solana/id.json` confirmed present on a normal dev machine, which is why the adopt-a-personal-key branch is the common case rather than the rare one. The real default-path key was never written to during testing |
