### PR TITLE
Ask resolveRpcUrl whether a DAS RPC is live instead of re-deciding in hasDasRpc

### DIFF
--- a/packages/core/src/core/rpc.spec.ts
+++ b/packages/core/src/core/rpc.spec.ts
@@ -69,6 +69,18 @@ describe("core/rpc — resolveRpcUrl priority", () => {
     expect(await hasDasRpc()).toBe(false);
   });
 
+  it("hasDasRpc follows the env RPC a dead key falls back to (it must agree with resolveRpcUrl)", async () => {
+    // The regression: a PRESENT but dead key used to short-circuit the env check, so the
+    // market showed "add a Helius key" while every read was already served by a working
+    // DAS-capable env RPC (and codex lost the whole MCP server via runtime's hasDasRpc gate).
+    process.env.DAS_RPC_URL = "https://das.example/rpc";
+    vi.stubGlobal("fetch", vi.fn().mockResolvedValue({ json: async () => ({ error: { code: -32401, message: "Unauthorized" } }) }));
+    const { hasDasRpc, saveHeliusKey, resolveRpcUrl } = await import("./rpc.js");
+    await saveHeliusKey("DEADKEYCCCC"); // distinct key = distinct URL = its own probe entry
+    expect(await resolveRpcUrl()).toBe("https://das.example/rpc"); // reads DO go to the env RPC
+    expect(await hasDasRpc()).toBe(true); // so the status must not claim there is none
+  });
+
   it("maskedHeliusKey shows only the last 4 chars (null when no key)", async () => {
     const { maskedHeliusKey, saveHeliusKey } = await import("./rpc.js");
     expect(await maskedHeliusKey()).toBeNull();

--- a/packages/core/src/core/rpc.ts
+++ b/packages/core/src/core/rpc.ts
@@ -121,15 +121,13 @@ export async function resolveRpcUrl(): Promise<string> {
   return (await heliusKeyWorks(url)) ? url : fallback;
 }
 
-/** Whether a DAS-capable RPC is actually ANSWERING — not merely configured. A stored Helius
- *  key must PASS the probe (a rejected / allowlist-blocked key silently degrades to the public
- *  RPC, which serves no DAS), or an explicit env RPC the operator set on purpose. This drives
- *  the market's "DAS ready" status, so it must reflect reality, not key presence. The probe is
- *  shared/cached with resolveRpcUrl (same URL), so this adds no extra round-trip in practice. */
+/** Whether a DAS-capable RPC is actually ANSWERING — not merely configured. Derived from the
+ *  ONE resolver above instead of re-deciding here: everything except the bare public default
+ *  (a probed-live Helius key, or an explicit env RPC) is the DAS path, so this is true exactly
+ *  when resolveRpcUrl did NOT land on the public fallback, and the two can never disagree.
+ *  Same cost: the probe is cached per URL, so this adds no extra round-trip. */
 export async function hasDasRpc(): Promise<boolean> {
-  const helius = await loadHeliusKey();
-  if (helius) return heliusKeyWorks(heliusUrl(helius.api_key));
-  return !!(process.env.DAS_RPC_URL || process.env.SOLANA_RPC_URL);
+  return (await resolveRpcUrl()) !== getPublicRpcUrl();
 }
 
 /** A masked view of the stored key for the UI: only the last 4 chars, rest dotted.


### PR DESCRIPTION
# Ask resolveRpcUrl whether a DAS RPC is live instead of re-deciding in hasDasRpc

`hasDasRpc()` re-decides what `resolveRpcUrl()` already decided, and the two can disagree. A stored Helius key that fails the probe makes `hasDasRpc()` return early with false, short-circuiting the env check, while `resolveRpcUrl()` falls back to `DAS_RPC_URL`/`SOLANA_RPC_URL` and serves every read from that working DAS-capable endpoint. Result: the market shows the "add a Helius key" empty state while the market actually works, and on codex the runtime's `hasDasRpc` gate silently drops the whole AgentNet MCP server.

The combination is ordinary: a key that expires, hits an IP allowlist, or is just briefly unreachable during the 5s probe, on a machine where an operator set an env RPC on purpose.

## What changed

`hasDasRpc()` becomes a derivation of the resolver: true exactly when `resolveRpcUrl()` did not land on the bare public fallback. Everything except that fallback (a probed-live Helius key, or an explicit env RPC) is the DAS path, so the status and the reads can never disagree again. Same cost: identical calls, and the probe is cached per URL, so no extra round-trip.

A spec pins the regression and is mutation-checked: with `rpc.ts` reverted to main it fails (`hasDasRpc` claims false while `resolveRpcUrl` returns the env RPC), with this change it passes. Suite: 9/9 in `rpc.spec.ts`; full core suite unchanged at 6 failed | 276 passed (282), identical failed set to unmodified `4219832`.

Held to five rules, argued against this diff:

1. **No meaningless wrappers with identical input/output** - a function body shrank to one expression; nothing new wraps anything.
2. **Scan existing functions first and reuse; never two functions with the same purpose** - this is the rule that IS the fix: two functions were independently deciding "is there a DAS RPC", and now one decides and the other asks it.
3. **No type variables that won't be reused; inline them** - none added.
4. **No non-essential parameters** - no signature changed.
5. **Keep responsibilities separated; if the design feels wrong, say so** - the resolver keeps owning resolution; the status function stops duplicating it. Said-so: `getPublicRpcUrl()` comparison assumes the public URL is never itself DAS-capable, which is true for the two configured defaults; if a DAS-capable public default ever ships, this reads false-negative and the constant comparison should become a flag on the resolver.

## Evidence

| Row | Artifact |
|---|---|
| Before/After screenshots | N/A - status-plumbing change; the visible symptom is the market empty state described above |
| Video walkthrough (MP4) | N/A - same |
| Backend logs | Mutation run: reverted `rpc.ts` fails the new spec (1 failed / 8 passed), fixed passes 9/9; full suite 6 failed / 276 passed matching baseline |
| Frontend logs | N/A - no UI change; the UI consumes the corrected boolean |
| Real-LLM trajectory | N/A - no model in the path |
| Domain artifacts | The failure combination verified from code at `4219832`: dead-key early return vs resolver env fallback, and the codex MCP gate in `runtime/index.ts` that consumes it |
