### PR TITLE
Document .vsix packaging from source and rebuild dist on package

### DIFF
--- a/install-guide/vscode.md
+++ b/install-guide/vscode.md
@@ -113,6 +113,30 @@ In VS Code (Marketplace install) or the Extension Development Host window (sourc
 
 ---
 
+## Optional — (from source) package a .vsix
+
+To install your own build into your real VS Code (instead of the Extension Development
+Host), or to cut a Marketplace release, package the extension from `surfaces/vscode`:
+
+```bash
+cd surfaces/vscode
+npx @vscode/vsce package --no-dependencies
+code --install-extension agentnet-vscode-<version>.vsix
+```
+
+`--no-dependencies` is required, not optional. Without it `vsce` shells out to
+`npm list --production --parseable --depth=99999` to walk the dependency tree, npm cannot
+read this pnpm workspace's symlinked layout, and packaging dies with
+`npm error code ELSPROBLEMS`. Skipping the walk is safe here because nothing from
+`node_modules` ships: tsup inlines the core SDK into `dist/`, and `.vscodeignore` keeps the
+`.vsix` down to `dist/` plus `media/`.
+
+Packaging runs the `vscode:prepublish` script first, so `dist/` is always rebuilt from the
+current source and the `.vsix` can never carry a stale bundle. The `.vsix` itself is
+gitignored; rebuild it rather than committing it.
+
+---
+
 ## Optional — cloud session sync
 
 Sessions are stored locally by default. To sync them across devices you can connect a

--- a/surfaces/vscode/package.json
+++ b/surfaces/vscode/package.json
@@ -91,6 +91,7 @@
     }
   },
   "scripts": {
+    "vscode:prepublish": "npm run build",
     "build": "tsup",
     "watch": "tsup --watch"
   },


### PR DESCRIPTION
# Document .vsix packaging from source and rebuild dist on package

Two gaps for anyone cutting or testing an extension build from source.

**`vsce package` fails outright on this repo.** Its npm dependency walk (`npm list --production --parseable --depth=99999`) cannot read the pnpm workspace's symlinked layout and dies with `npm error code ELSPROBLEMS` (reproduced from a clean checkout). The working invocation is `--no-dependencies`, and it was recorded nowhere. The install guide now documents it, and why skipping the walk is safe here: tsup inlines the core SDK into `dist/`, and `.vscodeignore` keeps the package to `dist/` plus `media/`, so nothing from `node_modules` ships.

**vsce never rebuilt.** It catches a MISSING `dist/` but not a STALE one, and `dist/` is gitignored, so a release cut without a manual build ships whatever bundle happens to be on disk. The standard `vscode:prepublish` hook now runs the existing build script, so packaging always rebuilds from current source.

25 added lines, no workflow or CI changes.

Held to five rules, argued against this diff:

1. **No meaningless wrappers with identical input/output** - one script line and one doc section; no code.
2. **Scan existing functions first and reuse; never two functions with the same purpose** - `vscode:prepublish` invokes the existing `build` script rather than restating the tsup invocation, and the doc lives in the existing `install-guide/vscode.md` rather than a new file.
3. **No type variables that won't be reused; inline them** - none.
4. **No non-essential parameters** - none.
5. **Keep responsibilities separated; if the design feels wrong, say so** - said-so: `vscode:prepublish` runs on every `vsce package`, so packaging gets a few seconds slower in exchange for never shipping a stale bundle. If you prefer fast repacks for local iteration, `vsce package --no-dependencies --skip-license` with a manual build is unchanged; the hook only guards the path a release actually takes.

## Evidence

| Row | Artifact |
|---|---|
| Before/After screenshots | N/A - build tooling and docs |
| Video walkthrough (MP4) | N/A - same |
| Backend logs | The ELSPROBLEMS failure reproduced in a clean checkout without `--no-dependencies` (hundreds of `missing:` lines ending in `invalid: @iqlabs-official/agent-sdk@0.0.1`); with `--no-dependencies` the package succeeds and the produced `.vsix` matches the shipped 0.1.6 layout (12 files, no source maps, no `node_modules`) |
| Frontend logs | N/A |
| Real-LLM trajectory | N/A |
| Domain artifacts | The published marketplace 0.1.6 VSIX was compared against a from-source package earlier in this QA pass; the `mcp-stdio.js` entry was verified functionally identical |
