### PR TITLE
Stay silent on market requests when the env lacks the capability

### DIFF
--- a/packages/core/src/chat/session.spec.ts
+++ b/packages/core/src/chat/session.spec.ts
@@ -452,6 +452,91 @@ describe("chat/session — slash commands", () => {
   });
 });
 
+// Market requests fan out to EVERY recv on the transport (localhost POST). When the env
+// lacks a market capability, some surface's own handler (attachMarketHandlers) owns the
+// answer — so the dispatcher must stay SILENT, exactly like buySkill always did. The old
+// code answered anyway (searchResults [], ownedSkills [], balance null, agents []), and
+// whichever reply landed last won: the empty one could wipe the real catalog in the store.
+describe("chat/session — market requests stay silent when env lacks the capability", () => {
+  // Poll for a reply of `type` — some answers await a slow dynamic import (ownedSkillsMsg
+  // pulls in skillSource, ~400ms cold), so a fixed flush races it the same way
+  // waitForNotice explains for /init. 5ms ticks give a ~2s budget under full-suite load.
+  const waitForType = async (transport: any, type: string) => {
+    for (let i = 0; i < 400; i++) {
+      const hit = transport.send.mock.calls.find((c: any[]) => c[0]?.type === type);
+      if (hit) return hit[0];
+      await new Promise((r) => setTimeout(r, 5));
+    }
+    throw new Error(`"${type}" was never sent`);
+  };
+  // Prove SILENCE deterministically: the pump drains the queue serially, so queueing a
+  // "wallet" probe behind the market request and waiting for its answer guarantees the
+  // market case ran to completion — only then is "no reply" meaningful.
+  const silentAfter = async (fromUI: any, transport: any, req: any, replyType: string) => {
+    fromUI(req);
+    fromUI({ type: "wallet" });
+    await waitForType(transport, "wallet");
+    expect(transport.send.mock.calls.some((c: any[]) => c[0]?.type === replyType)).toBe(false);
+  };
+
+  it("searchSkills: no searchResults reply without env.searchSkills", async () => {
+    const { fromUI, transport } = harness();
+    await silentAfter(fromUI, transport, { type: "searchSkills", query: "solana" }, "searchResults");
+    expect(transport.send.mock.calls.some((c: any[]) => c[0]?.type === "searchError")).toBe(false);
+  });
+
+  it("searchSkills: still answers when env.searchSkills exists", async () => {
+    const card = { id: "m1", name: "clean-code" };
+    const { fromUI, transport } = harness({ env: { searchSkills: async () => [card] } });
+    fromUI({ type: "searchSkills", query: "clean" });
+    expect(await waitForType(transport, "searchResults")).toEqual({ type: "searchResults", results: [card] });
+  });
+
+  it("ownedSkills: no ownedSkills reply without env.ownedSkills/ownedNftSkills", async () => {
+    const { fromUI, transport } = harness();
+    await silentAfter(fromUI, transport, { type: "ownedSkills" }, "ownedSkills");
+  });
+
+  it("ownedSkills: still answers when the env exposes an owned view", async () => {
+    const { fromUI, transport } = harness({ ownedSkills: ["clean-code"] });
+    fromUI({ type: "ownedSkills" });
+    expect(await waitForType(transport, "ownedSkills")).toEqual(
+      expect.objectContaining({ type: "ownedSkills", names: ["clean-code"] }),
+    );
+  });
+
+  it("getBalance: no balance reply without env.solBalance", async () => {
+    const { fromUI, transport } = harness();
+    await silentAfter(fromUI, transport, { type: "getBalance" }, "balance");
+  });
+
+  it("getBalance: still answers when env.solBalance exists", async () => {
+    const { fromUI, transport } = harness({ env: { solBalance: async () => 42 } });
+    fromUI({ type: "getBalance" });
+    expect(await waitForType(transport, "balance")).toEqual({ type: "balance", lamports: 42 });
+  });
+
+  it("listAgents: no agents reply without env.listAgents", async () => {
+    const { fromUI, transport } = harness();
+    await silentAfter(fromUI, transport, { type: "listAgents" }, "agents");
+  });
+
+  it("listAgents: still answers when env.listAgents exists", async () => {
+    const agent = { wallet: "w1", name: "luna" };
+    const { fromUI, transport } = harness({ env: { listAgents: async () => [agent] } });
+    fromUI({ type: "listAgents" });
+    expect(await waitForType(transport, "agents")).toEqual({ type: "agents", agents: [agent] });
+  });
+
+  it("/skills: no ownedSkills reply on a surface whose env lacks the owned view", async () => {
+    const { fromUI, transport } = harness();
+    fromUI({ type: "slashCommand", command: "skills" });
+    fromUI({ type: "wallet" });
+    await waitForType(transport, "wallet");
+    expect(transport.send.mock.calls.some((c: any[]) => c[0]?.type === "ownedSkills")).toBe(false);
+  });
+});
+
 // A throwing handler used to escape the pump as an unhandled rejection and take the whole
 // host process down (issue #150 B1: connectCloud without Google creds). The dispatcher must
 // survive it, keep draining the queue, and tell the client its action failed.

--- a/packages/core/src/chat/session.ts
+++ b/packages/core/src/chat/session.ts
@@ -515,7 +515,9 @@ export function createChatSession(
         // refresh the panel once it lands.
         void (async () => {
           await env.loadOwnedSkills?.();
-          sendMarket(await ownedSkillsMsg(env));
+          // Same rule as buySkill/publishSkill: a surface whose env has no owned-skill
+          // capability must not emit a phantom-empty ownedSkills — its own handler answers.
+          if (env.ownedSkills || env.ownedNftSkills) sendMarket(await ownedSkillsMsg(env));
         })().catch(() => {});
         break;
       case "new":   await open(); await pushSessions(); break;
@@ -613,8 +615,14 @@ export function createChatSession(
           break;
         }
         if (command === "skills") {
-          sendMarket(await ownedSkillsMsg(env));
-          transport.send({ type: "notice", text: "Skills refreshed." });
+          // Only answer if this surface actually owns the capability; otherwise its own
+          // market handler does, and a phantom-empty reply here would wipe the panel.
+          if (env.ownedSkills || env.ownedNftSkills) {
+            sendMarket(await ownedSkillsMsg(env));
+            transport.send({ type: "notice", text: "Skills refreshed." });
+          } else {
+            transport.send({ type: "notice", text: "Skills are managed by this surface." });
+          }
           break;
         }
         if (command === "compact") {
@@ -730,8 +738,13 @@ export function createChatSession(
       // is caught here, not at runtime on some surface.
       case "searchSkills": {
         const req = m as Extract<MarketRequest, { type: "searchSkills" }>;
+        // Another handler may own search on this surface (e.g. the localhost market handler).
+        // POST fans out to every recv, so answering searchResults [] here when we lack the
+        // capability would race the real handler's items — whichever lands last wins, and
+        // the [] wipes the catalog. Stay silent instead — the capable handler answers.
+        if (!env.searchSkills) break;
         try {
-          const results = env.searchSkills ? await env.searchSkills(req.query ?? "", req.kind, req.sort) : [];
+          const results = await env.searchSkills(req.query ?? "", req.kind, req.sort);
           sendMarket({ type: "searchResults", results });
         } catch (e) {
           // a chain/RPC failure must NOT leave the UI stuck on "Searching…": surface it.
@@ -790,10 +803,17 @@ export function createChatSession(
         break;
       }
       case "ownedSkills":
+        // Same race as searchSkills: without the capability our answer would be an empty
+        // set that can land after the real handler's owned list and wipe it. Stay silent —
+        // the capable handler answers.
+        if (!env.ownedSkills && !env.ownedNftSkills) break;
         sendMarket(await ownedSkillsMsg(env));
         break;
       case "getBalance":
-        sendMarket({ type: "balance", lamports: env.solBalance ? await env.solBalance() : null });
+        // Same race as searchSkills: a null balance from here can land after the real
+        // handler's lamports and blank the display. Stay silent — the capable handler answers.
+        if (!env.solBalance) break;
+        sendMarket({ type: "balance", lamports: await env.solBalance() });
         break;
       case "airdrop": {
         if (!env.airdrop) break; // another handler owns this on some surfaces (e.g. localhost)
@@ -846,8 +866,11 @@ export function createChatSession(
       }
       // issue #35: agent directory
       case "listAgents": {
+        // Same race as searchSkills: an empty directory from here can land after the real
+        // handler's agents and wipe the list. Stay silent — the capable handler answers.
+        if (!env.listAgents) break;
         try {
-          const agents = env.listAgents ? await env.listAgents() : [];
+          const agents = await env.listAgents();
           sendMarket({ type: "agents", agents });
         } catch (e) {
           sendMarket({ type: "searchError", message: e instanceof Error ? e.message : String(e) });


### PR DESCRIPTION
# Stay silent on market requests when the env lacks the capability

Found live tonight, driving the localhost surface headless over SSE/RPC with an ephemeral wallet: one `searchSkills` POST produced **two** `searchResults` events, and the phantom one could land last and wipe the catalog.

The dispatcher answers a market request even when its `ChatEnv` has no capability for it. On localhost the surface's own `attachMarketHandlers` answers the same posted message with real data, so two replies race; the webview store replaces `marketResults` wholesale (`store.tsx:525`), so whichever lands last wins, and the empty one blanks the panel. The `buySkill` case already documents the correct rule (`session.ts:763`): when `env` lacks the capability, stay silent and let the surface's handler answer. `searchSkills`, `ownedSkills`, `getBalance`, and `listAgents` all violated it.

## What changed

Each of the four cases now does `if (!env.X) break;` before answering, byte-identical in shape to the `buySkill` / `disposeSkill` / `reEquipSkill` / `airdrop` guards already in the same switch. No new mechanism, no signature change, `ChatEnv` untouched.

Two more emitters of the same `ownedSkills` message had the same defect and are fixed the same way: the fire-and-forget "ready" refresh push and the `/skills` slash command both called `ownedSkillsMsg` unguarded, while `publishSkill` (`:941`) already guards it with `if (env.ownedSkills || env.ownedNftSkills)`. On localhost both emitted a phantom-empty `ownedSkills` that wiped the panel; they now match the `publishSkill` guard. `/skills` on a surface that manages skills itself gets a plain notice instead of a misleading "Skills refreshed."

**Why VS Code is unaffected:** `surfaces/vscode` wires all four capabilities into the session env (`extension.ts:591,603,609,613`), so the silent path never fires there; it is `surfaces/localhost` that wires no market capabilities (its own HTTP handlers own them), which is exactly why the double-answer only shows up there.

Held to five rules, argued against this diff:

1. **No meaningless wrappers with identical input/output** - no new function; guards added inline to existing cases.
2. **Scan existing functions first and reuse; never two functions with the same purpose** - this is the rule the fix restores: the surface's handler and the dispatcher were both answering one request. The guard shape is copied from `buySkill`, not invented.
3. **No type variables that won't be reused; inline them** - none added.
4. **No non-essential parameters** - no signature changed.
5. **Keep responsibilities separated; if the design feels wrong, say so** - said-so: the real contract is "a surface that owns a capability's handler must not also receive the dispatcher's answer for it," and this enforces it case by case rather than centrally. A single `capabilityOwnedBySurface` gate would be cleaner but would touch the dispatcher's core loop; I kept it local and mirrored your existing guards. If you would rather have the central version, say so.

## Evidence

| Row | Artifact |
|---|---|
| Before/After screenshots | N/A - the symptom is a webview panel blanking; captured as the live repro below |
| Video walkthrough (MP4) | N/A |
| Backend logs | Live repro: localhost headless, ephemeral wallet, one `searchSkills` POST returned two `searchResults` over SSE, the second empty. After the fix the dispatcher stays silent and only the surface handler answers |
| Frontend logs | N/A - the corrupted state was in the webview store; the fix is upstream of it |
| Real-LLM trajectory | N/A - message dispatch, no model |
| Domain artifacts | 9 new specs pin silence-when-absent and still-answers-when-present for all four cases plus the `/skills` guard; mutation-checked (revert `session.ts` to main and they fail). Full core suite 6 failed / 285 passed (291), the 6 identical to unmodified `4219832`; `tsc` clean for core, cli, localhost |
