### PR TITLE
CLI: connect GitHub and register verified work (#167)

### DIFF
--- a/surfaces/cli/src/commands.ts
+++ b/surfaces/cli/src/commands.ts
@@ -13,6 +13,7 @@ export const SLASH_COMMANDS: SlashCmd[] = [
   { name: "market", desc: "browse and buy skills" },
   { name: "agents", desc: "browse agents and profiles" },
   { name: "skills", desc: "your owned skill collection" },
+  { name: "github", desc: "connect GitHub and register verified work" },
   { name: "more", desc: "load older history (scroll-back)" },
   { name: "compact", desc: "compact the conversation context" },
   { name: "clear", desc: "clear the on-screen transcript" },

--- a/surfaces/cli/src/views/Chat.tsx
+++ b/surfaces/cli/src/views/Chat.tsx
@@ -414,7 +414,7 @@ export function Chat({
   const [showSessions, setShowSessions] = useState(false);
   const [showMarket, setShowMarket] = useState(false);
   // which market screen /market, /agents and /skills land on
-  const [marketStage, setMarketStage] = useState<"list" | "agents" | "owned">("list");
+  const [marketStage, setMarketStage] = useState<"list" | "agents" | "owned" | "github">("list");
   const [showModels, setShowModels] = useState(false);
   const [showEfforts, setShowEfforts] = useState(false);
   const [showAccount, setShowAccount] = useState(false);
@@ -822,7 +822,7 @@ export function Chat({
     setPanelFocused(false);
   }
 
-  function openMarket(stage: "list" | "agents" | "owned" = "list") {
+  function openMarket(stage: "list" | "agents" | "owned" | "github" = "list") {
     setPanelFocused(false);
     if (!market) {
       setNotice("skill market still loading, try again in a moment");
@@ -1004,6 +1004,9 @@ export function Chat({
         return;
       case "skills":
         openMarket("owned");
+        return;
+      case "github":
+        openMarket("github");
         return;
       case "resume": {
         const hit = chat.sessions.find((s) => s.sessionId.startsWith(arg));

--- a/surfaces/cli/src/views/SkillMarket.tsx
+++ b/surfaces/cli/src/views/SkillMarket.tsx
@@ -3,6 +3,7 @@ import { Box, Text, useInput, useStdout } from "ink";
 import type { SkillCard, SkillDetail } from "@iqlabs-official/agent-sdk";
 import type { Reputation, AgentProfile } from "@iqlabs-official/agent-sdk";
 import { maskedHeliusKey, hasDasRpc, saveHeliusKey, getNetwork } from "@iqlabs-official/agent-sdk";
+import { saveGithubToken, loadGithubToken, maskedGithubToken, registerVerifiedWork, parseGithubRepo } from "@iqlabs-official/agent-sdk";
 import { colors, glyph } from "../theme.js";
 import type { OwnedSkill } from "../components/WelcomePanel.js";
 import { ChipCarousel } from "../components/ChipCarousel.js";
@@ -11,6 +12,7 @@ import { tierInfo, tierGauge } from "./market/tiers.js";
 import { AgentProfileView, type ProfileSub } from "./market/AgentProfileView.js";
 import { SkillDetailView, type DetailSub } from "./market/SkillDetailView.js";
 import { HeliusPanel, HeliusBadge, type RpcStatusLite } from "./market/HeliusPanel.js";
+import { GithubPanel, type GithubStatusLite, type GithubFocus } from "./market/GithubPanel.js";
 import { PublishProgressView, type PublishProgress } from "./market/PublishProgressView.js";
 
 export interface MarketApi {
@@ -44,6 +46,7 @@ type Stage =
   | "agents"
   | "agentProfile"
   | "helius"
+  | "github"
   | "blogCompose"
   | "owned";
 
@@ -135,7 +138,7 @@ export function SkillMarket({
   ownedNames: string[];
   onBought: () => void;
   onClose: () => void;
-  initialStage?: "list" | "agents" | "owned";
+  initialStage?: "list" | "agents" | "owned" | "github";
   owned?: OwnedSkill[];
 }) {
   const [stage, setStage] = useState<Stage>(initialStage ?? "list");
@@ -204,12 +207,35 @@ export function SkillMarket({
   const [heliusKeyInput, setHeliusKeyInput] = useState("");
   const [heliusFlash, setHeliusFlash] = useState<string | null>(null);
 
+  // github verified-work screen: token connect + register-repo. Mirrors the helius
+  // screen's shape (status + one flash), plus the register form's repo/skill picker.
+  const [githubStatus, setGithubStatus] = useState<GithubStatusLite | null>(null);
+  const [ghTokenInput, setGhTokenInput] = useState("");
+  const [ghRepoInput, setGhRepoInput] = useState("");
+  const [ghSelected, setGhSelected] = useState<Record<string, boolean>>({}); // mint -> chosen
+  const [ghFocus, setGhFocus] = useState<GithubFocus>("repo");
+  const [ghSkillIdx, setGhSkillIdx] = useState(0);
+  const [ghFlash, setGhFlash] = useState<string | null>(null);
+
   const owned = new Set(ownedNames);
   const agentRows = useStdout().stdout?.rows || 24; // || not ??: detached pty reports 0
   const visibleResults = results.filter((c) => !hideOwned || !owned.has(c.name));
   // index over the FILTERED list - what's on screen is what enter/buy act on
   const clamped = Math.min(idx, Math.max(0, visibleResults.length - 1));
   const selected = visibleResults[clamped];
+
+  // The one reason /github register can't fire yet, in the order the form is filled
+  // (mirrors the app's RegisterWorkRepo blockReason). Reuses core parseGithubRepo for
+  // the client-side validity check so a bad repo is caught before any network call.
+  // Single source: both the github useInput gate and GithubPanel read this.
+  const ghChosen = Object.keys(ghSelected).filter((m) => ghSelected[m]);
+  const githubBlockReason: string | null =
+    !githubStatus?.hasToken ? "add a GitHub token above first."
+    : ghRepoInput.trim().length === 0 ? "enter a repo first: owner/name or a github.com URL."
+    : parseGithubRepo(ghRepoInput) == null ? "that repo is not valid. use owner/name or a github.com URL."
+    : ownedCollection.length === 0 ? "buy or mint a skill first, then link it here."
+    : ghChosen.length === 0 ? "pick at least one skill this repo used."
+    : null;
 
   async function search(q: string, k: "skill" | "workflow", sort: "supply" | "stars" = marketSort) {
     setLoading(true);
@@ -234,10 +260,16 @@ export function SkillMarket({
     setRpcStatus({ hasKey: !!masked, masked, network });
   }
 
+  async function refreshGithubStatus() {
+    const masked = await maskedGithubToken().catch(() => null);
+    setGithubStatus({ hasToken: !!masked, masked });
+  }
+
   useEffect(() => {
     void search("", kind);
     void api.solBalance().then(setBalance).catch(() => setBalance(null));
     void refreshRpcStatus();
+    void refreshGithubStatus();
     void api.disposedSkillMints?.().then((m) => setDisposedNames(new Set(Object.keys(m)))).catch(() => {});
     // /agents lands straight on the directory; owned needs no fetch (data via prop)
     if (initialStage === "agents") void loadAgents();
@@ -468,6 +500,43 @@ export function SkillMarket({
     setHeliusFlash(key ? "key saved" : "key cleared");
   }
 
+  // Save (or, with "", clear) the GitHub token. Mirrors doSaveHeliusKey: core stores it
+  // 0600, then we re-read the mask so the badge reflects the new state.
+  async function doSaveGithubToken(token: string) {
+    setBusy(true);
+    await saveGithubToken(token);
+    await refreshGithubStatus();
+    setBusy(false);
+    setGhTokenInput("");
+    setGhFlash(token ? "token saved" : "token removed");
+  }
+
+  // Register the repo as verified work for the chosen skills. The blockReason gate has
+  // already checked token/repo/skill presence, so this just loads the stored token and
+  // hands the whole flow to core registerVerifiedWork (marker commit + indexer POST).
+  async function doRegisterRepo() {
+    const chosen = Object.keys(ghSelected).filter((m) => ghSelected[m]);
+    const stored = await loadGithubToken();
+    if (!stored || !walletAddr) { setGhFlash("connect a wallet and a GitHub token first"); return; }
+    setBusy(true);
+    setGhFlash(null);
+    try {
+      const res = await registerVerifiedWork({
+        token: stored.token,
+        repo: ghRepoInput.trim(),
+        skillMints: chosen,
+        walletAddress: walletAddr,
+      });
+      setGhFlash(`registered ${res.count} link${res.count === 1 ? "" : "s"} for ${res.repo}${res.markerAdded ? " (marker committed)" : ""}`);
+      setGhRepoInput("");
+      setGhSelected({});
+    } catch (e) {
+      setGhFlash(e instanceof Error ? e.message : String(e));
+    } finally {
+      setBusy(false);
+    }
+  }
+
   // get/set helpers for publish form fields
   function pubGet(f: Exclude<PublishField, "kind">) {
     return { name: pubName, desc: pubDesc, text: pubText, category: pubCategory, hashtags: pubHashtags, price: pubPrice, image: pubImage }[f];
@@ -493,6 +562,40 @@ export function SkillMarket({
       if (key.return) { void doSaveHeliusKey(heliusKeyInput.trim()); return; }
       if (key.backspace || key.delete) { setHeliusKeyInput((v) => v.slice(0, -1)); return; }
       if (input && !key.ctrl && !key.meta) { setHeliusKeyInput((v) => v + input); return; }
+      return;
+    }
+
+    // ── github verified work ──────────────────────────────────────────────
+    if (stage === "github") {
+      if (key.escape) { setStage("list"); setGhFlash(null); return; }
+      // No token yet: one field to paste the Personal Access Token.
+      if (!githubStatus?.hasToken) {
+        if (key.return) { void doSaveGithubToken(ghTokenInput.trim()); return; }
+        if (key.backspace || key.delete) { setGhTokenInput((v) => v.slice(0, -1)); return; }
+        if (input && !key.ctrl && !key.meta) { setGhTokenInput((v) => v + input); return; }
+        return;
+      }
+      // Token present: register-repo form. [tab] cycles token -> repo -> skills.
+      if (key.tab) { setGhFocus((f) => (f === "token" ? "repo" : f === "repo" ? "skills" : "token")); return; }
+      if (ghFocus === "token") {
+        if (input === "x" || key.return) { void doSaveGithubToken(""); return; } // remove token
+        return;
+      }
+      if (ghFocus === "skills") {
+        if (key.upArrow) { setGhSkillIdx((i) => Math.max(0, i - 1)); return; }
+        if (key.downArrow) { setGhSkillIdx((i) => Math.min(Math.max(0, ownedCollection.length - 1), i + 1)); return; }
+        if (input === " ") {
+          const cur = ownedCollection[Math.min(ghSkillIdx, Math.max(0, ownedCollection.length - 1))];
+          if (cur) setGhSelected((s) => ({ ...s, [cur.id]: !s[cur.id] }));
+          return;
+        }
+        if (key.return) { if (githubBlockReason) setGhFlash(githubBlockReason); else void doRegisterRepo(); return; }
+        return;
+      }
+      // ghFocus === "repo": text entry, enter submits (or shows why it can't).
+      if (key.return) { if (githubBlockReason) setGhFlash(githubBlockReason); else void doRegisterRepo(); return; }
+      if (key.backspace || key.delete) { setGhRepoInput((v) => v.slice(0, -1)); return; }
+      if (input && !key.ctrl && !key.meta) { setGhRepoInput((v) => v + input); return; }
       return;
     }
 
@@ -681,6 +784,7 @@ export function SkillMarket({
     if (input === "a") { setStage("agents"); void loadAgents(); return; }
     if (input === "p") { setPubResult(null); setPubProgress(null); setPubField("kind"); setPubKind("skill"); setStage("publish"); return; }
     if (input === "r") { setHeliusFlash(null); setHeliusKeyInput(""); setStage("helius"); return; }
+    if (input === "g") { setGhFlash(null); setGhFocus("repo"); setStage("github"); return; }
     if (input === "h") { setHideOwned((v) => !v); setIdx(0); return; }
     if (input === "s") { const next = marketSort === "stars" ? "supply" : "stars"; setMarketSort(next); void search(query, kind, next); return; }
     if (key.tab) {
@@ -695,6 +799,24 @@ export function SkillMarket({
   // ── helius settings ─────────────────────────────────────────────────────────
   if (stage === "helius") {
     return <HeliusPanel status={rpcStatus} keyInput={heliusKeyInput} busy={busy} flash={heliusFlash} />;
+  }
+
+  // ── github verified work ──────────────────────────────────────────────────────
+  if (stage === "github") {
+    return (
+      <GithubPanel
+        status={githubStatus}
+        tokenInput={ghTokenInput}
+        repoInput={ghRepoInput}
+        owned={ownedCollection}
+        selected={ghSelected}
+        focus={ghFocus}
+        skillIdx={Math.min(ghSkillIdx, Math.max(0, ownedCollection.length - 1))}
+        blockReason={githubBlockReason}
+        busy={busy}
+        flash={ghFlash}
+      />
+    );
   }
 
   // ── blog composer ─────────────────────────────────────────────────────────
@@ -1032,7 +1154,7 @@ export function SkillMarket({
         <Text dimColor>  ·  </Text>
         <Text color={kind === "workflow" ? colors.iqCyan : colors.dim} bold={kind === "workflow"}>workflows</Text>
         <Text dimColor>  ·  </Text>
-        <Text color={colors.dim}>[a] agents  [p] publish  [r] rpc</Text>
+        <Text color={colors.dim}>[a] agents  [p] publish  [r] rpc  [g] github</Text>
       </Box>
       {/* search box + hide-owned filter */}
       <Box marginTop={1}>

--- a/surfaces/cli/src/views/market/GithubPanel.tsx
+++ b/surfaces/cli/src/views/market/GithubPanel.tsx
@@ -1,0 +1,136 @@
+// GitHub verified-work screen for the CLI market, ported from the app's two
+// onboarding views (surfaces/webview ConnectGithub.tsx + RegisterWorkRepo.tsx)
+// into ink boxes. Two modes gated on whether a token is stored, matching the app:
+// no token -> paste a Personal Access Token; token present -> register a repo as
+// verified work for the skills it used. Core owns everything real (token storage
+// saveGithubToken/maskedGithubToken 0600 file, and registerVerifiedWork which
+// commits the public .agentnet marker then registers with the indexer); this file
+// is pure render, the same split the CLI's HeliusPanel uses for the RPC key.
+import React from "react";
+import { Box, Text } from "ink";
+import { colors, glyph } from "../../theme.js";
+import type { OwnedSkill } from "../../components/WelcomePanel.js";
+
+// Pre-fills GitHub's new-token page with the repo scope (write to your repos, needed
+// to commit the .agentnet marker) plus a description, so a user creates the right token
+// in one step. Same URL the app uses (ConnectGithub.tsx).
+const TOKEN_URL = "https://github.com/settings/tokens/new?scopes=repo&description=AgentNet";
+
+export interface GithubStatusLite {
+  hasToken: boolean;
+  masked: string | null;
+}
+
+// Which sub-field of the register form has focus. Only meaningful once a token is
+// stored; without one the screen is a single token-entry field.
+export type GithubFocus = "token" | "repo" | "skills";
+
+function GithubBadge({ status }: { status: GithubStatusLite | null }) {
+  if (!status) return null;
+  if (status.hasToken) {
+    return <Text color={colors.ok}>{glyph.ok} connected · {status.masked}</Text>;
+  }
+  return <Text color={colors.warn}>no token · add one to register verified work</Text>;
+}
+
+export function GithubPanel({
+  status,
+  tokenInput,
+  repoInput,
+  owned,
+  selected,
+  focus,
+  skillIdx,
+  blockReason,
+  busy,
+  flash,
+}: {
+  status: GithubStatusLite | null;
+  tokenInput: string;
+  repoInput: string;
+  owned: OwnedSkill[];
+  selected: Record<string, boolean>;
+  focus: GithubFocus;
+  skillIdx: number;
+  blockReason: string | null;
+  busy: boolean;
+  flash: string | null;
+}) {
+  const hasToken = !!status?.hasToken;
+  return (
+    <Box flexDirection="column" paddingX={1} borderStyle="round" borderColor={colors.iqViolet}>
+      <Text bold color={colors.iqMagenta}>❖ GitHub verified work</Text>
+      <Box marginTop={1}>
+        <Text dimColor>status  </Text>
+        <GithubBadge status={status} />
+      </Box>
+
+      {!hasToken ? (
+        // No token yet: one field to paste the Personal Access Token.
+        <Box flexDirection="column" marginTop={1}>
+          <Box>
+            <Text color={colors.iqCyan}>▸ </Text>
+            <Text dimColor>token </Text>
+            <Text>{tokenInput}</Text>
+            <Text inverse> </Text>
+          </Box>
+          <Box marginTop={1}>
+            <Text dimColor>create a token (repo scope): </Text>
+            <Text color={colors.iqCyan}>{TOKEN_URL}</Text>
+          </Box>
+          {flash ? <Box marginTop={1}><Text color={colors.ok}>{flash}</Text></Box> : null}
+          {busy ? <Text dimColor>saving...</Text> : null}
+          <Box marginTop={1}>
+            <Text dimColor>paste a Personal Access Token · ↵ save · esc back</Text>
+          </Box>
+        </Box>
+      ) : busy ? (
+        // Registering: the two working steps, mirroring the app's step rows.
+        <Box flexDirection="column" marginTop={1}>
+          <Text dimColor>{glyph.ok} commit .agentnet marker</Text>
+          <Text dimColor>{glyph.ok} register with the indexer</Text>
+          <Box marginTop={1}><Text dimColor>working...</Text></Box>
+        </Box>
+      ) : (
+        // Token present: register a repo as verified work for the skills it used.
+        <Box flexDirection="column" marginTop={1}>
+          <Box>
+            <Text color={focus === "token" ? colors.iqCyan : colors.dim}>{focus === "token" ? "▸ " : "  "}</Text>
+            <Text dimColor>token </Text>
+            <Text>{status?.masked}</Text>
+            <Text dimColor>  [x] remove</Text>
+          </Box>
+          <Box>
+            <Text color={focus === "repo" ? colors.iqCyan : colors.dim}>{focus === "repo" ? "▸ " : "  "}</Text>
+            <Text dimColor>repo  </Text>
+            <Text dimColor={!repoInput}>{repoInput || "owner/name or github.com URL"}</Text>
+            {focus === "repo" ? <Text inverse> </Text> : null}
+          </Box>
+          <Box marginTop={1} flexDirection="column">
+            <Text color={focus === "skills" ? colors.iqCyan : colors.dim}>{focus === "skills" ? "▸ " : "  "}skills this repo used</Text>
+            {owned.length === 0 ? (
+              <Text dimColor>  no owned skills yet</Text>
+            ) : (
+              owned.map((s, i) => {
+                const on = !!selected[s.id];
+                const cursor = focus === "skills" && i === skillIdx;
+                return (
+                  <Box key={s.id}>
+                    <Text color={cursor ? colors.iqCyan : colors.dim}>{cursor ? "  ▸ " : "    "}</Text>
+                    <Text color={on ? colors.ok : colors.dim}>{on ? "[x]" : "[ ]"} </Text>
+                    <Text color={on ? colors.bone : colors.dim}>{s.name}</Text>
+                  </Box>
+                );
+              })
+            )}
+          </Box>
+          {blockReason ? <Box marginTop={1}><Text color={colors.warn}>{blockReason}</Text></Box> : null}
+          {flash ? <Box marginTop={1}><Text color={colors.ok}>{glyph.sparkle} {flash}</Text></Box> : null}
+          <Box marginTop={1}>
+            <Text dimColor>[tab] field · [space] toggle skill · ↵ register · [x] remove token · esc back</Text>
+          </Box>
+        </Box>
+      )}
+    </Box>
+  );
+}


### PR DESCRIPTION
# CLI: add the GitHub verified-work screen

Closes the gap called out in #167 (carried from #157): the CLI was the only surface without the GitHub verified-work flow. The app and VS Code already ship it. This adds a token-connect + register-repo screen to the CLI skill market, wired to the SAME core primitives the other surfaces use.

## What this does

- A new `github` stage in the CLI market with two modes, gated on whether a token is stored (the exact gate the app uses in `AgentProfileView.tsx`: token form vs register form):
  - No token: paste a Personal Access Token. Shows the pre-scoped create-token URL (`github.com/settings/tokens/new?scopes=repo&description=AgentNet`), the same URL the app uses.
  - Token present: pick a repo (`owner/name` or a github.com URL) and the owned skills it used, then register.
- Three ways in, matching the market's existing patterns: `[g]` from the list (next to `[r]` rpc), the `/github` slash command, and `initialStage="github"`.
- Register hands the whole flow to core `registerVerifiedWork` (commit the public `.agentnet` marker, then POST the repo/skill link to the indexer). The CLI does not reimplement any of it.

## Why it is wired in-process, not through a dispatcher

The CLI is an in-process Ink app, not a postMessage surface. Its existing Helius/RPC screen already imports core storage functions directly into the view (`SkillMarket.tsx` HeliusPanel path). This change follows that precedent exactly, so no `marketMessages` protocol, no `marketplaceEnv`, and no `session.ts` dispatcher change is needed (those cases exist for the postMessage surfaces and the CLI never takes that path). No core dispatch was touched, so no new core spec is added.

## The five rules, argued against the diff

1. **No meaningless wrappers.** `doSaveGithubToken` and `doRegisterRepo` are not pass-throughs: each carries CLI-view state work core cannot do (set busy, refresh the status badge, clear inputs, load the stored token before the call, surface the result as a flash). They mirror the existing `doSaveHeliusKey`. `GithubPanel` is pure render. `GithubBadge` is a local helper used inside the panel, not an exported single-use component (I intentionally did not export it, unlike `HeliusBadge`, because the CLI market header does not render a GitHub badge, so a public export would be dead).
2. **Reuse existing functions, never two with one purpose.** Registration reuses core `registerVerifiedWork`; the client-side repo check reuses core `parseGithubRepo` (the same `parseRepo` the core flow calls internally, re-exported for exactly this pre-validation); token storage reuses `saveGithubToken`/`loadGithubToken`/`maskedGithubToken`. No parser, no HTTP, no marker logic is duplicated in the CLI.
3. **No single-use type vars.** No throwaway type aliases were introduced. `GithubStatusLite` and `GithubFocus` each back real state that is read in more than one place (input handler + render). The block-reason string is a plain `string | null`, computed once (`githubBlockReason`) and read by both the input gate and the panel, so there is one source, not two.
4. **No non-essential params.** `GithubPanel` receives only what it renders. `doSaveGithubToken(token)` takes the one value it stores; `""` clears, matching how core `loadGithubToken` treats an empty token as absent (same convention as `doSaveHeliusKey("")`). `doRegisterRepo()` takes nothing and reads component state, like the sibling `doPublish`/`doComment`.
5. **Separate concerns, say so if the design feels wrong.** Render lives in `GithubPanel.tsx` (no I/O), state and actions live in `SkillMarket.tsx`, storage and the marker/indexer flow live in core. The one spot that could feel like a smell: `doRegisterRepo` re-checks token+wallet even though `githubBlockReason` already gates the keypress. That is deliberate: `githubBlockReason` covers repo/skill validity, but the token must be loaded async right before the call (it can change between screens), and `walletAddr` is a prop that could be empty, so the guard is a real last check, not a duplicate of the gate.

## Evidence

| Claim | Where | Verify |
| --- | --- | --- |
| Reuses core storage + flow, no reimplementation | `SkillMarket.tsx:6` imports `saveGithubToken, loadGithubToken, maskedGithubToken, registerVerifiedWork, parseGithubRepo`; call at `SkillMarket.tsx:524` | `grep -n registerVerifiedWork surfaces/cli/src/views/SkillMarket.tsx` |
| Client-side pre-validate reuses `parseGithubRepo` | `SkillMarket.tsx:235` in `githubBlockReason` | `grep -n parseGithubRepo surfaces/cli/src/views/SkillMarket.tsx` |
| Single source for the block reason | computed at `SkillMarket.tsx:232`, read by input gate `:592`/`:596` and panel render `:805` | inspection |
| Three entry points | `[g]` at `SkillMarket.tsx:787`; `/github` at `Chat.tsx` switch + `commands.ts`; `initialStage` union widened | `grep -n '"github"' surfaces/cli/src/views/Chat.tsx surfaces/cli/src/commands.ts` |
| Render is I/O free | `views/market/GithubPanel.tsx` (new, 136 lines) | inspection |
| No em-dash or en-dash in changed user-facing strings | all four files | `grep -nP '[\x{2013}\x{2014}]'` finds only pre-existing comment lines |

### Commands run

- CLI typecheck: `npx tsc --noEmit -p surfaces/cli/tsconfig.json` -> exit 0, 0 errors.
- Core typecheck: `npx tsc --noEmit -p packages/core/tsconfig.json` -> exit 0, 0 errors.
- CLI build: `npm run build` (tsup) -> Build success, `dist/cli.js` emitted; the github imports resolve and bundle through core.
- Core suite baseline (before): `npx vitest run` -> `Test Files 5 failed | 38 passed (43)`, `Tests 6 failed | 288 passed (294)`.
- Core suite after: identical, `6 failed | 288 passed`. The 6 failures are pre-existing and unrelated (session re-key, `/resume` and `/skills` slash instructions, and the public-devnet default RPC resolution, issue #23). This change touches only CLI view and route code plus one new file, so the core suite cannot move.

## Diffstat

```
 surfaces/cli/src/commands.ts                  |   1 +
 surfaces/cli/src/views/Chat.tsx               |   7 +-
 surfaces/cli/src/views/SkillMarket.tsx        | 126 +++++++++++++-
 surfaces/cli/src/views/market/GithubPanel.tsx | 136 +++++++++++++++++
 4 files changed, 266 insertions(+), 4 deletions(-)
```
