### PR TITLE
Android: open foreign loopback ports in the browser, not our WebView

### DIFF
--- a/surfaces/android/app/src/main/java/com/iqlabs/agentnet/MainActivity.kt
+++ b/surfaces/android/app/src/main/java/com/iqlabs/agentnet/MainActivity.kt
@@ -162,11 +162,11 @@ class MainActivity : AppCompatActivity() {
             javaScriptCanOpenWindowsAutomatically = true
         }
         webView.webViewClient = object : WebViewClient() {
-            // Our app UI is served from the loopback server (127.0.0.1) — keep that inside
-            // the WebView. Any OTHER http(s) link (e.g. the Claude OAuth login page the
-            // ConnectClaude screen surfaces) must open in the EXTERNAL browser: otherwise
-            // claude.ai would take over our WebView and the user couldn't get back to paste
-            // their code. Opening externally lets them authorize, then return to the app.
+            // Our app UI is served from the loopback server at Paths.PORT — keep that inside
+            // the WebView. Any OTHER link (e.g. the Claude OAuth login page the ConnectClaude
+            // screen surfaces, or a dev server the agent starts on another loopback port) must
+            // open in the EXTERNAL browser: otherwise it would take over our WebView and the
+            // user couldn't get back. Opening externally lets them read it, then return.
             override fun shouldOverrideUrlLoading(view: WebView, url: String): Boolean = openExternally(url)
             // Our UI is loaded → drain any deep link a notification tap stashed (cold start
             // reads the intent in onCreate, before the page — and thus its JS — exists).
@@ -279,15 +279,24 @@ class MainActivity : AppCompatActivity() {
         startServerFlow()
     }
 
-    // The single place that routes a URL off our WebView: an external host opens in the system
-    // browser as its own task ("new tab"); our own loopback UI (127.0.0.1) declines with false
-    // so it stays inside the WebView. Shared by direct navigations (shouldOverrideUrlLoading)
-    // and new-window requests (onCreateWindow) so both behave identically.
+    // The single place that routes a URL off our WebView: anything that isn't our own UI opens
+    // in the system browser as its own task ("new tab"); our own UI declines with false so it
+    // stays inside the WebView. Shared by direct navigations (shouldOverrideUrlLoading) and
+    // new-window requests (onCreateWindow) so both behave identically.
+    //
+    // "Our own UI" is a loopback host AT Paths.PORT, not merely a loopback host. Matching the
+    // host alone could not tell our server apart from any OTHER loopback port, so tapping a
+    // http://127.0.0.1:5173 link in a transcript (a dev server the agent just started) navigated
+    // this WebView in place and replaced the whole app with a chrome-less page — and nothing in
+    // this Activity handles back, so the only way out was force-killing the app. A URL with no
+    // explicit port parses to port -1, which is never our origin (the WebView loads from the URL
+    // constant above, port included), so it too falls through and opens externally.
     private fun openExternally(url: String): Boolean {
-        val host = runCatching { Uri.parse(url).host }.getOrNull()
-        if (host == null || host == "127.0.0.1" || host == "localhost") return false
+        val uri = runCatching { Uri.parse(url) }.getOrNull() ?: return false
+        val host = uri.host ?: return false
+        if ((host == "127.0.0.1" || host == "localhost") && uri.port == Paths.PORT) return false
         return runCatching {
-            startActivity(Intent(Intent.ACTION_VIEW, Uri.parse(url)).addFlags(Intent.FLAG_ACTIVITY_NEW_TASK))
+            startActivity(Intent(Intent.ACTION_VIEW, uri).addFlags(Intent.FLAG_ACTIVITY_NEW_TASK))
             true // handled: opened in the external browser
         }.getOrDefault(false)
     }


### PR DESCRIPTION
## Open foreign loopback ports in the browser, not our WebView

This is a standalone bug fix. A loopback dev-server link tapped in a chat transcript hijacks the entire Android app.

### The bug

`MainActivity.openExternally()` is the single place that routes a URL off our WebView. It matched loopback by HOST only:

```kotlin
val host = runCatching { Uri.parse(url).host }.getOrNull()
if (host == null || host == "127.0.0.1" || host == "localhost") return false
```

There is no port check. Our own UI is served from `http://127.0.0.1:${Paths.PORT}/` (`Paths.PORT = 4317`), but the guard returns `false` (keep in WebView) for EVERY loopback port, not just ours. `shouldOverrideUrlLoading` then navigates in place. So tapping a `http://127.0.0.1:5173` link (a Vite/dev server the agent just started, surfaced in the transcript) replaces the whole app UI with a chrome-less page.

And there is no way back. A grep across `surfaces/android` finds no `onBackPressed`, no `OnBackPressedCallback`, no `goBack`, no `canGoBack`. Once the WebView navigates away from our UI, the only escape is force-killing the app.

This is the same failure mode your own commit `cb5a74b` fixed for the `target="_blank"` / `window.open` path: "loaded inside our chrome-less WebView with no way back". That commit routed new-window requests through `openExternally()`, but the host-only match left the direct-navigation loopback case open.

Partly observed on a real Seeker (Android 16): from the chat screen a single back press exits the app to the launcher, which is the no-way-back half. The in-place navigation itself is read from the code path above (host-only match plus `shouldOverrideUrlLoading`), not reproduced live, since it needs a connected engine to render a loopback link in a transcript.

### The fix

Compare the PORT against `Paths.PORT`, so our own UI stays in the WebView and every OTHER loopback port takes the same external `ACTION_VIEW` path any foreign host already takes:

```kotlin
val uri = runCatching { Uri.parse(url) }.getOrNull() ?: return false
val host = uri.host ?: return false
if ((host == "127.0.0.1" || host == "localhost") && uri.port == Paths.PORT) return false
```

`Paths.PORT` is a fixed `const val` (4317), the same constant the WebView's `URL` is built from, so the two can never drift. A URL with no explicit port parses to `-1`, which is never our origin, so it also falls through and opens externally, and our own URL always carries its port so it is unaffected.

The Drive bridge port (`Paths.GOOGLE_AUTH_PORT = 4318`) is safe: it is only ever reached by a server-side `fetch` from `surfaces/localhost/src/index.ts` (the `GOOGLE_AUTHORIZE_URL` env var), never navigated in the WebView, so this change does not touch it.

### Evidence

| Claim | Grounding |
| --- | --- |
| Guard matched host only, no port | `MainActivity.openExternally()` before this diff |
| Our UI is `127.0.0.1:Paths.PORT` | `MainActivity.kt`: `URL = "http://127.0.0.1:${Paths.PORT}/"`; `Paths.PORT = 4317` |
| No back handling anywhere | `git grep` for `onBackPressed`/`OnBackPressedCallback`/`goBack`/`canGoBack` in `surfaces/android` returns nothing |
| Same failure mode is documented | `cb5a74b`: "loaded inside our chrome-less WebView with no way back" |
| Drive port is fetched, not navigated | `GOOGLE_AUTHORIZE_URL` consumed by `fetch(...)` in `surfaces/localhost/src/index.ts` |
| Observed on device | Seeker (Android 16): back press from chat exits the app (the no-way-back half). The port-hijack itself is inferred from the code path, not run live (needs a connected engine) |
| Compiles | `./gradlew :app:compileDebugKotlin --no-daemon --rerun-tasks` -> BUILD SUCCESSFUL (only pre-existing deprecation warnings, none on the touched lines) |

### Against the five rules

1. No meaningless wrapper. No new function; the existing `openExternally()` gains one condition.
2. Reuse, never two functions one purpose. The external open still runs through the one `FLAG_ACTIVITY_NEW_TASK` `ACTION_VIEW` path shared by `shouldOverrideUrlLoading` and `onCreateWindow`. No second routing mechanism.
3. No single-use type var. `uri` replaces the throwaway re-parse (`Uri.parse(url)` was called twice before), so it removes a parse rather than adding a name.
4. No non-essential params. Signature unchanged.
5. Separated concerns. This is purely the off-WebView routing decision. It touches nothing about how or whether builds are previewed.

### Relation to #143

This is the loopback routing question raised on #143, extracted as a standalone fix. It is independent of any preview feature: it adds no tab, no injected memory section, and no server. It only makes the existing "open foreign links externally" behavior correct for loopback ports, which is the direction of opening external links in the system browser. Whatever is decided on preview, a foreign loopback link should not be able to trap the app with no way back.
