### PR TITLE
Preview, the no-tab version: an agent hint to serve builds and hand back a browser link

### DIFF
--- a/packages/core/src/memory/index.ts
+++ b/packages/core/src/memory/index.ts
@@ -67,3 +67,4 @@ export class MemorySync {
 export type { CanonicalMemory, MemoryRecord, MemoryType } from "./types.js";
 export { MemoryStore } from "./store.js";
 export { updateSkillsSection } from "./skillsSection.js";
+export { updatePreviewSection } from "./previewSection.js";

--- a/packages/core/src/memory/previewSection.spec.ts
+++ b/packages/core/src/memory/previewSection.spec.ts
@@ -1,0 +1,89 @@
+import { describe, it, expect, vi, beforeEach, afterEach } from "vitest";
+
+// Mock the filesystem + paths so the test is pure (no real memory files). We assert the
+// managed block is spliced in when the surface opts in, self-removes when it does not, never
+// dirties a file to write nothing, and leaves content outside the markers untouched — all via
+// the SAME shared spliceIntoFile the skills section uses (proving one splicer, not two).
+const files = new Map<string, string>();
+const writeSpy = vi.fn(async (f: string, data: string) => { files.set(f, data); });
+
+vi.mock("node:fs/promises", () => ({
+  readFile: vi.fn(async (f: string) => {
+    if (files.has(f)) return files.get(f)!;
+    throw new Error("ENOENT");
+  }),
+  writeFile: (f: string, data: string) => writeSpy(f, data),
+  // present only so skillsSection.js (imported transitively) type-loads; unused here.
+  readdir: vi.fn(async () => []),
+}));
+
+vi.mock("../core/paths.js", () => ({
+  claudeSkillsDir: () => "/skills",
+  claudeMemoryDir: () => "/mem",
+  codexAgentsFile: (cwd: string) => `${cwd}/AGENTS.md`,
+}));
+
+import { updatePreviewSection } from "./previewSection.js";
+
+const MEMORY = "/mem/MEMORY.md";
+const START = "<!-- agentnet:preview:start -->";
+const END = "<!-- agentnet:preview:end -->";
+const prevEnv = process.env.AGENTNET_PREVIEW_HINT;
+
+describe("memory/previewSection", () => {
+  beforeEach(() => { files.clear(); writeSpy.mockClear(); delete process.env.AGENTNET_PREVIEW_HINT; });
+  afterEach(() => {
+    if (prevEnv === undefined) delete process.env.AGENTNET_PREVIEW_HINT;
+    else process.env.AGENTNET_PREVIEW_HINT = prevEnv;
+  });
+
+  it("renders the loopback-link hint when the surface opts in (AGENTNET_PREVIEW_HINT set)", async () => {
+    process.env.AGENTNET_PREVIEW_HINT = "1";
+    await updatePreviewSection("claude", "/proj");
+    const out = files.get(MEMORY)!;
+    expect(out).toContain(START);
+    expect(out).toContain(END);
+    expect(out).toContain("http://localhost:PORT");
+    expect(out).toContain("BACKGROUND");
+    expect(out).not.toMatch(/[—–]/); // no em-dash or en-dash in an agent-facing string
+    expect(out).not.toContain("/preview/announce"); // no endpoint to POST — the plugin owns no server
+  });
+
+  it("removes the block when the surface does not opt in, keeping content outside the markers", async () => {
+    files.set(MEMORY, `# Memory index\n\n- a note\n\n${START}\nold hint\n${END}`);
+    await updatePreviewSection("claude", "/proj"); // env unset
+    const out = files.get(MEMORY)!;
+    expect(out).toContain("# Memory index");
+    expect(out).toContain("- a note");     // human content untouched
+    expect(out).not.toContain(START);      // block gone
+    expect(out).not.toContain("old hint");
+  });
+
+  it("never dirties a file to write nothing (disabled + no existing block = no write)", async () => {
+    await updatePreviewSection("claude", "/proj"); // env unset, no file/markers
+    expect(writeSpy).not.toHaveBeenCalled();
+    expect(files.has(MEMORY)).toBe(false);
+  });
+
+  it("toggles idempotently through the SHARED splicer: add, then remove, exactly one block each pass", async () => {
+    process.env.AGENTNET_PREVIEW_HINT = "1";
+    await updatePreviewSection("claude", "/proj");
+    let out = files.get(MEMORY)!;
+    expect(out.match(/agentnet:preview:start/g)?.length).toBe(1);
+    // re-run enabled: still exactly one block (replace-in-place, not appended)
+    await updatePreviewSection("claude", "/proj");
+    out = files.get(MEMORY)!;
+    expect(out.match(/agentnet:preview:start/g)?.length).toBe(1);
+    // now disable: the block is spliced out
+    delete process.env.AGENTNET_PREVIEW_HINT;
+    await updatePreviewSection("claude", "/proj");
+    expect(files.get(MEMORY)!).not.toContain(START);
+  });
+
+  it("targets AGENTS.md for codex via the shared memoryFileFor mapping", async () => {
+    process.env.AGENTNET_PREVIEW_HINT = "1";
+    await updatePreviewSection("codex", "/proj");
+    expect(files.has("/proj/AGENTS.md")).toBe(true);
+    expect(files.has(MEMORY)).toBe(false);
+  });
+});

--- a/packages/core/src/memory/previewSection.ts
+++ b/packages/core/src/memory/previewSection.ts
@@ -1,0 +1,48 @@
+// "Web preview" memory section — a managed, auto-updated block that tells the agent, when it
+// builds or runs a web app, to serve it on a loopback port in the BACKGROUND and hand the user
+// the plain http://localhost:PORT link. The user opens that link in the system browser, so this
+// plugin owns NO server and NO UI: it is one short hint, nothing else.
+//
+// It reuses the skills-section machinery wholesale (memoryFileFor + the shared spliceIntoFile
+// over a marker-delimited block), so there is one splicer and one cli -> file mapping, not two.
+// Injected the same way skills are (runtime/index.ts, after MemorySync.injectAtStart).
+//
+// GATED on AGENTNET_PREVIEW_HINT: only a surface where handing back a browser link is the actual
+// UX sets it (surfaces/localhost, which serves both the desktop web app and the Android shell).
+// Where the env is unset (cli, vscode, codex) the block renders empty and self-removes: an
+// existing block is spliced out, and a file that never had it is left untouched (no write at
+// all), so an agent there is never told to serve a preview no one can open.
+
+import { memoryFileFor, spliceIntoFile } from "./skillsSection.js";
+
+const START = "<!-- agentnet:preview:start -->";
+const END = "<!-- agentnet:preview:end -->";
+
+/** The managed block: the hint when this surface hands back browser links, or empty (which
+ *  removes the block) when it does not. One short paragraph, no endpoint to POST, no port to
+ *  track — the agent picks the port and prints the link. */
+function renderBlock(enabled: boolean): string {
+  if (!enabled) return "";
+  const line = [
+    "When you build or run a web app for the user, start its dev server in the BACKGROUND on a",
+    "loopback port, then reply with the plain http://localhost:PORT link. Do not hold your turn",
+    "open waiting on the server; keep it running and hand back the link. The user opens that link",
+    "in the system browser to see what you built.",
+  ].join("\n");
+  return `${START}\n${line}\n${END}`;
+}
+
+/**
+ * Update the "web preview" section for one runtime. Renders the hint ONLY when
+ * AGENTNET_PREVIEW_HINT is set (the surface that hands back browser links); otherwise the
+ * block is removed. Call AFTER MemorySync.injectAtStart (which regenerates the memory files),
+ * alongside updateSkillsSection. Best-effort — a filesystem hiccup here must never block a
+ * session, so it never throws.
+ */
+export async function updatePreviewSection(cli: "claude" | "codex", cwd: string): Promise<void> {
+  try {
+    await spliceIntoFile(memoryFileFor(cli, cwd), renderBlock(!!process.env.AGENTNET_PREVIEW_HINT), START, END);
+  } catch {
+    /* never throw from preview-section sync */
+  }
+}

--- a/packages/core/src/memory/skillsSection.ts
+++ b/packages/core/src/memory/skillsSection.ts
@@ -94,16 +94,26 @@ function renderBlock(skills: InstalledSkillSummary[]): string {
   return `${START}\n${line}\n${END}`;
 }
 
-/** Splice (replace-or-append) the skills line into a file, preserving everything
- *  outside our markers. Creates the file if missing. */
-async function spliceIntoFile(file: string, block: string): Promise<void> {
+/** The memory file a runtime's managed blocks live in: claude's MEMORY.md index in the
+ *  project memory dir, or codex's repo AGENTS.md. Shared by every managed-block updater
+ *  (skills, preview) so the cli -> file mapping has one source of truth. */
+export function memoryFileFor(cli: "claude" | "codex", cwd: string): string {
+  return cli === "claude" ? join(claudeMemoryDir(cwd), "MEMORY.md") : codexAgentsFile(cwd);
+}
+
+/** Splice (replace-or-append) a marker-delimited block into a file, preserving everything
+ *  outside the markers. Creates the file if missing. An empty block whose markers are not
+ *  already present is a no-op: never create or dirty a file just to write nothing. Shared
+ *  by every managed-block updater (skills, preview) so there is one splicer, not two. */
+export async function spliceIntoFile(file: string, block: string, start: string, end: string): Promise<void> {
   let existing = "";
   try {
     existing = await readFile(file, "utf8");
   } catch {
     /* file doesn't exist yet — spliceMarkedBlock returns the block alone */
   }
-  await writeFile(file, spliceMarkedBlock(existing, block, START, END));
+  if (!block && !existing.includes(start)) return;
+  await writeFile(file, spliceMarkedBlock(existing, block, start, end));
 }
 
 /**
@@ -120,9 +130,7 @@ async function spliceIntoFile(file: string, block: string): Promise<void> {
 export async function updateSkillsSection(cli: "claude" | "codex", cwd: string): Promise<InstalledSkillSummary[]> {
   try {
     const skills = await installedSkillSummaries();
-    const block = renderBlock(skills);
-    const file = cli === "claude" ? join(claudeMemoryDir(cwd), "MEMORY.md") : codexAgentsFile(cwd);
-    await spliceIntoFile(file, block);
+    await spliceIntoFile(memoryFileFor(cli, cwd), renderBlock(skills), START, END);
     return skills;
   } catch {
     /* never throw from skill-section sync */

--- a/packages/core/src/runtime/index.ts
+++ b/packages/core/src/runtime/index.ts
@@ -10,7 +10,7 @@ import { spawnCli } from "./spawn.js";
 import { SessionStore } from "../account/store.js";
 import { prepareResume } from "./inject/index.js";
 import { getDeviceProfile, buildDeviceNotice } from "../core/device.js";
-import { MemorySync, updateSkillsSection } from "../memory/index.js";
+import { MemorySync, updateSkillsSection, updatePreviewSection } from "../memory/index.js";
 import { SoulStore } from "../soul/store.js";
 import { injectSoulNative } from "../soul/convert/native.js";
 import { setSkillShoppingActive } from "../skill-market/passive.js";
@@ -154,6 +154,10 @@ export function createRuntime(
         // Must run AFTER injectAtStart, which regenerates MEMORY.md / AGENTS.md.
         const skills = await updateSkillsSection(opts.cli, opts.cwd);
         if (opts.cli === "claude" && skills.length) enabledSkills = skills.map((s) => s.name);
+        // Same managed-block machinery: on a surface that hands back browser links (gated on
+        // AGENTNET_PREVIEW_HINT inside), tell the agent to serve web apps on a loopback port
+        // and reply with the http://localhost:PORT link; elsewhere the block self-removes.
+        await updatePreviewSection(opts.cli, opts.cwd);
       } catch (e) {
         console.warn("[memory] inject failed:", e);
       }

--- a/surfaces/localhost/src/index.ts
+++ b/surfaces/localhost/src/index.ts
@@ -78,6 +78,12 @@ import { SessionStore } from "@iqlabs-official/agent-sdk/account/store";
 import { migrateSessions } from "@iqlabs-official/agent-sdk/account/migrate";
 
 const PORT = Number(process.env.AGENTNET_PORT ?? 4317);
+// This surface serves the app to a user with a system browser (desktop web + the Android
+// shell), so a http://localhost:PORT link the agent hands back actually opens. Declare that
+// to the runtime, which then gives the agent the "serve web apps + hand back a link" memory
+// hint (packages/core memory/previewSection). The cli/vscode surfaces never set this, so
+// their agents are not told to serve a preview no one there would open.
+process.env.AGENTNET_PREVIEW_HINT = "1";
 const GOOGLE_AUTHORIZE_URL = process.env.GOOGLE_AUTHORIZE_URL || "";
 
 // The built React UI (surfaces/webview/dist) this host serves. Default is the sibling


### PR DESCRIPTION
## The no-tab preview you described on #143

On #143 you closed the in-app preview frame because it ran against your direction of
opening external links in the system browser, and you named the version you would take
instead: "keep just the agent hint to serve builds and hand back a browser link, without
a dedicated tab." This is that version, and only that version.

When an agent builds or runs a web app, it now gets one short memory hint: serve the dev
server on a loopback port in the background, then reply with the plain
`http://localhost:PORT` link. The user opens that link in the system browser. The plugin
owns no server and no UI. Nothing frames the page in-app.

## Drops all three costs you objected to

Your close listed three costs. This drops each one.

1. **The permanent 5th bottom tab.** Gone. No `PreviewScreen`, no `TabBar` change, no
   pager widening, no store `preview` slice, no `Markdown.tsx` loopback-link interception.
   The webview is untouched. `TAB_ORDER` is still Chat / Skills / Rank / Market.
2. **The injected agent-memory section.** Made as light as it can be and no longer injected
   everywhere. It is one short managed block, and it is gated: it renders only on the
   surface where a browser handback is the real UX (surfaces/localhost, which serves the
   desktop web app and the Android shell), and it self-removes on cli / vscode / codex. The
   block carries no endpoint to POST and tracks no port. It is a hint, not a section.
3. **The loopback announce server to maintain.** Gone. No `/preview/announce` route, no
   `previewStatus` SSE, no `preview.ts` validation module, no `AGENTNET_PREVIEW_PORT`. The
   agent picks a port and prints a link. There is nothing to keep alive.

## What landed (six files, +164 / -8)

- `packages/core/src/memory/skillsSection.ts` - generalized the existing splicer instead of
  adding a second one: `spliceIntoFile` now takes the marker pair and is exported, and
  `memoryFileFor(cli, cwd)` centralizes the cli to file mapping. It also learns to never
  dirty a file to write nothing: an empty block whose markers are absent is a no-op.
- `packages/core/src/memory/previewSection.ts` (new) - the managed block, gated on
  `AGENTNET_PREVIEW_HINT`, spliced through the shared `spliceIntoFile` / `memoryFileFor`.
- `packages/core/src/memory/previewSection.spec.ts` (new) - renders when enabled, removes
  when not, never writes to a file just to clear an absent block, toggles idempotently
  through the shared splicer, targets AGENTS.md for codex.
- `packages/core/src/memory/index.ts` - re-exports `updatePreviewSection` next to
  `updateSkillsSection` so the memory public surface stays in one place.
- `packages/core/src/runtime/index.ts` - calls `updatePreviewSection` right after
  `updateSkillsSection`, in the same best-effort block, after `injectAtStart`.
- `surfaces/localhost/src/index.ts` - sets `AGENTNET_PREVIEW_HINT = "1"` (one line), the
  only surface that opts in.

## Your five rules, argued against this diff

1. **No meaningless wrappers.** `updatePreviewSection` is not a pass-through: it owns a
   distinct marker, its own gate, and its own copy. `memoryFileFor` is not a wrapper either;
   it removes a cli to file ternary that was about to exist in two places.
2. **Reuse, never two functions with one purpose.** This is the core of the diff. I did not
   add a second splicer or a second file-mapping. I widened the existing `spliceIntoFile` to
   take a marker pair and both blocks flow through it. One splicer, one mapping.
3. **No single-use type vars.** None added. `renderBlock` takes a plain `boolean`; no new
   type alias, no interface.
4. **No non-essential params.** `spliceIntoFile` gained `start` / `end` because it now
   serves two blocks with different markers, which is the whole point of sharing it. The
   gate is read from `process.env` inside `updatePreviewSection`, not threaded as a param, so
   `updatePreviewSection(cli, cwd)` matches `updateSkillsSection(cli, cwd)` exactly.
5. **Separate concerns.** The surface declares a capability (an env flag); core decides the
   content; the splicer does the mechanical write. previewSection shares only the mechanical
   splicer with skillsSection, nothing about the copy or the gate.

## Where the design still feels unfinished (per rule 5)

The hint tells the agent to hand back a `http://localhost:PORT` link so the user opens it in
the system browser. On Android today that does not yet happen: `MainActivity.openExternally`
returns `false` for any loopback host, so a loopback link tapped in chat stays inside the
WebView instead of opening the browser, and there is no back handling. So this hint is only
fully useful once the Android loopback-handback fix lands. On desktop web and cli the link
already opens a browser, so the hint is useful there now. I did not touch MainActivity here.

## Evidence

| Check | Command | Result |
| --- | --- | --- |
| Core typecheck | `tsc --noEmit` (packages/core) | 0 errors |
| Localhost typecheck | `tsc --noEmit` (surfaces/localhost) | 0 errors |
| New + refactored specs | `vitest run memory/previewSection.spec memory/skillsSection.spec` | 11 passed |
| Full core suite (before) | `vitest run` | 6 failed / 288 passed (43 files) |
| Full core suite (after) | `vitest run` | 6 failed / 293 passed (44 files) |
| Real unmocked splice | `tsx` against a temp AGENTS.md | add / preserve note / remove / no-dirty all true, no em or en dash |

The 6 failing tests are pre-existing and network dependent (migrate, session, dasSource,
seed, skillSource, all RPC devnet vs mainnet defaults). This diff adds 5 passing tests and
no failures. Every user-facing and agent-facing string is em-dash and en-dash free.

One sequencing note: the browser handback this relies on only works on Android once #177 lands (today a foreign loopback link stays inside the WebView), so that fix is the natural first half of this pair.

Refs #143.

And an open offer while I'm in this part of the codebase: if there's anything on the CLI first-class-surface pass, or anywhere else, you'd rather hand off than do yourself, I'm happy to take it.
