### PR TITLE
CLI: keep the welcome panel inside its frame at narrow terminal widths

### DIFF
--- a/surfaces/cli/src/components/WelcomePanel.tsx
+++ b/surfaces/cli/src/components/WelcomePanel.tsx
@@ -10,6 +10,11 @@ const SETTINGS: PanelField[] = ["wallet", "cloud", "engine", "helius"];
 const SKILLS_IDX = SETTINGS.length;
 const FOCUS_TOTAL = SKILLS_IDX + 1;
 
+// Narrowest a band can be before its widest content wraps: the skills row, once every
+// skill folds, still needs ` //SKILLS_ ` plus the `+N · ▸ MARKET` tail (26 cells). Below
+// this the panel drops its logo column rather than seat a too-narrow band beside it.
+const MIN_BAND = 26;
+
 // A clickable terminal hyperlink (OSC 8). Modern terminals (iTerm2, VS Code,
 // kitty, …) render `label` underlined and open `url` on ⌘/Ctrl-click; the rest
 // just show the label, so we keep the raw URL visible separately as a fallback.
@@ -167,7 +172,14 @@ export function WelcomePanel({
 
   const cols = process.stdout.columns || 80;
   // Frame paddingX(2) outside, own bold border(2) + left column + its rail(1) inside.
-  const bandW = Math.max(24, cols - 2 - 2 - leftW - 1);
+  const inner = cols - 2 - 2;
+  const besideLogo = inner - leftW - 1;
+  // The old `Math.max(24, ...)` floor kept bands 24 wide even when fewer columns remained
+  // beside the logo, so the row ran past the frame on a narrow terminal. Instead: show the
+  // logo only where a full band fits beside it, and below that drop the logo and give the
+  // bands the whole inner width. Where the logo fits, the layout is unchanged.
+  const showLogo = besideLogo >= MIN_BAND;
+  const bandW = showLogo ? besideLogo : Math.max(1, inner);
 
   // The bone rules between bands are part of the silhouette but cost 4 rows; on a short
   // terminal the bands pack tight instead. Full height: 5 bands + 4 rules + hint + border.
@@ -245,23 +257,26 @@ export function WelcomePanel({
 
   return (
     <Box flexDirection="row" borderStyle="bold" borderColor={colors.bone} marginBottom={1}>
-      {/* logo column behind a bold rail, the design's 280px left cell */}
-      <Box
-        flexDirection="column"
-        paddingX={1}
-        justifyContent="center"
-        alignItems="center"
-        borderStyle="bold"
-        borderColor={colors.bone}
-        borderTop={false}
-        borderBottom={false}
-        borderLeft={false}
-      >
-        <Text color={colors.bone}>{mascot[0]}</Text>
-        <Text dimColor>{mascot[1]}</Text>
-        <Text dimColor>{mascot[2]}</Text>
-        <Text dimColor>{mascot[3]}</Text>
-      </Box>
+      {/* logo column behind a bold rail, the design's 280px left cell; dropped when the
+          terminal is too narrow to seat it beside a readable band (see showLogo) */}
+      {showLogo ? (
+        <Box
+          flexDirection="column"
+          paddingX={1}
+          justifyContent="center"
+          alignItems="center"
+          borderStyle="bold"
+          borderColor={colors.bone}
+          borderTop={false}
+          borderBottom={false}
+          borderLeft={false}
+        >
+          <Text color={colors.bone}>{mascot[0]}</Text>
+          <Text dimColor>{mascot[1]}</Text>
+          <Text dimColor>{mascot[2]}</Text>
+          <Text dimColor>{mascot[3]}</Text>
+        </Box>
+      ) : null}
 
       {/* stacked config bands */}
       <Box flexDirection="column" justifyContent="center">


### PR DESCRIPTION
Closes the narrow-width frame overflow from the round-1 QA findings on #167 (checklist 1.4, "the frame never overflows or smears at small terminal sizes"): https://github.com/IQCoreTeam/AgentNet/issues/167#issuecomment-5300437989

## The bug

The welcome panel is a two column silhouette: a logo cell on the left behind a bold rail, then the config bands on the right. Band width was floored at 24 cells (`Math.max(24, ...)`) even when the terminal had fewer columns left beside the logo, so on a narrow terminal the `//WALLET_`, `//CLOUD_`, `//ENGINE_`, `//HELIUS_` and `//SKILLS_` rows ran past the frame border (measured +2 cells at 40 cols, up to +11 at 20). The fixed `//TAG_` labels cannot truncate, so the bands are not the part that should give: the logo is.

## The fix

Show the logo only where a full band fits beside it; below that, drop the logo and give the bands the whole inner width. `MIN_BAND` is the narrowest a band can be before its widest content (the skills row's folded `+N · ▸ MARKET` tail, 26 cells) wraps. Where the logo fits (`besideLogo >= MIN_BAND`), nothing changes.

```mermaid
flowchart TD
  W[terminal columns] --> Q{besideLogo >= MIN_BAND?}
  Q -- yes --> A[logo cell + bands: full silhouette, unchanged]
  Q -- no --> B[drop logo: bands take the whole inner width]
  A --> C[every row fits inside the frame]
  B --> C
```

Real terminal, real binary: source builds of origin/main and this branch, run in Terminal.app at 30 columns.

| BEFORE: origin at 30 cols, panel spills and double renders | AFTER: this branch, same terminal |
|---|---|
| ![origin at 30 cols, bands spill the frame and the panel smears](https://github.com/RemilioNubilio/AgentNet/releases/download/pr-evidence/cli-30col-before.png) | ![this branch at 30 cols, every band inside the frame](https://github.com/RemilioNubilio/AgentNet/releases/download/pr-evidence/cli-30col-after.png) |

And the wide silhouette is untouched, this branch at 86 cols:

![this branch at 86 cols, logo column and bands exactly as on main](https://github.com/RemilioNubilio/AgentNet/releases/download/pr-evidence/cli-86col-after.png)

Exact cell counts at 30 cols (offline render, the verification method `plans/cli-design-parity.md` names):

BEFORE (origin, bands spill the border):
```
┏━━━━━━━━━━━━━━━━━━━━━━━━━━━━┓
┃            ┃ //WALLET_  ◉ GcqH…KRcE   (+7)
┃ ( ◕ ◡ ◕ )  ┃ //CLOUD_      ◉ ICLOUD   (+7)
┃ ⠐⠄ ░▒▓▓▒░  ┃ //ENGINE_     ┃CLAUDE    (+6)
┃ THE AGENT  ┃ //HELIUS_  ◉ AB12…YZ90   (+7)
┃ LAYER      ┃ //SKILLS_ +2 · ▸ MARKET  (+8)
┗━━━━━━━━━━━━━━━━━━━━━━━━━━━━┛
```
AFTER (this branch):
```
┏━━━━━━━━━━━━━━━━━━━━━━━━━━━━┓
┃ //WALLET_    ◉ GcqH…KRcE   ┃
┃ //CLOUD_        ◉ ICLOUD   ┃
┃ //ENGINE_         CLAUDE   ┃
┃ //HELIUS_    ◉ AB12…YZ90   ┃
┃ //SKILLS_  +2 · ▸ MARKET   ┃
┗━━━━━━━━━━━━━━━━━━━━━━━━━━━━┛
```

## Held to five rules, argued against this diff

1. No meaningless wrappers with identical input/output: no new function; a named constant and an inline branch on the existing `bandW`.
2. Scan existing functions first and reuse; never two with one purpose: reuses the existing `Band`, `leftW` and `bandW`; the inner width `cols - 2 - 2` is lifted into one `inner` so the two width terms cannot desync.
3. No type variables that will not be reused; inline them: none added. `MIN_BAND` is a value constant used by the one branch that needs it.
4. No non-essential parameters: no signature changed; the panel already reads `process.stdout.columns`.
5. Keep responsibilities separated; if the design feels wrong, say so: said-so. Dropping the logo below a threshold is a design choice, not just a bug fix. I kept the wide silhouette byte identical and only degrade where the logo genuinely cannot coexist with a readable band (43 to 50 cols on origin only "fit" by shrinking the bands below readability and wrapping the skills row). If you would rather the logo persist and the bands truncate harder, that is a one line change to the branch; tell me which you prefer.

## Evidence

| Row | Artifact |
|---|---|
| Before/After screenshots | Real Terminal.app captures above: origin at 30 cols spills the border and double renders the panel; this branch is contained at 30 and unchanged at 86. The offline render below them gives the exact per row cell counts. |
| Video walkthrough (MP4) | N/A, static layout. |
| Backend logs | Offline render sweep, cols 16 to 90, on this branch: ALL CLEAN (no row exceeds its width), including a 14 skill fold forcing the widest skills row. The same sweep on origin/main overflows at 24 to 27 widths. |
| Frontend logs | Byte identical to origin at every logo shown width (51 to 90): the wide layout is untouched. |
| Real-LLM trajectory | N/A, no model in the render path. |
| Domain artifacts | `tsc --noEmit` 0 errors, `tsup` build success. An adversarial pass drove the real component through all five focus states, the helius key editor with a 64 char paste, long cloud/engine/helius values, CJK and packed emoji: none crossed the frame. |

## Known and out of scope (pre-existing, not touched by this diff)

- The helius key editor and its instruction line are not width bound, so at their widest they squeeze the logo column even at 80 cols. This predates the fix and is contained (ink hard wraps inside the border). A follow up can width bind that row.
- `displayWidth` counts emoji as 1 cell while a real terminal counts 2, so a packed emoji skill name over packs the skills row and it wraps. Also pre-existing; `displayWidth` and `fitSkills` are unchanged here.
