### PR TITLE
CLI: keep the key editor and hint rows inside the band width

### DIFF
--- a/surfaces/cli/src/components/ToolCard.tsx
+++ b/surfaces/cli/src/components/ToolCard.tsx
@@ -6,7 +6,7 @@ import type { ToolAction } from "@iqlabs-official/agent-sdk/runtime/contract";
 import { glyph, toolTint, colors, surface } from "../theme.js";
 import { TodoPanel } from "./TodoPanel.js";
 import { DiffView } from "./DiffView.js";
-import { stripAnsi, clampLines, lineCount, wrapBlock, displayWidth } from "../format.js";
+import { stripAnsi, clampLines, lineCount, wrapBlock, displayWidth, truncateStart } from "../format.js";
 
 const MAX_OUTPUT_LINES = 12;
 
@@ -91,15 +91,6 @@ function CodeBox({
       </Box>
     </Box>
   );
-}
-
-// Title band segments: left label (truncated from the left, so the tail of a path — the
-// part that identifies the file — survives) padded against a right-aligned meta slot.
-function bandTitle(left: string, width: number): string {
-  if (displayWidth(left) <= width) return left;
-  let tail = left;
-  while (tail.length > 1 && displayWidth(`…${tail}`) > width) tail = tail.slice(1);
-  return `…${tail}`;
 }
 
 // Output block: syntax-highlighted when a language is known, else plain.
@@ -188,7 +179,7 @@ export function ToolCard({ tool, fallback }: { tool?: ToolAction; fallback?: str
     const adds = tool.diff.split("\n").filter((l) => l.startsWith("+") && !l.startsWith("+++")).length;
     const dels = tool.diff.split("\n").filter((l) => l.startsWith("-") && !l.startsWith("---")).length;
     const meta = `+${adds} −${dels}`;
-    const title = bandTitle(tool.file || "workspace", Math.max(4, bandW - displayWidth(meta) - 3));
+    const title = truncateStart(tool.file || "workspace", Math.max(4, bandW - displayWidth(meta) - 3));
     const gap = Math.max(1, bandW - displayWidth(title) - displayWidth(meta) - 2);
     // In the transcript there is no key handler, so a collapsed "press [d] to expand"
     // diff could never be opened — the edit's actual before/after was unreachable. Show

--- a/surfaces/cli/src/components/WelcomePanel.tsx
+++ b/surfaces/cli/src/components/WelcomePanel.tsx
@@ -2,7 +2,7 @@ import React from "react";
 import { Box, Text, useInput } from "ink";
 import { HELIUS_QUICKSTART_URL } from "@iqlabs-official/agent-sdk";
 import { colors, glyph, rule, tag } from "../theme.js";
-import { displayWidth } from "../format.js";
+import { displayWidth, truncateStart } from "../format.js";
 
 // Focusable rows, in order: the four settings bands, then the skills band (enter = market).
 export type PanelField = "wallet" | "cloud" | "engine" | "helius";
@@ -185,6 +185,7 @@ export function WelcomePanel({
   // terminal the bands pack tight instead. Full height: 5 bands + 4 rules + hint + border.
   const withRules = (maxRows ?? 99) >= 12;
 
+  const keyLead = ` ${tag("helius")} `;
   const shortAddr = walletAddr
     ? `${walletAddr.slice(0, 4)}…${walletAddr.slice(-4)}`
     : "○ not connected";
@@ -226,9 +227,11 @@ export function WelcomePanel({
       focused={active && focus === 2}
     />,
     keyInput !== null ? (
+      // tail-fitted so a pasted key stays one row with its newest characters visible;
+      // the reserved cell keeps the cursor block inside the band.
       <Box key="helius">
-        <Text color={colors.iqCyan} bold>{` ${tag("helius")} `}</Text>
-        <Text>{keyInput}</Text>
+        <Text color={colors.iqCyan} bold>{keyLead}</Text>
+        <Text>{truncateStart(keyInput, Math.max(1, bandW - displayWidth(keyLead) - 1))}</Text>
         <Text inverse> </Text>
       </Box>
     ) : (
@@ -278,8 +281,10 @@ export function WelcomePanel({
         </Box>
       ) : null}
 
-      {/* stacked config bands */}
-      <Box flexDirection="column" justifyContent="center">
+      {/* stacked config bands; width-bound so the free text rows (key editor, its
+          instructions, the hint) wrap or stay fitted inside the band width instead of widening the
+          column and squeezing the logo cell beside it */}
+      <Box flexDirection="column" justifyContent="center" width={bandW}>
         {bands.map((band, i) => (
           <React.Fragment key={i}>
             {i > 0 && withRules ? <Text color={colors.bone}>{rule(bandW)}</Text> : null}

--- a/surfaces/cli/src/format.ts
+++ b/surfaces/cli/src/format.ts
@@ -85,3 +85,12 @@ export function padCells(s: string, width: number): string {
   const pad = width - displayWidth(s);
   return pad > 0 ? s + " ".repeat(pad) : s;
 }
+
+// Fit to `width` cells keeping the TAIL: the part that identifies a path (its file name)
+// or the newest characters of typed input survives, behind a leading ellipsis.
+export function truncateStart(s: string, width: number): string {
+  if (displayWidth(s) <= width) return s;
+  let tail = s;
+  while (tail.length > 1 && displayWidth(`…${tail}`) > width) tail = tail.slice(1);
+  return `…${tail}`;
+}


### PR DESCRIPTION
Follow up to #179, closing the item its "Known and out of scope" section named: the helius key editor and its instruction lines are not width bound, so opening the editor breaks the panel even at the default 80 cols. Part of the #167 QA lane (checklist 1.4, "never overflows or smears").

## The bug

Three rows in the bands column carry free text with no width bound: the key editor row (the tag plus the raw typed key), its instruction lines (the widest is 59 cells, the quickstart URL line), and the active mode hint (38 cells). Whenever one of them is wider than the band width, yoga widens the whole bands column and takes the columns from the logo cell beside it. At 80 cols with the editor open: the mascot wraps ("THE AGENT" / "LAYER" on separate rows) and a pasted key jams straight into the label ("//HELIUShttps://rpc...") and wraps across four rows. The active hint does the same squeeze at 51 to 63 cols.

## The fix

One seam and one behavior:

- The bands column Box is now width bound to the band width, so free text rows wrap or stay fitted inside it instead of widening it. The logo cell can no longer be squeezed by anything in the column.
- The key editor value renders tail fitted to one row: a long paste shows an ellipsis plus the newest characters next to the cursor, the tag stays whole, and enter saves the full untruncated key (probed byte for byte through onSetHelius).

The tail fit turned out to already exist on main: ToolCard's local `bandTitle` carries the identical loop. It is hoisted into `format.ts` as `truncateStart` next to `displayWidth` and its friends, the welcome panel imports it, and ToolCard's local copy is deleted in favor of a direct call. `keyLead` is extracted because the label string is needed twice (render and width math).

Real terminal, real binary: source builds of main and this branch in Ghostty at 80 cols, the key editor opened and a 120 char RPC URL pasted through a pty driver.

| BEFORE: main at 80 cols, editor open | AFTER: this branch, same terminal |
|---|---|
| ![main at 80 cols: pasted key jams into the label and wraps four rows, the mascot wraps](https://github.com/RemilioNubilio/AgentNet/releases/download/pr-evidence/keyedit-80col-before.png) | ![this branch at 80 cols: key tail fitted to one row, tag whole, mascot intact](https://github.com/RemilioNubilio/AgentNet/releases/download/pr-evidence/keyedit-80col-after.png) |

## Held to five rules, argued against this diff

1. No meaningless wrappers with identical input/output: one wrapper is deleted, not added. ToolCard's `bandTitle` was a private name around exactly this loop; the call site now calls the shared helper directly.
2. Scan existing functions first and reuse; never two functions with one purpose: this rule is half the diff. The tail fit I needed already existed as `bandTitle`, so there is now one `truncateStart` in `format.ts` (the small text helpers home) instead of two copies in two components. `truncate` keeps heads, `truncateStart` keeps tails, and they share their shape deliberately.
3. No type variables that will not be reused; inline them: none added.
4. No non essential parameters: no signature changed; `truncateStart` keeps `bandTitle`'s exact signature.
5. Keep responsibilities separated; if the design feels wrong, say so: said so twice. (a) The column bound is one structural rule, "nothing in the bands column may outgrow the band width", rather than per row clamps; if you would rather each row bound itself, the per row version is mechanical. (b) At 80 cols the instruction lines now wrap (the URL line becomes two rows) instead of stealing from the logo; if you would rather they never wrap at the default width, shortening that copy is the alternative and it is your copy to call.

## Evidence

| Row | Artifact |
|---|---|
| Before/After screenshots | Real Ghostty captures above, both driven to the editor state through a pty with the same keystrokes and paste. |
| Video walkthrough (MP4) | N/A, static layout. |
| Backend logs | Offline keystroke probe (real component, real Readable stdin, tab x3 + enter + 200 char paste): contained with the logo intact at 80/60/40/30/20 on this branch; on main the same run squeezes the logo at 80 and 60. Default state sweep 16 to 90 stays ALL CLEAN with a 14 skill fold. |
| Frontend logs | Default state frames byte identical to main at every width 51 to 90; in active state a byte diff sweep 45..70 differs at exactly 51..63, each one replacing logo damage with a clean two line hint wrap. |
| Real-LLM trajectory | N/A, no model in the render path. |
| Domain artifacts | `tsc --noEmit` 0 errors, `tsup` build success. An adversarial pass drove the editor through backspace walks across the ellipsis (display matches the fit at every step), esc/reopen (stale free), CJK pastes (clean), and confirmed enter always submits the full pasted value even when the display is truncated. |

## Known and out of scope (pre existing, untouched)

- `displayWidth` counts emoji as 1 cell while terminals count 2, so an emoji paste can still wrap the fitted row inside the (now bounded) column, and packed emoji skill names over pack the skills row. The width bound keeps all of it contained. Extending `displayWidth`'s ranges fixes `truncate`, `truncateStart` and `fitSkills` at once; next on my #167 list unless you would rather take it.
- Backspace removes one UTF-16 code unit, so deleting through an emoji can leave a lone surrogate in the saved value. Byte identical behavior on main; noting it here so it is attributed, not missed.
