### PR TITLE
CLI: measure and wrap text by grapheme cluster, with an emoji aware ruler

### DIFF
--- a/surfaces/cli/src/components/Composer.tsx
+++ b/surfaces/cli/src/components/Composer.tsx
@@ -5,7 +5,7 @@ import { SLASH_COMMANDS } from "../commands.js";
 import { indexFiles, filterFiles } from "../fileIndex.js";
 import { readImageFromClipboard, readImageFile, type ImageInput } from "../clipboardImage.js";
 import { pinCursor, unpinCursor, layoutBuffer } from "../cursorPin.js";
-import { displayWidth } from "../format.js";
+import { displayWidth, graphemes } from "../format.js";
 import { useDelight } from "./DelightProvider.js";
 
 const MENU_CHROME = 2; // the menu block's marginTop + its hint row
@@ -39,7 +39,7 @@ export function splitBand(maxRows: number, hasMenu: boolean): { buf: number; men
 function splitAtCell(row: string, cell: number): [string, string, string] {
   let head = "";
   let w = 0;
-  const chars = [...row];
+  const chars = graphemes(row);
   let i = 0;
   for (; i < chars.length && w < cell; i++) {
     head += chars[i];

--- a/surfaces/cli/src/format.ts
+++ b/surfaces/cli/src/format.ts
@@ -22,30 +22,118 @@ export function lineCount(s: string): number {
   return t === "" ? 0 : t.split("\n").length;
 }
 
-// Terminal-cell width of a string: East Asian wide/fullwidth code points take 2 columns.
-// Covers what a chat composer realistically holds (Hangul, CJK, kana, fullwidth forms).
-export function displayWidth(s: string): number {
-  let w = 0;
-  for (const ch of s) {
+// Grapheme clusters are the unit a terminal draws (one flag, one joined family, one
+// accented letter = one glyph), so measuring and slicing walk clusters, never code
+// units. One shared segmenter; grapheme granularity is locale independent.
+const SEGMENTER = new Intl.Segmenter(undefined, { granularity: "grapheme" });
+export function graphemes(s: string): string[] {
+  const out: string[] = [];
+  for (const g of SEGMENTER.segment(s)) out.push(g.segment);
+  return out;
+}
+
+// A code point that renders 2 cells on its own: the East Asian wide/fullwidth ranges,
+// emoji pictographs, and the emoji-presentation singletons scattered below U+1F300
+// (⌚ ⏰ ✅ ✨ ❌ ⚡ ⭐ …, East Asian Wide since Unicode 9).
+function wideCodePoint(c: number): boolean {
+  return (
+    (c >= 0x1100 && c <= 0x115f) || // Hangul Jamo (leading)
+    (c >= 0x231a && c <= 0x231b) ||
+    (c >= 0x23e9 && c <= 0x23ec) ||
+    c === 0x23f0 ||
+    c === 0x23f3 ||
+    (c >= 0x25fd && c <= 0x25fe) ||
+    (c >= 0x2614 && c <= 0x2615) ||
+    (c >= 0x2648 && c <= 0x2653) ||
+    c === 0x267f ||
+    c === 0x2693 ||
+    c === 0x26a1 ||
+    (c >= 0x26aa && c <= 0x26ab) ||
+    (c >= 0x26bd && c <= 0x26be) ||
+    (c >= 0x26c4 && c <= 0x26c5) ||
+    c === 0x26ce ||
+    c === 0x26d4 ||
+    c === 0x26ea ||
+    (c >= 0x26f2 && c <= 0x26f3) ||
+    c === 0x26f5 ||
+    c === 0x26fa ||
+    c === 0x26fd ||
+    c === 0x2705 ||
+    (c >= 0x270a && c <= 0x270b) ||
+    c === 0x2728 ||
+    c === 0x274c ||
+    c === 0x274e ||
+    (c >= 0x2753 && c <= 0x2755) ||
+    c === 0x2757 ||
+    (c >= 0x2795 && c <= 0x2797) ||
+    c === 0x27b0 ||
+    c === 0x27bf ||
+    (c >= 0x2b1b && c <= 0x2b1c) ||
+    c === 0x2b50 ||
+    c === 0x2b55 ||
+    (c >= 0x2e80 && c <= 0xa4cf) || // CJK radicals … Yi
+    (c >= 0xa960 && c <= 0xa97c) || // Hangul Jamo Extended-A
+    (c >= 0xac00 && c <= 0xd7a3) || // Hangul syllables
+    (c >= 0xf900 && c <= 0xfaff) || // CJK compat ideographs
+    (c >= 0xfe10 && c <= 0xfe19) || // vertical forms
+    (c >= 0xfe30 && c <= 0xfe4f) || // CJK compat forms
+    (c >= 0xfe50 && c <= 0xfe66) || // small form variants
+    (c >= 0xfe68 && c <= 0xfe6b) ||
+    (c >= 0xff00 && c <= 0xff60) || // fullwidth forms
+    (c >= 0xffe0 && c <= 0xffe6) ||
+    c === 0x1f004 ||
+    c === 0x1f0cf ||
+    c === 0x1f18e ||
+    (c >= 0x1f191 && c <= 0x1f19a) ||
+    (c >= 0x1f200 && c <= 0x1f265) || // squared CJK (🈁 🈚 🉐 …)
+    (c >= 0x1f300 && c <= 0x1faff) || // emoji pictographs through Extended-A
+    (c >= 0x20000 && c <= 0x3fffd) // CJK extension planes
+  );
+}
+
+// Cells ONE grapheme cluster occupies. 2 when it carries a wide code point, a regional
+// indicator (flags), or a presentation mark on a visible base (☂ -> ☂️, # -> #⃣); 0
+// when it is only invisible marks (a bare joiner or selector); 1 otherwise. Stateless
+// per cluster, so summing cluster widths always equals the whole string's width.
+function clusterWidth(g: string): number {
+  let selector = false;
+  let visible = false;
+  for (const ch of g) {
     const c = ch.codePointAt(0)!;
-    w +=
-      (c >= 0x1100 && c <= 0x115f) || // Hangul Jamo (leading)
-      (c >= 0x2e80 && c <= 0xa4cf) || // CJK radicals … Yi
-      (c >= 0xac00 && c <= 0xd7a3) || // Hangul syllables
-      (c >= 0xf900 && c <= 0xfaff) || // CJK compat ideographs
-      (c >= 0xfe30 && c <= 0xfe4f) || // CJK compat forms
-      (c >= 0xff00 && c <= 0xff60) || // fullwidth forms
-      (c >= 0xffe0 && c <= 0xffe6) ||
-      (c >= 0x20000 && c <= 0x3fffd) // CJK extension planes
-        ? 2
-        : 1;
+    if (wideCodePoint(c) || (c >= 0x1f1e6 && c <= 0x1f1ff)) return 2;
+    if (c === 0xfe0e || c === 0xfe0f || c === 0x20e3) {
+      selector = true; // variation selectors and the enclosing keycap
+      continue;
+    }
+    if (c === 0x200b || c === 0x200d || c === 0x2060 || (c >= 0x0300 && c <= 0x036f))
+      continue; // joiners, zero widths, combining marks
+    visible = true;
   }
+  // Ink's measurer widens selector-carrying pictographs in both directions (FE0E and
+  // FE0F); rounding every selector-on-base up to 2 can only wrap a hair early, never
+  // overflow. Bare text-presentation pictographs (⚠ © ™ typed without a selector) stay
+  // 1 on purpose: terminals advance them narrow even where ink budgets 2.
+  if (selector && visible) return 2;
+  return visible ? 1 : 0;
+}
+
+const ASCII_ONLY = /^[\x20-\x7e]*$/;
+
+// Terminal-cell width of a string, cluster by cluster: East Asian wide/fullwidth code
+// points and emoji take 2 columns, and a composed sequence (family, flag, skin tone,
+// accent) counts as the one glyph a terminal draws, the way ink's own measurer does.
+// Covers what a chat composer realistically holds (Hangul, CJK, kana, fullwidth forms,
+// emoji). Printable ascii, the overwhelming case for tool output, skips segmentation.
+export function displayWidth(s: string): number {
+  if (ASCII_ONLY.test(s)) return s.length;
+  let w = 0;
+  for (const g of SEGMENTER.segment(s)) w += clusterWidth(g.segment);
   return w;
 }
 
 // Split ONE logical line (no newlines) into display rows of at most `width` cells.
 //
-// The break is character-level, not word-level, and that is the whole point: a stack-trace
+// The break is cluster-level, not word-level, and that is the whole point: a stack-trace
 // path or a URL is a single unbreakable "word", so a word wrapper leaves it over-wide.
 // Anything wider than the frame is then drawn past the right edge, the terminal itself
 // wraps the excess back to column 0, and the tail lands OUTSIDE the card's border — the
@@ -55,11 +143,19 @@ export function displayWidth(s: string): number {
 // Pure partition: rows.join("") === line, so callers can map an index back to a row/cell.
 export function wrapHard(line: string, width: number): string[] {
   const w = Math.max(1, width);
+  if (ASCII_ONLY.test(line)) {
+    // every cell is one column: plain slicing, no segmentation
+    if (line.length <= w) return [line];
+    const rows: string[] = [];
+    for (let i = 0; i < line.length; i += w) rows.push(line.slice(i, i + w));
+    return rows;
+  }
   const rows: string[] = [];
   let row = "";
   let rowW = 0;
-  for (const ch of line) {
-    const cw = displayWidth(ch);
+  for (const g of SEGMENTER.segment(line)) {
+    const ch = g.segment;
+    const cw = clusterWidth(ch);
     // rowW > 0 guard: a single char wider than the row still gets its own row rather
     // than an empty one before it.
     if (rowW > 0 && rowW + cw > w) {

--- a/surfaces/cli/src/views/SessionList.tsx
+++ b/surfaces/cli/src/views/SessionList.tsx
@@ -2,7 +2,7 @@ import React, { useState } from "react";
 import { Box, Text, useInput } from "ink";
 import type { SessionMeta } from "@iqlabs-official/agent-sdk/runtime/contract";
 import { colors, copy, glyph, rule, tag } from "../theme.js";
-import { displayWidth } from "../format.js";
+import { displayWidth, graphemes } from "../format.js";
 
 // Compact uppercase age, design-project style: 12S / 5M / 2H / 3D.
 function age(ts: number): string {
@@ -18,7 +18,7 @@ function age(ts: number): string {
 function cell(s: string, w: number): string {
   let out = "";
   let used = 0;
-  for (const ch of s) {
+  for (const ch of graphemes(s)) {
     const cw = displayWidth(ch);
     if (used + cw > w) break;
     out += ch;


### PR DESCRIPTION
The follow up #180 named: `displayWidth`, the CLI's cell ruler, disagreed with ink's own measurer on emoji, so emoji content wrapped and truncated wrong everywhere the ruler is used (11 components: the skills row, chat wrap, the composer caret, session titles, band values). Part of the #167 QA lane.

## The bug

The ruler counted only the East Asian ranges as 2 cells. Ink lays out with string-width, which counts emoji as 2, folds joined sequences into one glyph, and honors variation selectors. Every disagreement is a rendering bug in one of two directions: the skills band over packs and wraps (`✦ 🔥🔥🔥🔥🔥` fit by our count, not by ink's), or truncation runs long and a row drifts. A second, subtler defect: the walkers that slice text per code point (`wrapHard`, the composer's `splitAtCell`, the session list's `cell`) could split a surrogate pair or a joined sequence mid glyph.

## The fix

Measure what the terminal draws: grapheme clusters.

- `displayWidth` segments with `Intl.Segmenter` (the platform primitive, the same segmentation ink's measurer uses) and sums per cluster widths. A cluster is 2 cells when it carries a wide code point, a regional indicator (flags), or a presentation mark on a visible base (`☂` to `☂️`, `#` to `#⃣`); 0 when it is only invisible marks; 1 otherwise. Stateless per cluster, so summing parts always equals the whole.
- The wide table gains the emoji pictographs (U+1F300 to U+1FAFF), the emoji presentation singletons below them (`⌚ ⏰ ✅ ✨ ❌ ⚡ ⭐` and friends, East Asian Wide since Unicode 9), squared CJK (`🈁 🈚 🉐`), Hangul Jamo Extended-A, and the vertical and small forms.
- The three per character walkers now walk the same clusters, so no sequence is ever split mid glyph and their sums cannot drift from the whole (the wrap partition `rows.join("") === line` is preserved).
- Printable ascii short circuits before segmentation: a 10k character tool output line wraps in the same time as before (measured 0.01ms; the naive cluster walk would have been 137x slower and was caught and killed in review).

## What stays deliberately different from string-width

Two divergence classes are decisions, not misses, and both are in the safe direction (we can only wrap a hair early, never draw past a border):

- Bare text presentation pictographs (`⚠ © ™` typed without a selector, or a `❤️` whose selector was backspaced off) stay 1 cell: terminals advance them narrow even where ink budgets 2. Matching string-width here would over wrap real text containing `©` and `™`.
- The pictograph block is taken wholesale, so a few hundred obscure non emoji symbols inside it (alchemical, chess, ornaments) count 2 where string-width says 1.

## Held to five rules, argued against this diff

1. No meaningless wrappers with identical input/output: `graphemes` is the one new helper and it exists because three components need the same cluster walk; `clusterWidth` and `wideCodePoint` are the split the old single function already implied.
2. Scan existing functions first and reuse; never two functions with one purpose: scanned the repo for another ruler or segmenter; `format.ts` is the only one and every consumer already imports it, so this upgrades the single source in place. `string-width` itself stays where it is: it is ink's transitive dependency, not ours, and depending on it directly would mean a new declared dependency for something 60 lines of table express in the file's own idiom.
3. No type variables that will not be reused; inline them: none added.
4. No non essential parameters: no signature changed; callers are untouched except the three walkers swapping their iteration unit.
5. Keep responsibilities separated; if the design feels wrong, say so: said so above, twice, under "deliberately different". One more for honesty: the composer still moves its cursor per UTF-16 unit (untouched here), so an arrow key can park mid cluster; every such state still renders within budget by both rulers (probed exhaustively), and snapping the cursor to cluster boundaries is its own change if you want it.

## Evidence

| Row | Artifact |
|---|---|
| Before/After screenshots | N/A: a measurement change; the visible symptom it fixes (emoji skills row wrapping and eating the label gap) is pinned by the offline renders in the domain row instead. |
| Video walkthrough (MP4) | N/A. |
| Backend logs | Parity: a 17 case corpus (Hangul, CJK, kana, fullwidth, fire x8, ZWJ x3, skin tones, flag pairs, VS15/16, keycap, combining, mixed) agrees with ink's actual resolver (string-width 7.2.0) exactly; the `✅ ✨ ⌚ 🀄` singleton class included. Adversarial fuzz, 5000 strings built to break it (broken ZWJ chains, odd flag runs, decomposed Hangul L+V+T, lone surrogates, zero widths): additivity failures 0, partition failures 0, over budget rows by our ruler 0. |
| Frontend logs | Welcome panel sweeps 16 to 90 all clean with ascii and with emoji skill names (the emoji row now folds to one line at the widths where it wrapped before); ascii frames byte identical to main at every width 51 to 90; an exhaustive composer caret sweep (2879 cursor states incl mid surrogate) keeps every rendered row within budget by both rulers. |
| Real-LLM trajectory | N/A, no model in the path. |
| Domain artifacts | `tsc --noEmit` 0 errors, `tsup` build success. Perf: 10k ascii line 0.01ms per wrap (unchanged), mixed 8k text 1.6ms. Three adversarial review rounds ran against this change; the first version was killed for breaking measure additivity and the rework is structurally immune (walkers and ruler share one segmentation). |

## Known and out of scope (pre existing, untouched)

- `truncate`, `bandTitle`'s successor and the band's inverted fallback still slice per code unit; a mid cluster tail renders a replacement glyph in rare emoji names. Cluster based trims are a clean follow up.
- Composer cursor movement per UTF-16 unit, as said under rule 5.
