### PR TITLE
CLI: repaint after the resize wipe by routing it through ink

### DIFF
--- a/surfaces/cli/src/views/Chat.tsx
+++ b/surfaces/cli/src/views/Chat.tsx
@@ -1,5 +1,5 @@
 import React, { useEffect, useMemo, useRef, useState, useCallback } from "react";
-import { Box, Text, Static, useApp, useInput } from "ink";
+import { Box, Text, Static, useApp, useInput, useStdout } from "ink";
 import type { AgentRuntime, Wallet, ChatMessage, SkillActivation } from "@iqlabs-official/agent-sdk/runtime/contract";
 import type { CliReport, StorageConfig } from "@iqlabs-official/agent-sdk";
 import type { CloudStatus } from "@iqlabs-official/agent-sdk/account/storage/mirror";
@@ -250,6 +250,7 @@ export function Chat({
   // live terminal size - the frame is sized to it so the bottom chrome (status +
   // composer section + footer) is structurally pinned to the bottom edge, and the
   // section rules span the full width.
+  const { write: inkWrite } = useStdout();
   const [rows, setRows] = useState(process.stdout.rows || 24);
   const [cols, setCols] = useState(process.stdout.columns || 80);
   const ruleW = Math.max(0, cols - 2); // frame paddingX(1) each side
@@ -275,7 +276,11 @@ export function Chat({
       lastSize.current = { rows: nr, cols: nc };
       setRows(nr);
       setCols(nc);
-      process.stdout.write("\u001b[2J\u001b[3J\u001b[H");
+      // The wipe goes THROUGH ink (useStdout().write), not behind its back: ink clears
+      // its frame, writes these bytes, then immediately repaints its last frame. A raw
+      // process.stdout.write here leaves ink believing its frame is still on screen, so
+      // nothing repaints and the terminal stays blank until the next real change.
+      inkWrite("\u001b[2J\u001b[3J\u001b[H");
       chat.redraw();
     };
     const onResize = () => {
@@ -287,7 +292,7 @@ export function Chat({
       if (t) clearTimeout(t);
       process.stdout.off("resize", onResize);
     };
-  }, [chat.redraw]);
+  }, [chat.redraw, inkWrite]);
 
   // local separators belong to the session they were typed in.
   useEffect(() => {


### PR DESCRIPTION
Fixes the top item from the round 3 findings on #167: every terminal resize ends on a blank screen until the next keypress.

## The bug

ink v5 repaints on SIGWINCH by itself, immediately. About 120ms later Chat's debounced resize handler writes a raw clear (`ESC[2J ESC[3J ESC[H`, the deliberate scrollback purge) straight to `process.stdout` and calls `chat.redraw()`. The raw write is invisible to ink: its differ still holds the frame the wipe just erased, the redraw renders byte identical output, ink writes nothing, and the screen stays blank until the next keypress or the periodic repaint. With a non empty transcript the `<Static>` replay masks it, which is why it looked intermittent; on the welcome screen the blank is total.

Real terminal, real binary, same resize (120x40 down to 80x30), no keys pressed:

| BEFORE: main after a resize | AFTER: this branch, same resize |
|---|---|
| ![main after a resize: a fully blank terminal with one cursor block](https://github.com/RemilioNubilio/AgentNet/releases/download/pr-evidence/cli-resize-before.png) | ![this branch after the same resize: complete frame](https://github.com/RemilioNubilio/AgentNet/releases/download/pr-evidence/cli-resize-after.png) |

## The fix

One line: the wipe goes through ink's `useStdout().write` instead of behind ink's back. That write path in ink 5.2.1 is `log.clear()`, then the bytes, then `log(lastOutput)`: ink erases its frame, writes the wipe, and repaints the full frame in the same breath (verified against the installed ink source and by a byte level probe of the emitted stream: erase, wipe bytes, immediate repaint, in order). The size change guard (the old SIGWINCH heap OOM protection) and the transcript replay are untouched; `inkWrite` joins the effect deps and is referentially stable (ink binds it once in its constructor).

## Held to five rules, argued against this diff

1. No meaningless wrappers with identical input/output: no wrapper; one call site swaps `process.stdout.write` for the hook the framework provides for exactly this.
2. Scan existing functions first and reuse; never two functions with one purpose: this is the rule that IS the fix. ink already owns "write around my frame and repaint" (`writeToStdout`); the handler was reimplementing half of it (the write) and skipping the half that matters (the repaint).
3. No type variables that will not be reused; inline them: none added.
4. No non essential parameters: no signature changed.
5. Keep responsibilities separated; if the design feels wrong, say so: said so. The deeper design would be ink owning the whole resize story (it already repaints on SIGWINCH); the manual wipe exists for the scrollback purge and the transcript replay, which are this app's own concerns, so the handler keeps them and only stops fighting ink. The boot wipe in `app.tsx` uses the same raw pattern but is safe because the phase flip guarantees different bytes in the same tick; left alone on purpose.

## Evidence

| Row | Artifact |
|---|---|
| Before/After screenshots | Real Terminal.app captures above: main is a fully blank window after the resize; this branch shows the complete frame with no key pressed. |
| Video walkthrough (MP4) | N/A, the pair of stills is the whole story. |
| Backend logs | Before/after verifier over 4 scenarios (single resizes both directions, a 10 resize burst then settle): main leaves 0 printable characters after its final clear in all 4; this branch a complete frame in all 4. Adversarial edge matrix on top: a real resumed session emits exactly 1 transcript replay per settled resize on both builds (litter not worsened), tmux style no change SIGWINCH emits ZERO bytes (guard intact), resizes during boot and 150ms after chat mount complete cleanly, a 50 resize storm at 60ms settles to one wipe and one replay per size, extremes 10x20 and 60x200 recover, and the post settle keypress path is byte identical to main. |
| Frontend logs | The two dist bundles differ by exactly the four hunks of this diff, so every measured delta is attributable. Fixed build emits about 1.3KB more per settled resize: the one extra frame paint that is the fix working. |
| Real-LLM trajectory | N/A, no model in the path. |
| Domain artifacts | `tsc --noEmit` 0 errors, `tsup` build success. `~/.agentnet/cli.json` byte identical before and after every probe run; real sessions untouched (read only fixture home for the destructive patterns). |

## Known and out of scope (pre existing, untouched)

- The scrollback litter from session open and backfill replays (round 2 and 3 findings) is unchanged by this diff, measured equal on both builds.
- At terminals shorter than the frame (10 rows) ink rewrites its accumulated static buffer per render; byte identical on main, an ink upstream behavior.
