### PR TITLE
CLI: the #167 fix ladder, 48 one-fix commits, every prefix merge-safe

### DIFF
--- a/packages/core/src/account/sessionLog.ts
+++ b/packages/core/src/account/sessionLog.ts
@@ -9,8 +9,11 @@ import type { ChatMessage, CanonicalSession } from "../runtime/contract.js";
 import { encryptForWallet, decryptForWallet, type SessionKey } from "../core/crypto.js";
 
 // A log record: either session meta (first line) or one chat message.
+// A page may hold several meta records (settings/device updates append one);
+// decode is last-record-wins, and each meta is a FULL snapshot of the session's
+// current settings, so an absent model/effort means "engine default", not "unchanged".
 type LogRecord =
-  | { kind: "meta"; sessionId: string; cli: string; title: string; ts: number; lastDevice?: { id: string; label: string } }
+  | { kind: "meta"; sessionId: string; cli: string; title: string; ts: number; lastDevice?: { id: string; label: string }; model?: string; effort?: string }
   | { kind: "msg"; msg: ChatMessage };
 
 const NL = new TextEncoder().encode("\n");
@@ -27,7 +30,7 @@ export async function encodeRecord(key: SessionKey, rec: LogRecord): Promise<Uin
 
 // Convenience encoders for the two record kinds.
 export function metaRecord(s: Omit<CanonicalSession, "messages">): LogRecord {
-  return { kind: "meta", sessionId: s.sessionId, cli: s.cli, title: s.title, ts: s.ts, lastDevice: s.lastDevice };
+  return { kind: "meta", sessionId: s.sessionId, cli: s.cli, title: s.title, ts: s.ts, lastDevice: s.lastDevice, model: s.model, effort: s.effort };
 }
 export function msgRecord(msg: ChatMessage): LogRecord {
   return { kind: "msg", msg };
@@ -46,6 +49,8 @@ export async function decodeLog(
   let title = "";
   let ts = 0;
   let lastDevice: { id: string; label: string } | undefined = undefined;
+  let model: string | undefined = undefined;
+  let effort: CanonicalSession["effort"] = undefined;
   const messages: ChatMessage[] = [];
 
   for (const line of text.split("\n")) {
@@ -58,11 +63,13 @@ export async function decodeLog(
       title = rec.title;
       ts = rec.ts;
       lastDevice = rec.lastDevice;
+      model = rec.model;
+      effort = rec.effort as CanonicalSession["effort"];
     } else {
       messages.push(rec.msg);
     }
   }
 
   if (!sessionId) return null;
-  return { sessionId, cli, title, messages, ts, lastDevice };
+  return { sessionId, cli, title, messages, ts, lastDevice, model, effort };
 }

--- a/packages/core/src/account/store.ts
+++ b/packages/core/src/account/store.ts
@@ -34,8 +34,26 @@ function toSessionMeta(
   cli: "claude" | "codex",
   ts: number,
   lastDevice?: SessionMeta["lastDevice"],
+  model?: string,
+  effort?: SessionMeta["effort"],
 ): SessionMeta {
-  return { sessionId, title, cli, ts, ...(lastDevice ? { lastDevice } : {}) };
+  return {
+    sessionId,
+    title,
+    cli,
+    ts,
+    ...(lastDevice ? { lastDevice } : {}),
+    ...(model ? { model } : {}),
+    ...(effort ? { effort } : {}),
+  };
+}
+
+// Sort/display ts = LAST ACTIVITY: a page's meta ts is only rewritten on rollover
+// (every PAGE_SIZE messages), so a short session would keep its creation time forever
+// and sink in the list right after being used. The newest message's own ts is already
+// persisted and reflects the real last touch; meta ts covers an empty (meta-only) page.
+function lastActivityTs(s: CanonicalSession): number {
+  return s.messages.length ? s.messages[s.messages.length - 1].ts ?? s.ts : s.ts;
 }
 
 const pageKey = (sessionId: string, page: number) => `${sessionId}__p${page}`;
@@ -130,6 +148,12 @@ export class SessionStore {
     const blob = await this.storage.get(pageKey(sessionId, last));
     const decoded = blob ? await decodeLog(await this.getKey(), blob) : null;
     const state = { page: last, count: decoded?.messages.length ?? 0 };
+    // Seed the meta cache from the page we just decoded (first touch of this session in
+    // this process), so appendMessage's settings-change check below compares against what
+    // storage actually says - and a later listMine gets this meta without a re-decode.
+    if (decoded && !this.metaCache.has(sessionId)) {
+      this.cacheMeta(last, { ...decoded, ts: lastActivityTs(decoded) });
+    }
     this.cur.set(sessionId, state);
     return state;
   }
@@ -152,6 +176,15 @@ export class SessionStore {
     if (state.count === 0) {
       // new (empty) page -> write its meta line first
       await this.write(pk, await encodeRecord(key, metaRecord(meta)));
+    } else {
+      // Settings changed mid-page (a model/effort switch, or the session crossing to the
+      // other engine): the page's opening meta line is now stale, and resume restores
+      // whatever meta says. Append a refreshed meta record - decode is last-record-wins -
+      // so storage always names what the session is ACTUALLY running.
+      const prev = this.metaCache.get(meta.sessionId)?.meta;
+      if (prev && (prev.cli !== meta.cli || prev.model !== meta.model || prev.effort !== meta.effort)) {
+        await this.write(pk, await encodeRecord(key, metaRecord(meta)));
+      }
     }
     await this.write(pk, await encodeRecord(key, msgRecord(msg)));
     state.count += 1;
@@ -170,7 +203,7 @@ export class SessionStore {
   private cacheMeta(page: number, meta: Omit<CanonicalSession, "messages">): void {
     this.metaCache.set(meta.sessionId, {
       page,
-      meta: toSessionMeta(meta.sessionId, meta.title, meta.cli, meta.ts, meta.lastDevice),
+      meta: toSessionMeta(meta.sessionId, meta.title, meta.cli, meta.ts, meta.lastDevice, meta.model, meta.effort),
     });
   }
 
@@ -195,7 +228,9 @@ export class SessionStore {
     for (let p = 0; p <= last; p++) {
       const page = await this.loadPage(srcId, p);
       if (!page) continue;
-      if (!meta) meta = { sessionId: newId, cli: page.cli, title, ts: page.ts, lastDevice: page.lastDevice };
+      // Newest readable page wins: it carries the session's CURRENT settings (cli/model/
+      // effort), which is what the copy should wake up wearing.
+      meta = { sessionId: newId, cli: page.cli, title, ts: page.ts, lastDevice: page.lastDevice, model: page.model, effort: page.effort };
       messages.push(...page.messages);
     }
     if (!meta) throw new Error(`could not read session: ${srcId}`);
@@ -341,16 +376,8 @@ export class SessionStore {
           decoded++;
           const s = await this.loadPage(sessionId, page);
           if (!s) return null;
-          // Sort/display by LAST ACTIVITY, not creation. The page meta ts is only written
-          // when a page rolls over (every PAGE_SIZE messages), so a short session keeps its
-          // creation time forever and sinks in the list even right after you use it. The
-          // last message's own ts is already persisted and reflects the real last touch;
-          // fall back to the meta ts on an empty (meta-only) newest page. Read-side only —
-          // nothing is rewritten to disk.
-          const lastTs = s.messages.length
-            ? s.messages[s.messages.length - 1].ts ?? s.ts
-            : s.ts;
-          const meta = toSessionMeta(sessionId, s.title, s.cli, lastTs, s.lastDevice);
+          // Last-activity ts (see lastActivityTs): read-side only, nothing rewritten.
+          const meta = toSessionMeta(sessionId, s.title, s.cli, lastActivityTs(s), s.lastDevice, s.model, s.effort);
           this.metaCache.set(sessionId, { page, meta });
           return meta;
         } catch {

--- a/packages/core/src/core/verifiedWork.ts
+++ b/packages/core/src/core/verifiedWork.ts
@@ -37,7 +37,7 @@ function markerWallet(content: string): string | null {
 export function parseRepo(input: string): { owner: string; name: string } | null {
   let s = (input || "").trim();
   if (!s) return null;
-  s = s.replace(/^git@github\.com:/i, "").replace(/^https?:\/\/(www\.)?github\.com\//i, "");
+  s = s.replace(/^git@github\.com:/i, "").replace(/^(https?:\/\/)?(www\.)?github\.com\//i, "");
   s = s.replace(/\.git$/i, "").replace(/^\/+/, "").replace(/\/+$/, "");
   const [owner, name] = s.split("/").filter(Boolean);
   if (!owner || !name) return null;

--- a/packages/core/src/runtime/contract.ts
+++ b/packages/core/src/runtime/contract.ts
@@ -230,6 +230,10 @@ export interface SessionMeta {
   cli: "claude" | "codex";
   ts: number; // last updated
   lastDevice?: { id: string; label: string };
+  // the model/effort the session last ran with (absent = engine default), so a
+  // resume can restore them instead of silently switching to another model
+  model?: string;
+  effort?: "low" | "medium" | "high" | "xhigh" | "max";
 }
 
 // what gets encrypted to storage (CLI-neutral, so codex↔claude + cross-device)
@@ -240,4 +244,6 @@ export interface CanonicalSession {
   messages: ChatMessage[];
   ts: number;
   lastDevice?: { id: string; label: string };
+  model?: string;
+  effort?: "low" | "medium" | "high" | "xhigh" | "max";
 }

--- a/packages/core/src/runtime/contract.ts
+++ b/packages/core/src/runtime/contract.ts
@@ -106,6 +106,10 @@ export interface ToolAction {
   command?: string; // shell command (Bash / codex command_execution)
   output?: string; // command stdout/stderr or result text
   exitCode?: number; // process exit code, when known
+  // true = the approval gate refused this call (user deny / codex declined item). The
+  // tool never ran, so there is no exitCode; surfaces render this from the approval
+  // outcome instead of guessing success from a missing exit code.
+  denied?: boolean;
   file?: string; // target file (Edit / Write / Read)
   diff?: string; // unified-ish diff for edits ("-old" / "+new" lines)
 }

--- a/packages/core/src/runtime/index.ts
+++ b/packages/core/src/runtime/index.ts
@@ -136,6 +136,8 @@ export function createRuntime(
             title: resumeResult.title ?? "",
             ts: Date.now(),
             lastDevice: device,
+            model: opts.model,
+            effort: opts.effort,
           });
         }
       }
@@ -191,7 +193,9 @@ export function createRuntime(
       const compactCbs: Array<() => void> = [];
       const pending: ChatMessage[] = []; // messages awaiting a known sessionId
 
-      const meta = () => ({ sessionId, cli: opts.cli, title, ts: Date.now(), lastDevice: device });
+      // Meta snapshots stamp the session's CURRENT settings (model/effort) so a later
+      // resume can restore them instead of silently switching to the default model.
+      const meta = () => ({ sessionId, cli: opts.cli, title, ts: Date.now(), lastDevice: device, model: opts.model, effort: opts.effort });
 
       // Show the message to the UI, then append it to the encrypted log. Stamp the
       // producing CLI on every message so the UI badges each turn with the right

--- a/packages/core/src/runtime/session-settings.spec.ts
+++ b/packages/core/src/runtime/session-settings.spec.ts
@@ -1,0 +1,139 @@
+import { describe, it, expect, vi, beforeEach, afterEach } from "vitest";
+import { mkdtempSync, rmSync } from "node:fs";
+import { tmpdir } from "node:os";
+import { join } from "node:path";
+import { createRuntime } from "./index.js";
+import { manualStorage } from "../account/storage/manual.js";
+import { testWallet } from "../account/keypairWallet.js";
+import { SessionStore } from "../account/store.js";
+
+// Mock spawnCli: no real engine ever runs. The fake reveals the passed sessionId
+// (or a fixed fresh id) and lets sends complete silently.
+vi.mock("./spawn.js", () => ({
+  spawnCli: vi.fn((opts: any) => ({
+    send: vi.fn(),
+    onSessionId: (cb: any) => cb(opts.sessionId || "fresh-session-id"),
+    onMessage: () => {},
+    onSkill: () => {},
+    onUsage: () => {},
+    onCompact: () => {},
+    onTurnEnd: () => {},
+    onError: () => {},
+  })),
+}));
+
+vi.mock("../core/device.js", async (importOriginal) => {
+  const original = await importOriginal<typeof import("../core/device.js")>();
+  return {
+    ...original,
+    getDeviceProfile: vi.fn(() => Promise.resolve({ id: "device-T", label: "Test" })),
+  };
+});
+
+// Session model/effort fidelity (issue 167 round 2 finding 6): what a session runs with
+// must be persisted in its meta, so a resume can restore it instead of silently falling
+// back to the default model.
+describe("runtime/session-settings: model/effort persist and survive resume", () => {
+  let home: string;
+  const origEnv = { ...process.env };
+
+  beforeEach(() => {
+    home = mkdtempSync(join(tmpdir(), "agentnet-settings-"));
+    process.env.AGENTNET_HOME = home;
+    // keep the engines' own config dirs inside the sandbox too (memory/skills injects)
+    process.env.CLAUDE_CONFIG_DIR = join(home, "claude");
+    process.env.CODEX_HOME = join(home, "codex");
+  });
+
+  afterEach(() => {
+    process.env = { ...origEnv };
+    rmSync(home, { recursive: true, force: true });
+  });
+
+  it("a session started with a model/effort lists them back in a fresh process", async () => {
+    const wallet = testWallet();
+    const storage = manualStorage();
+    const runtime = createRuntime(wallet, storage);
+
+    const handle = await runtime.startSession({
+      cli: "claude",
+      cwd: home,
+      model: "haiku",
+      effort: "low",
+    });
+    handle.send("hello");
+    await new Promise((r) => setTimeout(r, 50));
+
+    // A FRESH store (new metaCache) = what a later `agentnet resume` boot sees.
+    const metas = await new SessionStore(wallet, storage).listMine();
+    expect(metas).toHaveLength(1);
+    expect(metas[0].model).toBe("haiku");
+    expect(metas[0].effort).toBe("low");
+    expect(metas[0].cli).toBe("claude");
+  });
+
+  it("resuming under different settings refreshes the stored meta mid-page", async () => {
+    const wallet = testWallet();
+    const storage = manualStorage();
+
+    const first = await createRuntime(wallet, storage).startSession({
+      cli: "claude",
+      cwd: home,
+      model: "haiku",
+      effort: "low",
+    });
+    first.send("first turn");
+    await new Promise((r) => setTimeout(r, 50));
+
+    // New process resumes the same session with an explicit different model.
+    const second = await createRuntime(wallet, storage).startSession({
+      cli: "claude",
+      cwd: home,
+      sessionId: "fresh-session-id",
+      model: "sonnet",
+      effort: "high",
+    });
+    second.send("second turn");
+    await new Promise((r) => setTimeout(r, 50));
+
+    const metas = await new SessionStore(wallet, storage).listMine();
+    expect(metas).toHaveLength(1);
+    expect(metas[0].model).toBe("sonnet");
+    expect(metas[0].effort).toBe("high");
+  });
+
+  it("sessions saved before the fields existed list with no model/effort", async () => {
+    const wallet = testWallet();
+    const storage = manualStorage();
+    const store = new SessionStore(wallet, storage);
+    // Old-format meta: no model/effort keys were ever written.
+    await store.appendMessage(
+      { sessionId: "old-session", cli: "claude", title: "old", ts: Date.now() },
+      { role: "user", text: "hi", ts: Date.now() },
+    );
+
+    const metas = await new SessionStore(wallet, storage).listMine();
+    expect(metas).toHaveLength(1);
+    expect(metas[0].model).toBeUndefined();
+    expect(metas[0].effort).toBeUndefined();
+  });
+
+  it("a fork wakes up wearing the source session's settings", async () => {
+    const wallet = testWallet();
+    const storage = manualStorage();
+    const runtime = createRuntime(wallet, storage);
+
+    const handle = await runtime.startSession({
+      cli: "claude",
+      cwd: home,
+      model: "haiku",
+      effort: "xhigh",
+    });
+    handle.send("branch me");
+    await new Promise((r) => setTimeout(r, 50));
+
+    const forked = await runtime.forkSession("fresh-session-id");
+    expect(forked.model).toBe("haiku");
+    expect(forked.effort).toBe("xhigh");
+  });
+});

--- a/packages/core/src/runtime/spawn.ts
+++ b/packages/core/src/runtime/spawn.ts
@@ -337,6 +337,20 @@ function claudeEngine(opts: SpawnOpts): Engine {
   const actionKey = (req: ApprovalRequest) =>
     req.kind === "bash" ? `bash:${req.command}` : `${req.tool}:${req.file || ""}`;
 
+  // A canUseTool deny reaches the output stream only as an is_error tool_result whose
+  // content is the deny message we returned, which used to render as a FAILED RUN of a
+  // command that never ran (and left the tool_use card reading as success; issue 167).
+  // Remember each interactive deny here so the echo can be recognized (exact message
+  // match) and surfaced as an explicit denial record instead. Cleared on turn end.
+  const pendingDenials: { name: string; message: string }[] = [];
+  function markIfDenied(cm: ChatMessage): ChatMessage {
+    if (cm.role !== "tool" || cm.tool?.exitCode !== 1) return cm;
+    const i = pendingDenials.findIndex((p) => p.message === (cm.tool?.output ?? "").trim());
+    if (i === -1) return cm;
+    const { name, message } = pendingDenials.splice(i, 1)[0];
+    return { ...cm, text: `${name} denied`, tool: { name, denied: true, output: message } };
+  }
+
   // canUseTool: claude calls this BEFORE each tool; we translate to a neutral
   // ApprovalRequest, await the channel, and map the decision back to the SDK shape.
   const canUseTool = async (toolName: string, input: Record<string, unknown>) => {
@@ -356,7 +370,9 @@ function claudeEngine(opts: SpawnOpts): Engine {
     if (allowed.has(key)) return { behavior: "allow" as const, updatedInput: input };
     const decision = await approval.request(req);
     if (decision.outcome === "deny") {
-      return { behavior: "deny" as const, message: decision.reason ?? "Denied by user" };
+      const message = decision.reason ?? "Denied by user";
+      pendingDenials.push({ name: toolName, message });
+      return { behavior: "deny" as const, message };
     }
     if (decision.outcome === "always") {
       allowed.add(key); // remember for the rest of the session
@@ -462,14 +478,14 @@ function claudeEngine(opts: SpawnOpts): Engine {
             cb.emitPartial({ ...cm, text: streamBuf });
           } else {
             if (cm.role === "assistant" && !cm.partial) streamBuf = ""; // final block arrived
-            cb.emitMsg(cm);
+            cb.emitMsg(markIfDenied(cm));
           }
         }
         if (r.contextTokens !== undefined) cb.emitUsage(r.contextTokens, defaultWindow("claude", opts.model));
         // claude surfaces a compaction as a "summary" record (compact_boundary); mirror it
         // as the explicit compaction cue so the UI behaves the same as it does for codex.
         if (r.messages.some((cm) => cm.role === "summary")) cb.emitCompact();
-        if (r.turnEnded) { streamBuf = ""; cb.emitTurn(); }
+        if (r.turnEnded) { streamBuf = ""; pendingDenials.length = 0; cb.emitTurn(); }
       }
     } catch (e) {
       cb.emitErr(`[claude engine] ${e instanceof Error ? e.message : String(e)}`);
@@ -685,7 +701,11 @@ function codexEngine(opts: SpawnOpts): Engine {
           role: "tool",
           text: it.command.split("\n")[0]?.slice(0, 80) || "bash",
           ts: Date.now(),
-          tool: { name: "Bash", command: it.command, output: (aggregatedOutput ?? "").slice(0, 4000), exitCode },
+          // a declined approval completes the item with status "declined" and no exit
+          // code; record the refusal instead of a run that never happened.
+          tool: it.status === "declined"
+            ? { name: "Bash", command: it.command, denied: true }
+            : { name: "Bash", command: it.command, output: (aggregatedOutput ?? "").slice(0, 4000), exitCode },
         });
       } else if ((it.type === "fileChange" || it.type === "file_change") && Array.isArray(it.changes)) {
         for (const c of it.changes) {

--- a/surfaces/cli/src/app.tsx
+++ b/surfaces/cli/src/app.tsx
@@ -1,6 +1,6 @@
 import React, { useEffect, useState } from "react";
 import { Box, Text, useApp, useInput } from "ink";
-import type { AgentRuntime } from "@iqlabs-official/agent-sdk/runtime/contract";
+import type { AgentRuntime, SessionMeta } from "@iqlabs-official/agent-sdk/runtime/contract";
 import { autoApprove, type StorageConfig, type CliReport } from "@iqlabs-official/agent-sdk";
 import type { CloudStatus } from "@iqlabs-official/agent-sdk/account/storage/mirror";
 import { InkApprovalChannel } from "./InkApprovalChannel.js";
@@ -54,6 +54,9 @@ export function App({ options }: { options: AppOptions }) {
   // reported by mirrorStorage after each cloud write attempt — drives the StatusLine
   // sync chip so a dead/offline cloud is visible instead of silently drifting.
   const [cloudStatus, setCloudStatus] = useState<CloudStatus | null>(null);
+  // the saved meta of the session being resumed (looked up in go() before the chat
+  // renders), so the session comes back wearing ITS OWN model/effort.
+  const [resumed, setResumed] = useState<SessionMeta | null>(null);
 
   const { exit } = useApp();
   // Ctrl+C during boot/onboarding/error — nothing's running yet, so quit straight away.
@@ -75,6 +78,16 @@ export function App({ options }: { options: AppOptions }) {
     const rt = await buildRuntime(w, approval.current ?? autoApprove(), setCloudStatus);
     setRuntime(rt);
     setWallet(w);
+    // Resuming? Look up that session's saved meta BEFORE entering chat, so the first
+    // chat render already seeds useChat with the session's own model/effort (issue 167:
+    // a session created with --model haiku resumed showing and running the default
+    // model). Prefs are re-read here because the boot effect's setPrefs(savedPrefs)
+    // has not committed when go() runs in the same closure.
+    const resumeId = options.resume ?? (options.continue ? (await readPrefs()).lastSessionId : undefined);
+    if (resumeId) {
+      const meta = (await rt.listSessions().catch(() => [] as SessionMeta[])).find((s) => s.sessionId === resumeId);
+      if (meta) setResumed(meta);
+    }
     set(3, { status: "ok", label: "storage ready", detail: "READY" });
     // wipe the boot banner/checklist from the scrollback so the welcome panel lands on a
     // clean screen (Ink leaves prior static output in the terminal history otherwise),
@@ -202,16 +215,19 @@ export function App({ options }: { options: AppOptions }) {
     return <LoginGate report={report} prefer={loginPrefer} onDone={(rep, logged) => loginDone.current(rep, logged)} />;
   }
 
-  // chat — apply remembered prefs as defaults (explicit flags win); --continue resumes
-  // the most recent session. model comes from the resolved ENGINE's own remembered
-  // model — a claude model id (e.g. "sonnet") sent to codex's API is a 400, so the two
-  // must never share one field.
+  // chat precedence: explicit flag > the resumed session's own saved model/effort >
+  // remembered prefs. A resumed session must come back running what it ran (not the
+  // prefs default); an explicit flag is the user overriding that, so it still wins.
+  // model comes from the resolved ENGINE's own remembered model, a claude model id
+  // (e.g. "sonnet") sent to codex's API is a 400, so the two never share one field,
+  // and the session's saved model only applies when it reopens on the same engine.
   const effectiveCli = options.cli ?? prefs.lastCli ?? "claude";
+  const sessionModel = resumed && resumed.cli === effectiveCli ? resumed.model : undefined;
   const effective: AppOptions = {
     ...options,
     cli: effectiveCli,
-    model: options.model ?? (effectiveCli === "codex" ? prefs.lastModelCodex : prefs.lastModelClaude),
-    effort: options.effort ?? prefs.lastEffort,
+    model: options.model ?? sessionModel ?? (effectiveCli === "codex" ? prefs.lastModelCodex : prefs.lastModelClaude),
+    effort: options.effort ?? resumed?.effort ?? prefs.lastEffort,
     resume: options.resume ?? (options.continue ? prefs.lastSessionId : undefined),
   };
   return (

--- a/surfaces/cli/src/commands.ts
+++ b/surfaces/cli/src/commands.ts
@@ -15,6 +15,7 @@ export const SLASH_COMMANDS: SlashCmd[] = [
   { name: "skills", desc: "your owned skill collection" },
   { name: "github", desc: "connect GitHub and register verified work" },
   { name: "more", desc: "load older history (scroll-back)" },
+  { name: "context", desc: "show context window usage" },
   { name: "compact", desc: "compact the conversation context" },
   { name: "clear", desc: "clear the on-screen transcript" },
   { name: "copy", desc: "copy the last reply to the clipboard" },

--- a/surfaces/cli/src/commands.ts
+++ b/surfaces/cli/src/commands.ts
@@ -22,13 +22,15 @@ export const SLASH_COMMANDS: SlashCmd[] = [
   { name: "engine", desc: "switch engine (carries session)", args: "claude|codex" },
   { name: "model", desc: "change model", args: "<model>" },
   { name: "models", desc: "pick a model from a menu" },
-  { name: "effort", desc: "set reasoning effort", args: "low|medium|high|xhigh|max" },
+  // levels live in the desc, not args: "/effort low|medium|high|xhigh|max" is wider than
+  // the /help label column can afford, and it glued itself to its own description there.
+  { name: "effort", desc: "set reasoning effort: low|medium|high|xhigh|max", args: "<level>" },
   { name: "efforts", desc: "pick effort from a menu" },
   { name: "account", desc: "show engine, auth method, ctx usage" },
   { name: "settings", desc: "show current engine/model/effort/cwd" },
   { name: "btw", desc: "side-channel question without interrupting session", args: "<question>" },
   { name: "wallet", desc: "show wallet address" },
-  { name: "storage", desc: "view/change where sessions save (connect or reconnect cloud)" },
+  { name: "storage", desc: "where sessions save (connect or reconnect cloud)" },
   { name: "logout", desc: "sign out of cloud storage (back to local-only)" },
   { name: "iq", desc: "a random IQ fact" },
   { name: "dance", desc: "Iggy dances" },

--- a/surfaces/cli/src/components/ApprovalCard.tsx
+++ b/surfaces/cli/src/components/ApprovalCard.tsx
@@ -2,7 +2,7 @@ import React from "react";
 import { Box, Text } from "ink";
 import type { ApprovalRequest } from "@iqlabs-official/agent-sdk/runtime/approval/channel";
 import { colors, glyph, tag } from "../theme.js";
-import { DiffView } from "./DiffView.js";
+import { DiffView, diffFileCount } from "./DiffView.js";
 import { wrapHard, wrapBlock, padCells, displayWidth } from "../format.js";
 
 // The decision ring. ONE list drives both the rendered buttons and the key handler in
@@ -213,10 +213,17 @@ export function ApprovalCard({
           </Text>
         ) : null}
         {req.diff && bodyRows >= 3 ? (
+          // bodyRows pays for the diff's own chrome before content: summary row (1),
+          // "+N more lines" fold (1), and — expanded multi-file only — the one-row
+          // Files strip. Uncounted, that strip was the row that tipped a 3 file diff
+          // past a 40x24 terminal into the repaint storm.
           <DiffView
             diff={req.diff}
             width={innerW}
-            maxLines={Math.max(1, bodyRows - 2)}
+            maxLines={Math.max(
+              1,
+              bodyRows - 2 - (diffExpanded && diffFileCount(req.diff) > 1 ? 1 : 0),
+            )}
             expanded={diffExpanded}
             activeFileIdx={activeDiffFileIdx}
           />

--- a/surfaces/cli/src/components/ApprovalCard.tsx
+++ b/surfaces/cli/src/components/ApprovalCard.tsx
@@ -70,21 +70,39 @@ export function ApprovalCard({
   const cornerTop = " ".repeat(Math.max(0, cols - 5)) + (danger ? "══╗" : "──┐");
   const cornerBottom = danger ? "╚══" : "└──";
 
+  // Long commands/paths have no break opportunity, so ink cannot wrap them and they run
+  // past the frame. Wrap them ourselves; show the head and fold the rest.
+  const commandRows = req.command ? wrapHard(`$ ${req.command}`, innerW).slice(0, 3) : [];
+
+  // The typed reply is wrapped by US, not ink: handed a free-running string, ink wraps
+  // it at the frame edge and the card grows one silent row per line — at 30x24 a long
+  // deny reason was enough to push the frame past the terminal and resurrect the
+  // clear-and-repaint storm. Wrap at the inner width minus the prompt glyph (2) and
+  // one cell so the caret always fits on the last row, then show the TAIL rows: the
+  // caret end is what the typist needs to see, the head can scroll off. Two rows is
+  // room enough to read the sentence being finished.
+  const REPLY_INPUT_ROWS = 2;
+  const replyAllRows = reply ? wrapHard(replyText, Math.max(4, innerW - 3)) : [];
+  const replyShown = replyAllRows.slice(-REPLY_INPUT_ROWS);
+  const replyHeadHidden = replyAllRows.length > replyShown.length;
+
   // The inline card takes the composer's slot inside a FIXED-HEIGHT frame, so anything it
   // renders past `maxRows` is not scrolled — it is clipped away, bottom-first. The
   // bottom is where the keys live, so an unbounded card silently eats its own answer row
   // and the prompt reads as a truncated blob you can't act on. Budget the rows: the
-  // fixed chrome is counted, the diff/plan/options get whatever is left.
+  // fixed chrome is counted AT ITS RENDERED HEIGHT (wrapped command rows, shown reply
+  // rows — a band counted as 1 while painting 3 is the same storm by another door), and
+  // the diff/plan/options get whatever is left.
   const showCwd = req.kind === "bash" && Boolean(req.cwd);
   const fixedRows =
     1 + // marginTop
     1 + // corner top / border top
     1 + // //REQUEST_ band (or //ASK_ / //PLAN_)
     (question ? 1 : isPlan ? 0 : 1) + // title (permission) or question prompt line
-    (req.command ? 1 : 0) +
+    commandRows.length +
     (showCwd ? 1 : 0) +
     (req.file ? 1 : 0) +
-    (reply ? 4 : 3) + // reply editor (margin+label+input+hint) or margin+keys+hint
+    (reply ? 3 + replyShown.length : 3) + // reply editor (margin+label+input rows+hint) or margin+keys+hint
     1; // corner bottom / border bottom
   const budget = popup ? Math.max(6, (process.stdout.rows || 24) - 4) : maxRows;
   const bodyRows = Math.max(0, budget - fixedRows);
@@ -97,10 +115,6 @@ export function ApprovalCard({
   };
   const bandBg = danger ? colors.danger : colors.ok;
   const bandFg = danger ? colors.bone : colors.ink;
-
-  // Long commands/paths have no break opportunity, so ink cannot wrap them and they run
-  // past the frame. Wrap them ourselves; show the head and fold the rest.
-  const commandRows = req.command ? wrapHard(`$ ${req.command}`, innerW).slice(0, 3) : [];
 
   // The decision grid's row budget is ONE row (fixedRows counts it as one). Below the
   // width where every worded cell fits, the words shed and the bracketed letters
@@ -224,13 +238,16 @@ export function ApprovalCard({
             ? "type your own answer, then ↵:"
             : "edit command, then ↵ to run:"}
       </Text>
-      <Box>
-        <Text color={colors.ok}>❯ </Text>
-        <Text>
-          {replyText}
-          <Text inverse> </Text>
+      {/* pre-wrapped rows (each fits innerW with the prompt + caret), so ink never adds
+          a wrap of its own. When head rows scrolled off, the prompt glyph becomes … —
+          the same signal truncateStart gives — so the cut is never silent. */}
+      {replyShown.map((r, i) => (
+        <Text key={i}>
+          <Text color={colors.ok}>{i === 0 ? (replyHeadHidden ? "… " : "❯ ") : "  "}</Text>
+          {r}
+          {i === replyShown.length - 1 ? <Text inverse> </Text> : null}
         </Text>
-      </Box>
+      ))}
       <Text dimColor>↵ submit · esc back</Text>
     </Box>
   ) : question ? (

--- a/surfaces/cli/src/components/ApprovalCard.tsx
+++ b/surfaces/cli/src/components/ApprovalCard.tsx
@@ -102,6 +102,18 @@ export function ApprovalCard({
   // past the frame. Wrap them ourselves; show the head and fold the rest.
   const commandRows = req.command ? wrapHard(`$ ${req.command}`, innerW).slice(0, 3) : [];
 
+  // The decision grid's row budget is ONE row (fixedRows counts it as one). Below the
+  // width where every worded cell fits, the words shed and the bracketed letters
+  // survive - [Y] [A] [N] [R], plus [E]/[D] where they apply - because a wrapped grid
+  // silently makes the card taller than the budget Chat granted it, which at 30x24 was
+  // one of the rows that pushed the approval frame past the terminal into ink's
+  // clear-and-repaint path. The hint row underneath still spells out the highlighted
+  // choice, so no meaning is lost, only the redundant words.
+  const gridCells = APPROVAL_CHOICES.map((c) => ` [${c.key.toUpperCase()}] ${c.cell} `);
+  const gridW =
+    gridCells.reduce((n, s) => n + displayWidth(s), 0) + (req.diff ? displayWidth("  [D] DIFF") : 0);
+  const compactKeys = gridW > innerW;
+
   // ── PLAN (Kind B): the model wants to leave plan mode. ↵ runs it, esc keeps planning.
   const planBody = isPlan ? (
     <>
@@ -254,11 +266,12 @@ export function ApprovalCard({
               backgroundColor={on ? c.tint : undefined}
               bold={on}
             >
-              {` [${c.key.toUpperCase()}] ${c.cell} `}
+              {compactKeys ? ` [${c.key.toUpperCase()}] ` : gridCells[i]}
             </Text>
           );
         })}
-        {req.diff ? <Text dimColor>{"  [D] DIFF"}</Text> : null}
+        {compactKeys && canEdit ? <Text dimColor>{" [E]"}</Text> : null}
+        {req.diff ? <Text dimColor>{compactKeys ? " [D]" : "  [D] DIFF"}</Text> : null}
       </Box>
       <Text dimColor wrap="truncate-end">
         {"←/→ move · ↵ "}

--- a/surfaces/cli/src/components/ChipCarousel.tsx
+++ b/surfaces/cli/src/components/ChipCarousel.tsx
@@ -14,6 +14,7 @@ export function ChipCarousel<T>({
   title,
   hint,
   chipWidth = 24,
+  count = true,
 }: {
   items: T[];
   index: number;
@@ -22,6 +23,7 @@ export function ChipCarousel<T>({
   title?: string;
   hint?: string;
   chipWidth?: number;
+  count?: boolean; // false drops the "N / M" row when the parent's height budget is spent
 }) {
   // || not ??: a detached pty reports columns 0, which would window to a single chip
   const cols = useStdout().stdout?.columns || 80;
@@ -53,10 +55,12 @@ export function ChipCarousel<T>({
           </Text>
         </Box>
       </Box>
-      <Box>
-        <Text dimColor>{items.length > 0 ? `${index + 1} / ${items.length}` : ""}</Text>
-        {hint ? <Text dimColor>{items.length > 0 ? "   " : ""}{hint}</Text> : null}
-      </Box>
+      {count ? (
+        <Box>
+          <Text dimColor>{items.length > 0 ? `${index + 1} / ${items.length}` : ""}</Text>
+          {hint ? <Text dimColor>{items.length > 0 ? "   " : ""}{hint}</Text> : null}
+        </Box>
+      ) : null}
     </Box>
   );
 }

--- a/surfaces/cli/src/components/Composer.tsx
+++ b/surfaces/cli/src/components/Composer.tsx
@@ -56,12 +56,16 @@ function splitAtCell(row: string, cell: number): [string, string, string] {
 export function Composer({
   cwd,
   onSubmit,
+  onHelp,
   disabled,
   maxRows,
   history = [],
 }: {
   cwd: string;
   onSubmit: (text: string, images?: ImageInput[]) => void;
+  // "?" pressed on an empty buffer (the footer advertises "? /HELP"). Only the composer
+  // knows the buffer is empty, so the routing decision has to live here.
+  onHelp: () => void;
   disabled?: boolean;
   // Rows this band may occupy. Chat owns it: it is the only place that knows what the
   // rest of the frame already costs, so the composer must not guess its own share.
@@ -272,6 +276,9 @@ export function Composer({
       }
       if (key.leftArrow) return setCursor((c) => Math.max(0, c - 1));
       if (key.rightArrow) return setCursor((c) => Math.min(value.length, c + 1));
+      // "?" on an EMPTY composer opens help, keeping the footer's "? /HELP" promise.
+      // With anything typed (or an image awaiting a caption), "?" is just a character.
+      if (input === "?" && value.length === 0 && attached.length === 0) return onHelp();
       if (input && !key.ctrl && !key.meta) insertAt(input); // printable / paste (may include \n)
     },
     { isActive: !disabled },

--- a/surfaces/cli/src/components/DiffView.tsx
+++ b/surfaces/cli/src/components/DiffView.tsx
@@ -155,10 +155,14 @@ export function DiffView({
   const contentTotal = numbered.filter((e) => !e.sep).length;
   const hidden = contentTotal - new Set(shownRows.filter((r) => r.idx >= 0).map((r) => r.idx)).size;
 
+  // The summary is ONE row by contract - the hosting card counts it as one when it
+  // budgets rows - but its full sentence is wider than a narrow terminal, and a wrap
+  // here silently makes the card 2 rows taller than the count. truncate-end keeps the
+  // row honest; the counts at the head are the part that must survive.
   if (!expanded) {
     return (
       <Box flexDirection="column" marginY={0}>
-        <Text>
+        <Text wrap="truncate-end">
           <Text color={colors.ok}>+{totalAdds}</Text> <Text color={colors.err}>−{totalDels}</Text>
           <Text dimColor> lines changed across </Text>
           <Text color={colors.iqCyan} bold>{files.length}</Text>
@@ -188,7 +192,8 @@ export function DiffView({
   return (
     <Box flexDirection="column">
       {summary ? (
-        <Text>
+        // same one-row contract as the collapsed summary above
+        <Text wrap="truncate-end">
           <Text color={colors.ok}>+{totalAdds}</Text> <Text color={colors.err}>−{totalDels}</Text>
           <Text dimColor> lines changed across </Text>
           <Text color={colors.iqCyan} bold>{files.length}</Text>

--- a/surfaces/cli/src/components/DiffView.tsx
+++ b/surfaces/cli/src/components/DiffView.tsx
@@ -1,7 +1,15 @@
 import React from "react";
 import { Box, Text } from "ink";
 import { colors, diff as diffTheme } from "../theme.js";
-import { padCells, wrapHard } from "../format.js";
+import { padCells, wrapHard, displayWidth } from "../format.js";
+
+// How many files a diff carries — the ONE parse both this component and a hosting card's
+// row budget read, so "will the Files strip render?" can never disagree with whether it
+// does. A multi-file diff costs the strip's one row; the host subtracts it from the
+// content budget it passes as maxLines.
+export function diffFileCount(diff: string): number {
+  return parseMultiFileDiff(diff).length;
+}
 
 // Shaded diff — added lines on a dark-green band, removed on dark-red, hunks dim violet,
 // context dim. Lines are padded to a rectangle so the bands read as clean blocks; a header
@@ -179,15 +187,24 @@ export function DiffView({
     );
   }
 
-  const tabs = files.map((f, idx) => {
-    const isActive = idx === activeFileIdx;
-    const label = `[${idx + 1}] ${f.path.split("/").pop() || f.path}`;
-    return (
-      <Text key={idx} color={isActive ? colors.iqCyan : colors.dim} bold={isActive}>
-        {isActive ? ` ${label} ` : ` ${label} `}
-      </Text>
-    );
-  });
+  // The Files strip is ONE row by contract — the same contract the summary row keeps —
+  // because the hosting card counts it as one when it budgets rows. It used to be a
+  // marginY={1} Box whose tabs wrapped at narrow widths: 3 uncounted rows (blank, wrap,
+  // blank) that pushed the approval frame past a 40x24 terminal into the repaint storm.
+  // Now: no margins, one Text with truncate-end. The window below slides the visible
+  // tabs so the ACTIVE one always fits (a leading … marks what slid off); tabs past the
+  // right edge are cut by the truncation. Switching keys live in the host and are
+  // untouched — every file still renders when picked, its tab is just guaranteed a seat.
+  const tabLabels = files.map((f, idx) => ` [${idx + 1}] ${f.path.split("/").pop() || f.path} `);
+  let tabStart = 0;
+  {
+    const avail = width - displayWidth("Files: ") - 1; // 1 for the leading … marker
+    while (
+      tabStart < activeFileIdx &&
+      tabLabels.slice(tabStart, activeFileIdx + 1).reduce((n, s) => n + displayWidth(s), 0) > avail
+    )
+      tabStart++;
+  }
 
   return (
     <Box flexDirection="column">
@@ -209,9 +226,20 @@ export function DiffView({
       ) : null}
 
       {files.length > 1 ? (
-        <Box flexDirection="row" marginY={1}>
-          <Text dimColor>Files: </Text>
-          {tabs}
+        <Box>
+          <Text wrap="truncate-end">
+            <Text dimColor>Files: </Text>
+            {tabStart > 0 ? <Text dimColor>…</Text> : null}
+            {tabLabels.slice(tabStart).map((label, i) => {
+              const idx = tabStart + i;
+              const isActive = idx === activeFileIdx;
+              return (
+                <Text key={idx} color={isActive ? colors.iqCyan : colors.dim} bold={isActive}>
+                  {label}
+                </Text>
+              );
+            })}
+          </Text>
         </Box>
       ) : null}
 

--- a/surfaces/cli/src/components/Footer.tsx
+++ b/surfaces/cli/src/components/Footer.tsx
@@ -49,7 +49,11 @@ export function Footer({
           keeps one honest gap from the shortcuts when the row is completely full. */}
       <Box paddingLeft={1}>
         <Box flexShrink={0}>
-          <Text color={busy ? colors.warn : colors.ok} bold>{"● "}</Text>
+          {/* green = a turn is running, same encoding the status row teaches one band
+              up (its busy label is signal green). The dot used to flip amber on busy
+              while the status row went green, two colors for one state on one screen.
+              Idle dims: nothing is happening, nothing asks for the eye. */}
+          <Text color={busy ? colors.ok : colors.dim} bold>{"● "}</Text>
           <Text color={colors.bone} bold>{cli.toUpperCase()}</Text>
         </Box>
         <Text dimColor wrap="truncate-end"> · {modelLabel}</Text>

--- a/surfaces/cli/src/components/Footer.tsx
+++ b/surfaces/cli/src/components/Footer.tsx
@@ -49,11 +49,7 @@ export function Footer({
           keeps one honest gap from the shortcuts when the row is completely full. */}
       <Box paddingLeft={1}>
         <Box flexShrink={0}>
-          {/* green = a turn is running, same encoding the status row teaches one band
-              up (its busy label is signal green). The dot used to flip amber on busy
-              while the status row went green, two colors for one state on one screen.
-              Idle dims: nothing is happening, nothing asks for the eye. */}
-          <Text color={busy ? colors.ok : colors.dim} bold>{"● "}</Text>
+          <Text color={busy ? colors.warn : colors.ok} bold>{"● "}</Text>
           <Text color={colors.bone} bold>{cli.toUpperCase()}</Text>
         </Box>
         <Text dimColor wrap="truncate-end"> · {modelLabel}</Text>

--- a/surfaces/cli/src/components/Footer.tsx
+++ b/surfaces/cli/src/components/Footer.tsx
@@ -31,8 +31,9 @@ export function Footer({
 
   return (
     <Box justifyContent="space-between">
-      {/* left: shortcuts */}
-      <Box>
+      {/* left: shortcuts - pinned (flexShrink 0): these are the advertised keys, so they
+          never shed characters; the pill on the right takes all the shrink */}
+      <Box flexShrink={0}>
         {shortcuts.map((s, i) => (
           <Text key={s} dimColor>
             {i > 0 ? " · " : ""}
@@ -41,11 +42,17 @@ export function Footer({
         ))}
       </Box>
 
-      {/* right: engine + model */}
-      <Box>
-        <Text color={busy ? colors.warn : colors.ok} bold>{"● "}</Text>
-        <Text color={colors.bone} bold>{cli.toUpperCase()}</Text>
-        <Text dimColor> · {modelLabel}</Text>
+      {/* right: engine + model. The glyph and engine name are pinned (flexShrink 0) and
+          the model label truncates, so when the pill outgrows a narrow terminal it
+          shrinks by shedding model characters instead of wrapping onto a second row -
+          the same one-line contract the shortcuts keep by shedding items. The paddingLeft
+          keeps one honest gap from the shortcuts when the row is completely full. */}
+      <Box paddingLeft={1}>
+        <Box flexShrink={0}>
+          <Text color={busy ? colors.warn : colors.ok} bold>{"● "}</Text>
+          <Text color={colors.bone} bold>{cli.toUpperCase()}</Text>
+        </Box>
+        <Text dimColor wrap="truncate-end"> · {modelLabel}</Text>
       </Box>
     </Box>
   );

--- a/surfaces/cli/src/components/Footer.tsx
+++ b/surfaces/cli/src/components/Footer.tsx
@@ -19,9 +19,12 @@ export function Footer({
   const cols = process.stdout.columns || 80;
   // The design's footer names the panels that open (SESSIONS, MODEL) rather than raw
   // slash commands — /sessions and /model open exactly these, so the labels stay honest.
+  // The esc hint appears only while a turn is running: idle, esc does nothing at the top
+  // level, and a hint for a dead key teaches users to distrust the footer. Busy, esc
+  // interrupts the turn, so the label says INTERRUPT (same word the status row uses).
   const shortcuts =
     cols >= 90
-      ? ["? /HELP", "ESC CANCEL", "SESSIONS", "MODEL"]
+      ? ["? /HELP", ...(busy ? ["ESC INTERRUPT"] : []), "SESSIONS", "MODEL"]
       : cols >= 64
         ? ["? /HELP", "SESSIONS", "MODEL"]
         : ["? /HELP"];

--- a/surfaces/cli/src/components/Message.tsx
+++ b/surfaces/cli/src/components/Message.tsx
@@ -4,19 +4,38 @@ import type { ChatMessage } from "@iqlabs-official/agent-sdk/runtime/contract";
 import { glyph, colors, tag, surface } from "../theme.js";
 import { ToolCard } from "./ToolCard.js";
 import { Markdown } from "./Markdown.js";
-import { wrapBlock, padCells } from "../format.js";
+import { wrapBlock, padCells, truncateEnd } from "../format.js";
+
+// Painted text rows of the pinned TurnHeader for `text` at the current terminal width -
+// the same wrap the component renders, so a frame budget can count exactly what will
+// paint (the detail views' mainLines/mainViewportH pattern: one source for the row
+// count and the render). Excludes the component's marginTop; the caller counts that.
+export function turnHeaderRows(text: string, maxRows?: number): number {
+  const inner = Math.max(10, (process.stdout.columns || 80) - 4);
+  const n = wrapBlock(text, inner).length;
+  return maxRows !== undefined ? Math.min(n, Math.max(1, maxRows)) : n;
+}
 
 // The ONE inverted band on screen: the turn currently running, pinned above its streaming
 // reply so you can still read what you asked (the design's tab 09 "PINNED" header, and the
 // terminal's stand-in for the webview's scroll-pinned header). Settled turns in scrollback
 // do NOT use this - they render calm via <UserLine> - so the transcript is never a wall of
 // inverted bars. Reserving the invert for the live turn is what keeps a long chat scannable.
-export function TurnHeader({ text }: { text: string }) {
+//
+// `maxRows` clamps the band to a budgeted row count (Chat passes it while a tool approval
+// is pinned, where every band shares one terminal-height budget): the head rows survive -
+// the ask's opening words are what identify it - and the cut is marked with an ellipsis.
+export function TurnHeader({ text, maxRows }: { text: string; maxRows?: number }) {
   const inner = Math.max(10, (process.stdout.columns || 80) - 4); // frame paddingX + "> "
   const lines = wrapBlock(text, inner);
+  const budget = maxRows !== undefined ? Math.max(1, maxRows) : lines.length;
+  const shown =
+    lines.length > budget
+      ? [...lines.slice(0, budget - 1), truncateEnd(lines.slice(budget - 1).join(" "), inner)]
+      : lines;
   return (
     <Box flexDirection="column" marginTop={1}>
-      {lines.map((l, i) => (
+      {shown.map((l, i) => (
         <Text key={i} backgroundColor={colors.bone} color={colors.ink} bold>
           {i === 0 ? "❯ " : "  "}
           {padCells(l, inner)}

--- a/surfaces/cli/src/components/Message.tsx
+++ b/surfaces/cli/src/components/Message.tsx
@@ -6,13 +6,20 @@ import { ToolCard } from "./ToolCard.js";
 import { Markdown } from "./Markdown.js";
 import { wrapBlock, padCells, truncateEnd } from "../format.js";
 
+// Inner width of a full-width turn band: the frame's paddingX (2) plus the band's own
+// "❯ " prefix (2). ONE function, read at render time (a module const would freeze the
+// width at import and miss resizes), shared by the row counter and both band renderers
+// so a budget can never count a different wrap than the one that paints.
+function bandInnerW(): number {
+  return Math.max(10, (process.stdout.columns || 80) - 4);
+}
+
 // Painted text rows of the pinned TurnHeader for `text` at the current terminal width -
 // the same wrap the component renders, so a frame budget can count exactly what will
 // paint (the detail views' mainLines/mainViewportH pattern: one source for the row
 // count and the render). Excludes the component's marginTop; the caller counts that.
 export function turnHeaderRows(text: string, maxRows?: number): number {
-  const inner = Math.max(10, (process.stdout.columns || 80) - 4);
-  const n = wrapBlock(text, inner).length;
+  const n = wrapBlock(text, bandInnerW()).length;
   return maxRows !== undefined ? Math.min(n, Math.max(1, maxRows)) : n;
 }
 
@@ -26,7 +33,7 @@ export function turnHeaderRows(text: string, maxRows?: number): number {
 // is pinned, where every band shares one terminal-height budget): the head rows survive -
 // the ask's opening words are what identify it - and the cut is marked with an ellipsis.
 export function TurnHeader({ text, maxRows }: { text: string; maxRows?: number }) {
-  const inner = Math.max(10, (process.stdout.columns || 80) - 4); // frame paddingX + "> "
+  const inner = bandInnerW();
   const lines = wrapBlock(text, inner);
   const budget = maxRows !== undefined ? Math.max(1, maxRows) : lines.length;
   const shown =
@@ -50,7 +57,7 @@ export function TurnHeader({ text, maxRows }: { text: string; maxRows?: number }
 // So a long scrollback reads as a ladder of subtle grey bars you can scan for your own
 // words, while the bright bone invert is reserved for the single live turn (TurnHeader).
 function UserLine({ text }: { text: string }) {
-  const inner = Math.max(10, (process.stdout.columns || 80) - 4);
+  const inner = bandInnerW();
   const lines = wrapBlock(text, inner);
   return (
     <Box flexDirection="column" marginTop={1}>

--- a/surfaces/cli/src/components/StatusLine.tsx
+++ b/surfaces/cli/src/components/StatusLine.tsx
@@ -52,7 +52,13 @@ export function StatusLine({
 
   return (
     <Box width={Math.max(0, cols - 2)}>
-      <Iggy mood={mood} />
+      {/* The mascot is padded to the widest animation frame (see Iggy) so it never
+          RESIZES - but when the whole band is squeezed, those padding spaces WRAP,
+          hanging a phantom blank row under the band. Clamp the slot to one row and
+          clip the wrapped spaces: the same height={1} contract the status text keeps. */}
+      <Box height={1} overflow="hidden">
+        <Iggy mood={mood} />
+      </Box>
       <Box flexGrow={1} paddingLeft={2} overflow="hidden">
         {status}
       </Box>

--- a/surfaces/cli/src/components/ToolCard.tsx
+++ b/surfaces/cli/src/components/ToolCard.tsx
@@ -162,7 +162,15 @@ export function ToolCard({ tool, fallback }: { tool?: ToolAction; fallback?: str
 
   const kind = kindOf(tool.name);
   const tint = toolTint[kind];
-  const okExit = tool.exitCode === undefined || tool.exitCode === 0;
+  // Evidence-based status marker. An exit code only exists for a call that actually ran;
+  // a tool_use card paints BEFORE its outcome (and <Static> never repaints it), so the
+  // old "undefined exitCode = ok" guess stamped a green check on calls whose outcome was
+  // unknown, including DENIED ones, which then read as completed forever (issue 167
+  // round 2). Three honest states: ran (check/cross from the real exit code), denied
+  // (the approval flow's deny color and word), no recorded outcome (dim dot, no claim).
+  const denied = tool.denied === true;
+  const ran = !denied && typeof tool.exitCode === "number";
+  const failed = denied || (ran && tool.exitCode !== 0);
   const outLines = tool.output ? lineCount(stripAnsi(tool.output)) : 0;
   const fileLang = langFor(tool.file);
   const { card, inner } = cardWidth();
@@ -226,7 +234,7 @@ export function ToolCard({ tool, fallback }: { tool?: ToolAction; fallback?: str
         {outputInBox ? (
           <>
             <Text color={surface.pastHeader}>{"─".repeat(boxInner)}</Text>
-            <Output text={tool.output!} failed={!okExit} lang={fileLang} width={boxInner} bare />
+            <Output text={tool.output!} failed={failed} lang={fileLang} width={boxInner} bare />
           </>
         ) : null}
       </CodeBox>
@@ -248,13 +256,16 @@ export function ToolCard({ tool, fallback }: { tool?: ToolAction; fallback?: str
       paddingLeft={1}
       marginTop={1}
     >
-      {/* header row - the design's turn node (tab 09): a green check (red cross on failure)
-          leads, then the tool in caps, then where it acted. The kind is carried by the
-          label's tint, so the old leading kind-glyph is gone and the exit marker moves up
-          front where the eye already scans for pass/fail. */}
+      {/* header row - the design's turn node (tab 09): the status marker leads (check /
+          cross / dim dot per the evidence rule above), then the tool in caps, then where
+          it acted. A refusal additionally wears the approval flow's DENY word in its err
+          tint, so "refused" never reads as "ran and failed". */}
       <Box>
-        <Text color={okExit ? colors.ok : colors.err} bold>{okExit ? glyph.ok : glyph.fail} </Text>
+        <Text color={failed ? colors.err : ran ? colors.ok : colors.dim} bold>
+          {failed ? glyph.fail : ran ? glyph.ok : glyph.other}{" "}
+        </Text>
         <Text color={tint} bold>{tool.name.toUpperCase()}</Text>
+        {denied ? <Text color={colors.err} bold>{"  DENIED"}</Text> : null}
         {/* When a diff box follows, its title band owns the (full) path — repeating a
             shortened copy up here just said the same thing twice in two spellings. */}
         {tool.file && !tool.diff ? (
@@ -268,7 +279,7 @@ export function ToolCard({ tool, fallback }: { tool?: ToolAction; fallback?: str
       </Box>
       {body}
       {tool.output && !outputInBox ? (
-        <Output text={tool.output} failed={!okExit} lang={fileLang} width={inner - 2} />
+        <Output text={tool.output} failed={failed} lang={fileLang} width={inner - 2} />
       ) : null}
     </Box>
   );

--- a/surfaces/cli/src/components/WelcomePanel.tsx
+++ b/surfaces/cli/src/components/WelcomePanel.tsx
@@ -244,8 +244,11 @@ export function WelcomePanel({
       <Box key="skills" width={bandW}>
         <Text bold color={colors.bone}>{` ${tag("skills")}  `}</Text>
         <Text>
+          {/* non-dim pieces are exactly the wallet's OWNED skills (built-ins and the
+              market link are dim); green asserts ownership here the same way the
+              market chip's OWNED and the profile's owned rows do. */}
           {skillsValue.pieces.map((p, i) => (
-            <Text key={i} color={p.dim ? colors.dim : undefined}>{p.text}</Text>
+            <Text key={i} color={p.dim ? colors.dim : colors.ok}>{p.text}</Text>
           ))}
         </Text>
       </Box>

--- a/surfaces/cli/src/components/WelcomePanel.tsx
+++ b/surfaces/cli/src/components/WelcomePanel.tsx
@@ -83,7 +83,12 @@ function fitSkills(
     const reserve = left > 0 ? displayWidth(` · +${left}`) : 0;
     const cost = displayWidth(`${item.text} · `);
     if (used + cost + reserve > width) break;
-    pieces.push({ text: `${item.text} · `, dim: item.dim });
+    // The " · " separator is its own ALWAYS-DIM piece: an owned skill's green stops
+    // at its name, so every separator reads the same no matter which neighbor it
+    // trails. The budget above still counts name plus separator as one cost, so the
+    // fitted width is byte-identical to the joined-piece version.
+    pieces.push({ text: item.text, dim: item.dim });
+    pieces.push({ text: " · ", dim: true });
     used += cost;
     taken++;
   }

--- a/surfaces/cli/src/components/WelcomePanel.tsx
+++ b/surfaces/cli/src/components/WelcomePanel.tsx
@@ -2,7 +2,7 @@ import React from "react";
 import { Box, Text, useInput } from "ink";
 import { HELIUS_QUICKSTART_URL } from "@iqlabs-official/agent-sdk";
 import { colors, glyph, rule, tag } from "../theme.js";
-import { displayWidth, truncateStart } from "../format.js";
+import { displayWidth, truncateStart, truncateEnd } from "../format.js";
 
 // Focusable rows, in order: the four settings bands, then the skills band (enter = market).
 export type PanelField = "wallet" | "cloud" | "engine" | "helius";
@@ -27,12 +27,6 @@ export interface OwnedSkill {
   name: string;
 }
 
-function truncate(s: string, w: number): string {
-  if (displayWidth(s) <= w) return s;
-  let head = s;
-  while (head.length > 1 && displayWidth(`${head}…`) > w) head = head.slice(0, -1);
-  return `${head}…`;
-}
 
 // One config band, the design's row silhouette (tab 03): `//TAG_` on the left, the value
 // on the right edge, and the focused band FULLY inverted (ink on bone, edge to edge) —
@@ -51,7 +45,7 @@ function Band({
   focused: boolean;
 }) {
   const left = ` ${tag(label)}`;
-  const fitted = truncate(value, Math.max(4, width - displayWidth(left) - 3));
+  const fitted = truncateEnd(value, Math.max(4, width - displayWidth(left) - 3));
   if (focused) {
     const gap = Math.max(1, width - displayWidth(left) - displayWidth(fitted) - 1);
     return (

--- a/surfaces/cli/src/format.ts
+++ b/surfaces/cli/src/format.ts
@@ -190,3 +190,19 @@ export function truncateStart(s: string, width: number): string {
   while (tail.length > 1 && displayWidth(`…${tail}`) > width) tail = tail.slice(1);
   return `…${tail}`;
 }
+
+// Fit to `width` cells keeping the HEAD, with a trailing ellipsis when cut. Cell-aware
+// (wide glyphs count 2) and cluster-aware: the cut lands between grapheme clusters, so
+// an emoji or a composed glyph is dropped whole, never split into a broken surrogate.
+export function truncateEnd(s: string, width: number): string {
+  if (displayWidth(s) <= width) return s;
+  let head = "";
+  let used = 0;
+  for (const g of graphemes(s)) {
+    const cw = displayWidth(g);
+    if (used + cw + 1 > width) break; // reserve the ellipsis cell
+    head += g;
+    used += cw;
+  }
+  return `${head}…`;
+}

--- a/surfaces/cli/src/hooks/useChat.ts
+++ b/surfaces/cli/src/hooks/useChat.ts
@@ -43,7 +43,12 @@ export function useChat(
   opts: { cli: Engine; model?: string; effort?: EffortLevel; cwd: string; resume?: string; approval?: ApprovalChannel },
 ) {
   const [messages, setMessages] = useState<ChatMessage[]>([]);
-  const [sessions, setSessions] = useState<SessionMeta[]>([]);
+  // null = the first listSessions has not settled (the WelcomePanel null-means-loading
+  // convention): the session picker says loading instead of "no sessions yet" while the
+  // list is still being read. sessionsError carries a failed read's message (cleared on
+  // the next successful refresh), mirroring loadSessionError below.
+  const [sessions, setSessions] = useState<SessionMeta[] | null>(null);
+  const [sessionsError, setSessionsError] = useState<string | null>(null);
   const [busy, setBusy] = useState(false);
   const [cli, setCli] = useState<Engine>(opts.cli);
   const [model, setModel] = useState<string | undefined>(opts.model);
@@ -113,7 +118,15 @@ export function useChat(
   const backfillToken = useRef(0);
 
   const refreshSessions = useCallback(async () => {
-    setSessions(await runtime.listSessions());
+    // never throws: several callers fire-and-forget this (turn end, /sessions), so a
+    // failed read lands in sessionsError for the picker to show instead of rejecting
+    // into the void. A failure keeps any previously loaded list (settled data).
+    try {
+      setSessions(await runtime.listSessions());
+      setSessionsError(null);
+    } catch (e) {
+      setSessionsError(e instanceof Error ? e.message : String(e));
+    }
   }, [runtime]);
 
   // turn timer: tick elapsed while busy.
@@ -478,6 +491,7 @@ export function useChat(
   return {
     messages,
     sessions,
+    sessionsError,
     busy,
     cli,
     model,

--- a/surfaces/cli/src/index.tsx
+++ b/surfaces/cli/src/index.tsx
@@ -102,7 +102,9 @@ program
   .description("resume a saved session by id")
   .action((sessionId, _opts, cmd) => {
     const g = cmd.parent.opts();
-    launch({ cli: g.cli, cwd: g.cwd, keypair: g.keypair, model: g.model, resume: sessionId }, g.calm);
+    // pass --effort through like --model: `agentnet --effort high resume <id>` used to
+    // silently drop it, so the flag could never override the session's saved effort.
+    launch({ cli: g.cli, cwd: g.cwd, keypair: g.keypair, model: g.model, effort: g.effort, resume: sessionId }, g.calm);
   });
 
 // agentnet doctor → quick non-TUI engine install/login report.

--- a/surfaces/cli/src/index.tsx
+++ b/surfaces/cli/src/index.tsx
@@ -18,6 +18,10 @@ import { installStdoutFilter } from "./cursorPin.js";
 // to a log file instead (same content, just not in front of the user), unless the user asked
 // for exactly this kind of visibility (AGENTNET_DEBUG, or AGENTNET_PERF for the traffic-audit
 // [perf] lines) — then leave the real console methods alone.
+// Process-level warnings (the punycode DeprecationWarning class) get the same treatment but
+// must be caught earlier: they fire while the dependency chunks evaluate, before any code in
+// this module runs, so that capture lives in the tsup banner (see tsup.config.ts). It logs
+// them to the same file below.
 function quietDiagnosticsToFile() {
   if (process.env.AGENTNET_DEBUG || process.env.AGENTNET_PERF) return;
   const logFile = join(homedir(), ".agentnet", "cli-debug.log");

--- a/surfaces/cli/src/inputHistory.ts
+++ b/surfaces/cli/src/inputHistory.ts
@@ -1,0 +1,76 @@
+import { readFileSync } from "node:fs";
+import { mkdir, writeFile } from "node:fs/promises";
+import { homedir } from "node:os";
+import { join, dirname } from "node:path";
+
+// Persistent composer history, shell-style: everything the user SENDS (messages,
+// slash commands, ! bash lines) lands in one file, so a fresh session's up-arrow
+// recalls prior sessions' inputs the way codex does. This is a surface concern -
+// what was TYPED into this composer, across engines and sessions - so it lives
+// beside cli.json in the CLI's own config home, not in core's session store
+// (those are per-session, wallet-encrypted blobs on whichever storage backend is
+// connected; recalling keystrokes must not depend on decrypting session logs).
+//
+// Shape: a JSON array of strings, oldest first / newest last - JSON escaping keeps
+// multi-line inputs intact on one of the file's lines. Capped at the newest
+// HISTORY_CAP entries. The composer's recall walks it newest-first from the end.
+
+export const HISTORY_CAP = 1000;
+
+// Same root ~/.agentnet dir cli.json uses; AGENTNET_HOME overrides it exactly as
+// core/paths.ts documents for every other file under that root (lets probes and
+// multi-account setups point elsewhere).
+const historyFile = () =>
+  join(process.env.AGENTNET_HOME || join(homedir(), ".agentnet"), "input-history.json");
+
+// Sync read for boot: Chat seeds its history state in a useState initializer, the
+// same pattern readPrefsSync serves for DelightProvider.
+export function loadInputHistory(): string[] {
+  try {
+    const parsed: unknown = JSON.parse(readFileSync(historyFile(), "utf8"));
+    if (!Array.isArray(parsed)) return [];
+    return parsed
+      .filter((e): e is string => typeof e === "string" && e.length > 0)
+      .slice(-HISTORY_CAP);
+  } catch {
+    return []; // no file yet / unreadable / corrupt: start empty, never break boot
+  }
+}
+
+// Append one sent input. Empty strings never stored; a resend identical to the
+// newest stored entry is skipped (consecutive dedupe, like HISTIGNORE dups).
+// Read-modify-write keeps the file a plain capped array with no index to corrupt.
+// 0o600 like the token files: recalled inputs are the user's own prompts.
+export async function appendInputHistory(entry: string): Promise<void> {
+  if (!entry) return;
+  const cur = loadInputHistory();
+  if (cur[cur.length - 1] === entry) return;
+  cur.push(entry);
+  try {
+    await mkdir(dirname(historyFile()), { recursive: true, mode: 0o700 });
+    await writeFile(historyFile(), JSON.stringify(cur.slice(-HISTORY_CAP), null, 2), {
+      mode: 0o600,
+    });
+  } catch {
+    /* best-effort: a history write failure must never break the send */
+  }
+}
+
+// Merge history sources into one recall list, oldest first / newest last, no
+// duplicates: when the same text appears in more than one source (a persisted
+// entry retyped this session, a resumed transcript message already on disk) the
+// LATEST occurrence keeps its position, so up-arrow order stays session-local
+// newest first. Pure; the composer's histPos state machine consumes the result
+// unchanged.
+export function mergeHistory(...sources: string[][]): string[] {
+  const all = sources.flat().filter((e) => e.length > 0);
+  const seen = new Set<string>();
+  const out: string[] = [];
+  for (let i = all.length - 1; i >= 0; i--) {
+    if (!seen.has(all[i])) {
+      seen.add(all[i]);
+      out.unshift(all[i]);
+    }
+  }
+  return out;
+}

--- a/surfaces/cli/src/theme.ts
+++ b/surfaces/cli/src/theme.ts
@@ -22,6 +22,23 @@ export const colors = {
   danger: "#ff3b30", // hard danger (destructive command / gated), distinct from err text
 } as const;
 
+// Reputation metals: the tier ladder's visual identity (design tab 20's rank column).
+// Each rank owns one truecolor tone that reads distinctly on the near-black ground:
+// bronze is a copper, silver a cool grey-white (cooler than bone so the two never blur),
+// gold the warm gold the palette already knows, legendary the signal green the ladder
+// legend teaches. Every screen that shows a rank routes through tierColor so a badge,
+// a ladder rung, and the legend can never disagree about what a tier looks like.
+export const tierColors: Record<string, string> = {
+  bronze: "#cd7f32",
+  silver: "#c8ccd4",
+  gold: "#e3b341",
+  legendary: "#3fd96f",
+};
+
+// tierColor("Gold") → that rank's tone; unranked/unknown falls back to structural grey.
+export const tierColor = (name?: string | null): string =>
+  (name && tierColors[name.toLowerCase()]) || colors.dim;
+
 // Structural surfaces from the design that are NOT brand colors: the panel backgrounds,
 // rails, and separators used to LAYER a panel above the chat (the design's overlays rise
 // out of the footer instead of replacing the frame). Kept apart from `colors` so the brand

--- a/surfaces/cli/src/views/Chat.tsx
+++ b/surfaces/cli/src/views/Chat.tsx
@@ -1533,7 +1533,9 @@ export function Chat({
           walletAddr={address}
           ownedNames={installed}
           initialStage={marketStage}
-          owned={skills ?? []}
+          // null passes through while ownedSkills is still fetching: the market's owned
+          // and github screens say loading instead of claiming "no skills owned yet".
+          owned={skills}
           onBought={() => {
             // a buy installs the skill — refresh the badge source + the welcome panel list.
             void market.ownedSkills().then(setInstalled).catch(() => {});

--- a/surfaces/cli/src/views/Chat.tsx
+++ b/surfaces/cli/src/views/Chat.tsx
@@ -840,6 +840,14 @@ export function Chat({
     setPanelFocused(false);
   }
 
+  // /help and the footer's advertised "?" both land here: the composer routes a "?"
+  // pressed on an EMPTY buffer to onHelp (with text present, "?" just types), so the
+  // footer's "? /HELP" hint is a promise the keyboard actually keeps.
+  function openHelp() {
+    setHelpScroll(0); // each open starts at the top of the list
+    setShowHelp(true);
+  }
+
   function openMarket(stage: "list" | "agents" | "owned" | "github" = "list") {
     setPanelFocused(false);
     if (!market) {
@@ -1153,8 +1161,7 @@ export function Chat({
       case "help":
         // A dismissable overlay (not a one-line notice that vanishes on the next keystroke),
         // rendered straight from SLASH_COMMANDS so the list never drifts from the registry.
-        setHelpScroll(0); // each open starts at the top of the list
-        setShowHelp(true);
+        openHelp();
         return;
       case "keys":
         setShowKeys(true);
@@ -1668,6 +1675,7 @@ export function Chat({
         <Composer
           cwd={cwd}
           onSubmit={onSubmit}
+          onHelp={openHelp}
           disabled={showSessions || panelActive || !!pendingApproval}
           maxRows={composerMaxRows}
           history={chat.messages.filter((m) => m.role === "user").map((m) => m.text)}

--- a/surfaces/cli/src/views/Chat.tsx
+++ b/surfaces/cli/src/views/Chat.tsx
@@ -1240,12 +1240,17 @@ export function Chat({
   // /help overlay — the slash-command list, sourced from the shared registry so it stays
   // in lockstep with autocomplete instead of a hand-maintained string that drifts.
   if (showHelp) {
+    // Two honest columns: the widest "/name args" label sets the label column (the old
+    // fixed 24 was narrower than "/engine claude|codex" wants and glued long labels to
+    // their descriptions), and rows never wrap (truncate-end) so a long description
+    // cannot orphan half a sentence onto its own line.
+    const colW = Math.max(...SLASH_COMMANDS.map((c) => `/${c.name}${c.args ? ` ${c.args}` : ""}`.length)) + 2;
     return (
       <Box flexDirection="column" paddingX={1}>
         <Box borderStyle="round" borderColor={colors.bone} flexDirection="column" paddingX={2} paddingY={1}>
           <Text bold color={colors.iqCyan}>commands</Text>
           {SLASH_COMMANDS.map((c) => (
-            <Text key={c.name} dimColor>{`/${c.name}${c.args ? ` ${c.args}` : ""}`.padEnd(24)}{c.desc}</Text>
+            <Text key={c.name} dimColor wrap="truncate-end">{`/${c.name}${c.args ? ` ${c.args}` : ""}`.padEnd(colW)}{c.desc}</Text>
           ))}
           <Box marginTop={1}><Text dimColor>!cmd runs a shell command  ·  /keys for shortcuts</Text></Box>
           <Box marginTop={1}><Text dimColor>Esc / Enter  close</Text></Box>
@@ -1271,7 +1276,12 @@ export function Chat({
           <Text dimColor>{"Ctrl+V".padEnd(16)}paste an image from the clipboard</Text>
           <Text dimColor>{"\\ then Enter".padEnd(16)}insert a newline</Text>
           <Text dimColor>{"Ctrl+S".padEnd(16)}focus the welcome panel (Esc returns)</Text>
-          <Box marginTop={1}><Text dimColor>at an approval prompt:  y accept · a always · n deny · e edit · r reason · d diff</Text></Box>
+          {/* label and keys on separate rows: on one row the last key wrapped alone
+              ("· d diff" orphaned on its own line) at ordinary 80-col terminals */}
+          <Box marginTop={1} flexDirection="column">
+            <Text dimColor>at an approval prompt:</Text>
+            <Text dimColor>{"  y accept · a always · n deny · e edit · r reason · d diff"}</Text>
+          </Box>
           <Box marginTop={1}><Text dimColor>Esc / Enter  close</Text></Box>
         </Box>
       </Box>

--- a/surfaces/cli/src/views/Chat.tsx
+++ b/surfaces/cli/src/views/Chat.tsx
@@ -34,7 +34,7 @@ import { Select, TextInput } from "@inkjs/ui";
 import open from "open";
 import { chooseStorage } from "../bootstrap.js";
 import { copyToClipboard } from "../clipboard.js";
-import { Message, TurnHeader } from "../components/Message.js";
+import { Message, TurnHeader, turnHeaderRows } from "../components/Message.js";
 import { StatusLine } from "../components/StatusLine.js";
 import { ApprovalCard, APPROVAL_CHOICES, type ApprovalChoiceKey } from "../components/ApprovalCard.js";
 import { Composer } from "../components/Composer.js";
@@ -1605,9 +1605,19 @@ export function Chat({
     return null;
   })();
 
-  const liveMsg = streaming
+  // While a tool approval is pinned the turn is PAUSED - the engine is blocked on the
+  // user - so the streaming tail collapses to ONE dim row: an ellipsis plus the last
+  // line so far. Honest (nothing is advancing) and load-bearing: the full tail was one
+  // of the three unbudgeted row sources that pushed the approval frame past the
+  // terminal at 30x24 (issue 167 round 2). The full text still lands in <Static> when
+  // the turn settles, and the live tail returns the moment the approval resolves.
+  const liveMsg = streaming && !pendingApproval
     ? clampLiveTail(lastMsg, liveRows, process.stdout.columns || 80)
     : null;
+  const pausedTail =
+    streaming && pendingApproval
+      ? (lastMsg.text.split("\n").filter((l) => l.trim()).pop() ?? "").trim()
+      : null;
 
   // the welcome control panel shows on an empty, idle session. Focus stays on the composer
   // by default; Ctrl+S moves focus INTO the panel (panelActive), which then owns
@@ -1622,10 +1632,24 @@ export function Chat({
   const panelMaxRows = Math.max(8, rows - CHROME_ROWS - 3);
 
   // The dynamic frame must FIT on screen — ink cannot erase lines that have scrolled off,
-  // and a frame taller than the terminal smears old paints into the scrollback. So the
-  // approval card, which takes the composer's band, gets a row budget: the rest of the
-  // chrome (header 2 · rule/status/rule 3 · rule/footer 2) plus a little slack.
-  const approvalMaxRows = Math.max(6, rows - 10);
+  // and at outputHeight >= rows it abandons in-place updates entirely for clearTerminal
+  // plus a full static rewrite on EVERY render. During an approval the elapsed ticker is
+  // still rendering ~10x a second, so an over-tall frame is not a smear but a clear-and-
+  // repaint STORM with no settled frame (issue 167 round 2: 59 clears in 16s at 30x24).
+  // Budgeting only the card was not enough: the pinned ask's TurnHeader (6 rows for a
+  // wrapped filename), the live tail, and a wrapped key grid overflowed around it. So
+  // while an approval is pinned, EVERY band is budgeted: the ask clamps to
+  // APPROVAL_ASK_ROWS (TurnHeader maxRows), the tail drops to the one-row pausedTail
+  // above, the grid sheds words (ApprovalCard), and the card gets exactly what remains.
+  // The counted chrome: history band, status, two rules, footer (one row each, the
+  // one-row contracts those bands now keep even squeezed), the clamped ask + its margin,
+  // and the paused tail row. The -1 keeps the frame strictly SHORTER than the terminal.
+  const APPROVAL_ASK_ROWS = 2;
+  const approvalChrome =
+    5 +
+    (pinnedAsk ? turnHeaderRows(pinnedAsk, APPROVAL_ASK_ROWS) + 1 : 0) +
+    (pausedTail !== null ? 1 : 0);
+  const approvalMaxRows = Math.max(6, rows - approvalChrome - 1);
 
   return (
     <Box flexDirection="column" paddingX={1}>
@@ -1663,9 +1687,19 @@ export function Chat({
 
         {/* the turn you are waiting on: your own message stays on screen above the reply
             while it streams, the way the vscode surface pins its turn header. It lives in
-            the CONTENT section (which is free to grow), never in the fixed-height chrome. */}
-        {pinnedAsk ? <TurnHeader text={pinnedAsk} /> : null}
+            the CONTENT section (which is free to grow), never in the fixed-height chrome.
+            The one exception: while an approval is pinned it clamps to the budgeted rows,
+            so the card below keeps its keys on screen. */}
+        {pinnedAsk ? (
+          <TurnHeader text={pinnedAsk} maxRows={pendingApproval ? APPROVAL_ASK_ROWS : undefined} />
+        ) : null}
 
+        {pausedTail !== null ? (
+          <Text dimColor wrap="truncate-end">
+            {"… "}
+            {pausedTail}
+          </Text>
+        ) : null}
         {liveMsg ? <Message msg={liveMsg} live /> : null}
       </Box>
 

--- a/surfaces/cli/src/views/Chat.tsx
+++ b/surfaces/cli/src/views/Chat.tsx
@@ -1473,23 +1473,70 @@ export function Chat({
     );
   }
 
+  // the last message is rendered LIVE (dynamic) only while it's a streaming assistant;
+  // everything else is committed to <Static>, which renders each line once and never
+  // re-renders — so Iggy/spinner ticks don't repaint the whole scrollback. `epoch` resets
+  // Static on wholesale changes (resume / new / scroll-back prepend).
+  const lastMsg = chat.messages[chat.messages.length - 1];
+  const streaming = chat.busy && lastMsg?.role === "assistant";
+  const baseCommitted = streaming ? chat.messages.slice(0, -1) : chat.messages;
+  // Weave local system messages (model-switch separators etc.) into the committed history.
+  const committed = interleaveByTs(baseCommitted, localLog);
+  // content width inside the frame's paddingX(1)
+  const staticW = Math.max(20, (process.stdout.columns || 80) - 2);
+  /* The settled transcript is printed ONCE into real terminal scrollback — never
+     re-rendered, never clipped, scrollable with the terminal's own scrollbar. Only
+     live/in-flight content lives in the dynamic frame below, which is what keeps the
+     composer at the bottom of the viewport without a fixed-height frame fighting it.
+     (A fixed frame with the transcript inside clipped long output and made the
+     conversation read as disconnected chunks.) */
+  /* The explicit width is load-bearing, not cosmetic: ink renders <Static> from a
+     position:absolute box, which sizes to its CONTENT rather than to the terminal.
+     One unbreakable token (a stack-trace path, a URL) therefore made the whole
+     static block wider than the screen, and the terminal wrapped the overflow back
+     to column 0 — which is how fragments ended up printed outside the card borders.
+     Pinning the width here bounds every transcript row; the components additionally
+     hard-wrap their own text so no single token can exceed it. */
+  const transcript = (
+    <Static key={chat.epoch} items={committed.map((m, i) => ({ m, i }))}>
+      {({ m, i }) => (
+        <Box key={`${m.ts}-${i}`} width={staticW} flexDirection="column">
+          <Message msg={m} />
+        </Box>
+      )}
+    </Static>
+  );
+
   // skill-market overlay — search/list/detail/buy over marketplaceEnv. Takes over input
   // while open; Esc backs out a level (or closes from the list), like the VSCode market.
+  // The transcript's <Static> MUST stay mounted above the overlay. Returning SkillMarket
+  // alone unmounted it, and ink (5.2.1) never clears rootNode.staticNode when a <Static>
+  // leaves the tree while removeChild frees its whole yoga subtree; every later market
+  // render then calls node.staticNode.yogaNode.getComputedWidth() on freed wasm memory
+  // (renderer.js:13). Once enough new yoga nodes recycle that block (showing owned cards
+  // at 100+ cols, or detail then esc), the read lands out of bounds and the process dies:
+  // issue #167's deterministic "memory access out of bounds" crash. Keeping the one real
+  // <Static> in this branch removes the dangling reference at its source. The other
+  // overlay early-returns share the latent unmount but re-render little while open;
+  // folding them into one persistent frame is a wider refactor left out of this fix.
   if (showMarket && market) {
     return (
-      <SkillMarket
-        api={market}
-        walletAddr={address}
-        ownedNames={installed}
-        initialStage={marketStage}
-        owned={skills ?? []}
-        onBought={() => {
-          // a buy installs the skill — refresh the badge source + the welcome panel list.
-          void market.ownedSkills().then(setInstalled).catch(() => {});
-          void ownedSkills(address).then(setSkills).catch(() => {});
-        }}
-        onClose={() => setShowMarket(false)}
-      />
+      <Box flexDirection="column">
+        {transcript}
+        <SkillMarket
+          api={market}
+          walletAddr={address}
+          ownedNames={installed}
+          initialStage={marketStage}
+          owned={skills ?? []}
+          onBought={() => {
+            // a buy installs the skill — refresh the badge source + the welcome panel list.
+            void market.ownedSkills().then(setInstalled).catch(() => {});
+            void ownedSkills(address).then(setSkills).catch(() => {});
+          }}
+          onClose={() => setShowMarket(false)}
+        />
+      </Box>
     );
   }
 
@@ -1528,15 +1575,6 @@ export function Chat({
     );
   }
 
-  // the last message is rendered LIVE (dynamic) only while it's a streaming assistant;
-  // everything else is committed to <Static>, which renders each line once and never
-  // re-renders — so Iggy/spinner ticks don't repaint the whole scrollback. `epoch` resets
-  // Static on wholesale changes (resume / new / scroll-back prepend).
-  const lastMsg = chat.messages[chat.messages.length - 1];
-  const streaming = chat.busy && lastMsg?.role === "assistant";
-  const baseCommitted = streaming ? chat.messages.slice(0, -1) : chat.messages;
-  // Weave local system messages (model-switch separators etc.) into the committed history.
-  const committed = interleaveByTs(baseCommitted, localLog);
   // ONE row budget for the whole dynamic frame. It used to be two independent guesses —
   // the streaming tail took `rows - 14` and the composer separately took `rows / 3` — and
   // on any normal terminal their sum plus the chrome is MORE rows than exist. ink cannot
@@ -1585,31 +1623,10 @@ export function Chat({
   // approval card, which takes the composer's band, gets a row budget: the rest of the
   // chrome (header 2 · rule/status/rule 3 · rule/footer 2) plus a little slack.
   const approvalMaxRows = Math.max(6, rows - 10);
-  // content width inside the frame's paddingX(1)
-  const staticW = Math.max(20, (process.stdout.columns || 80) - 2);
 
   return (
     <Box flexDirection="column" paddingX={1}>
-      {/* The settled transcript is printed ONCE into real terminal scrollback — never
-          re-rendered, never clipped, scrollable with the terminal's own scrollbar. Only
-          live/in-flight content lives in the dynamic frame below, which is what keeps the
-          composer at the bottom of the viewport without a fixed-height frame fighting it.
-          (A fixed frame with the transcript inside clipped long output and made the
-          conversation read as disconnected chunks.) */}
-      {/* The explicit width is load-bearing, not cosmetic: ink renders <Static> from a
-          position:absolute box, which sizes to its CONTENT rather than to the terminal.
-          One unbreakable token (a stack-trace path, a URL) therefore made the whole
-          static block wider than the screen, and the terminal wrapped the overflow back
-          to column 0 — which is how fragments ended up printed outside the card borders.
-          Pinning the width here bounds every transcript row; the components additionally
-          hard-wrap their own text so no single token can exceed it. */}
-      <Static key={chat.epoch} items={committed.map((m, i) => ({ m, i }))}>
-        {({ m, i }) => (
-          <Box key={`${m.ts}-${i}`} width={staticW} flexDirection="column">
-            <Message msg={m} />
-          </Box>
-        )}
-      </Static>
+      {transcript}
 
       <Box flexDirection="column">
         {/* startup welcome panel — shown only on empty session so it doesn't re-appear.

--- a/surfaces/cli/src/views/Chat.tsx
+++ b/surfaces/cli/src/views/Chat.tsx
@@ -453,11 +453,14 @@ export function Chat({
   // is running (or a second press within the window) actually leaves — so one stray Ctrl+C
   // never nukes an in-flight turn. Cleared after 1.5s so the "again to quit" arming lapses.
   const ctrlCArmed = useRef(false);
+  // A /compact turn in flight. The busy-transition effect below reports its outcome once
+  // the turn ends; interrupts clear it so an aborted compact is never reported as done.
+  const awaitingCompact = useRef(false);
 
   // celebration on turn completion: confetti if the last tool looks like a win, else a
   // quick sparkle. Disabled visually by Celebrate under --calm.
   useEffect(() => {
-    if (prevBusy.current && !chat.busy && chat.messages.length) {
+    if (prevBusy.current && !chat.busy) {
       const last = chat.messages[chat.messages.length - 1];
       // an engine error ends the turn too — don't celebrate it; show the calm error face.
       const errored =
@@ -466,25 +469,33 @@ export function Chat({
         (last.tool?.name === "Error" ||
           (last.tool?.exitCode !== undefined && last.tool.exitCode !== 0) ||
           /\b(engine\]|exited with code|error)/i.test(last.text));
-      if (errored) {
-        setEggMood("error");
-      } else {
-        const lastTool = [...chat.messages].reverse().find((m) => m.role === "tool");
-        const win =
-          !!lastTool &&
-          (lastTool.tool?.exitCode === 0 || /\b\d+\s+pass(ing|ed)\b/i.test(lastTool.tool?.output ?? ""));
-        setCelebrate(win ? "confetti" : "sparkle");
-        setEggMood("success");
+      // A /compact turn just ended: report what it actually did, the same after-the-fact
+      // honesty /more uses (announcing success at fire time was the bug this replaces).
+      if (awaitingCompact.current) {
+        awaitingCompact.current = false;
+        if (!chat.turnError) setNotice(errored ? "compact failed (see transcript)" : "context compacted");
       }
-      const t = setTimeout(() => {
-        setCelebrate(null);
-        setEggMood(null);
-      }, 1600);
-      prevBusy.current = chat.busy;
-      return () => clearTimeout(t);
+      if (chat.messages.length) {
+        if (errored) {
+          setEggMood("error");
+        } else {
+          const lastTool = [...chat.messages].reverse().find((m) => m.role === "tool");
+          const win =
+            !!lastTool &&
+            (lastTool.tool?.exitCode === 0 || /\b\d+\s+pass(ing|ed)\b/i.test(lastTool.tool?.output ?? ""));
+          setCelebrate(win ? "confetti" : "sparkle");
+          setEggMood("success");
+        }
+        const t = setTimeout(() => {
+          setCelebrate(null);
+          setEggMood(null);
+        }, 1600);
+        prevBusy.current = chat.busy;
+        return () => clearTimeout(t);
+      }
     }
     prevBusy.current = chat.busy;
-  }, [chat.busy, chat.messages]);
+  }, [chat.busy, chat.messages, chat.turnError]);
 
   // idle nudge: Iggy dozes off after a minute of no activity. Any input resets it.
   useEffect(() => {
@@ -501,6 +512,7 @@ export function Chat({
     if (!key.ctrl || input !== "c") return;
     if (chat.busy) {
       chat.interrupt();
+      awaitingCompact.current = false; // an interrupted /compact must not report as done
       ctrlCArmed.current = true;
       setNotice("interrupted. press Ctrl+C again to quit");
       setTimeout(() => { ctrlCArmed.current = false; }, 1500);
@@ -517,6 +529,7 @@ export function Chat({
     (_i, key) => {
       if (key.escape) {
         chat.interrupt();
+        awaitingCompact.current = false; // an interrupted /compact must not report as done
         setNotice("interrupted.");
       }
     },
@@ -1088,9 +1101,17 @@ export function Chat({
           .catch(() => setNotice("could not load older history"));
         return;
       case "compact":
-        // claude/codex honor their own /compact command; pass it through as a turn.
+        // claude/codex honor their own /compact command; pass it through as a turn. Like
+        // /more, the outcome is announced when it is KNOWN (the busy-transition effect
+        // above): the old fire-time "compacting context" notice claimed progress before
+        // the engine even accepted the turn, and stayed on screen forever, done or not.
+        // While it runs, the activity row's spinner is the honest signal.
+        if (!chat.pendingId) {
+          setNotice("nothing to compact yet - say something first");
+          return;
+        }
+        awaitingCompact.current = true;
         void chat.send("/compact");
-        setNotice("compacting context…");
         return;
       case "clear":
         chat.clearView();

--- a/surfaces/cli/src/views/Chat.tsx
+++ b/surfaces/cli/src/views/Chat.tsx
@@ -1511,7 +1511,9 @@ export function Chat({
   );
 
   // skill-market overlay — search/list/detail/buy over marketplaceEnv. Takes over input
-  // while open; Esc backs out a level (or closes from the list), like the VSCode market.
+  // while open; Esc backs out a level, and on the stage the user entered at (list for
+  // /market, github/agents/owned for /github, /agents, /skills via initialStage) it
+  // closes the market back to chat, never a list the user hasn't visited.
   // The transcript's <Static> MUST stay mounted above the overlay. Returning SkillMarket
   // alone unmounted it, and ink (5.2.1) never clears rootNode.staticNode when a <Static>
   // leaves the tree while removeChild frees its whole yoga subtree; every later market

--- a/surfaces/cli/src/views/Chat.tsx
+++ b/surfaces/cli/src/views/Chat.tsx
@@ -1051,7 +1051,7 @@ export function Chat({
         openMarket("github");
         return;
       case "resume": {
-        const hit = chat.sessions.find((s) => s.sessionId.startsWith(arg));
+        const hit = (chat.sessions ?? []).find((s) => s.sessionId.startsWith(arg));
         if (arg && hit) {
           void chat.openSession(hit.sessionId);
           setNotice(`resumed ${hit.title || hit.sessionId.slice(0, 8)}`);
@@ -1458,6 +1458,7 @@ export function Chat({
     return (
       <SessionList
         sessions={chat.sessions}
+        error={chat.sessionsError}
         activeId={chat.pendingId}
         cloud={cloud && cloud.kind !== "local" ? cloud.kind : null}
         onResume={(id) => {

--- a/surfaces/cli/src/views/Chat.tsx
+++ b/surfaces/cli/src/views/Chat.tsx
@@ -82,8 +82,11 @@ function ActivityRow({
   const cast = useFrameLoop(castingFrames.length, 8);
 
   // The calm face line always carries a word (design tab 28): a steady dim "ready" when
-  // nothing is happening, replaced by the live status the moment something does.
-  let body: React.ReactNode = <Text dimColor>ready</Text>;
+  // nothing is happening, replaced by the live status the moment something does. It
+  // truncates like every other branch: at 30 cols the context meter leaves this text a
+  // couple of cells, and an unmarked Text WRAPS there ("re"/"ad"), breaking the one-row
+  // contract the surrounding chrome math depends on.
+  let body: React.ReactNode = <Text dimColor wrap="truncate-end">ready</Text>;
   if (error) {
     body = (
       <>

--- a/surfaces/cli/src/views/Chat.tsx
+++ b/surfaces/cli/src/views/Chat.tsx
@@ -46,6 +46,7 @@ import { SkillMarket } from "./SkillMarket.js";
 import { ModelPicker } from "./ModelPicker.js";
 import { EffortPicker } from "./EffortPicker.js";
 import type { EffortLevel } from "../prefs.js";
+import { loadInputHistory, appendInputHistory, mergeHistory } from "../inputHistory.js";
 import { type Mood } from "../components/Iggy.js";
 import { Spinner } from "../components/Spinner.js";
 import { useDelight } from "../components/DelightProvider.js";
@@ -250,6 +251,12 @@ export function Chat({
   });
   const [notice, setNotice] = useState("");
   const [localLog, setLocalLog] = useState<ChatMessage[]>([]);
+  // Persistent composer history: everything sent from this composer, loaded once at
+  // boot (lazy initializer, same sync-read pattern prefs uses) and appended on every
+  // send - slash commands and ! bash lines included, which never reach chat.messages.
+  // The transcript-derived list keeps covering resumed sessions; mergeHistory folds
+  // the three sources for the Composer, whose histPos recall stays untouched.
+  const [typedHistory, setTypedHistory] = useState<string[]>(() => loadInputHistory());
   // live terminal size - the frame is sized to it so the bottom chrome (status +
   // composer section + footer) is structurally pinned to the bottom edge, and the
   // section rules span the full width.
@@ -1199,6 +1206,12 @@ export function Chat({
     const text = value.trim();
     if (!text && !images?.length) return;
     setNotice("");
+    if (text) {
+      // record BEFORE dispatch so slash commands and bash lines are recallable too;
+      // consecutive-dupe guard mirrors the store's, keeping state and file aligned.
+      setTypedHistory((prev) => (prev[prev.length - 1] === text ? prev : [...prev, text]));
+      void appendInputHistory(text);
+    }
     if (text.startsWith("/")) return runSlash(text);
     if (text.startsWith("!")) return chat.runBash(text.slice(1)); // quick local shell
     void chat.send(text, images);
@@ -1758,7 +1771,10 @@ export function Chat({
           onHelp={openHelp}
           disabled={showSessions || panelActive || !!pendingApproval}
           maxRows={composerMaxRows}
-          history={chat.messages.filter((m) => m.role === "user").map((m) => m.text)}
+          history={mergeHistory(
+            chat.messages.filter((m) => m.role === "user").map((m) => m.text),
+            typedHistory,
+          )}
         />
       </Box>
       <Text color={colors.bone}>{rule(ruleW)}</Text>

--- a/surfaces/cli/src/views/Chat.tsx
+++ b/surfaces/cli/src/views/Chat.tsx
@@ -426,6 +426,9 @@ export function Chat({
   const [accountLines, setAccountLines] = useState<string[]>([]);
   const [showSettings, setShowSettings] = useState(false);
   const [showHelp, setShowHelp] = useState(false);
+  // first visible row of the /help command list; the overlay windows the registry to the
+  // terminal height (a 24-row terminal cannot show all the commands at once).
+  const [helpScroll, setHelpScroll] = useState(0);
   const [showKeys, setShowKeys] = useState(false);
   // welcome control panel: focus stays on the composer by default; Ctrl+S moves focus into
   // the panel to edit settings. showCloud opens the storage picker from the panel's cloud row.
@@ -729,8 +732,18 @@ export function Chat({
     { isActive: showSettings && !pendingApproval },
   );
 
+  // Rows of the /help overlay available to the command list: everything else in the
+  // overlay is fixed chrome (border 2, padding 2, title 1, two hint rows with their
+  // margins 4) plus the one-row slack that keeps any frame strictly shorter than the
+  // terminal (ink repaints the whole screen once a frame reaches terminal height).
+  const helpRows = Math.max(4, rows - 10);
+
   useInput(
-    (_input, key) => { if (key.escape || key.return) setShowHelp(false); },
+    (_input, key) => {
+      if (key.escape || key.return) return setShowHelp(false);
+      if (key.upArrow) setHelpScroll((s) => Math.max(0, s - 1));
+      if (key.downArrow) setHelpScroll((s) => Math.min(Math.max(0, SLASH_COMMANDS.length - helpRows), s + 1));
+    },
     { isActive: showHelp && !pendingApproval },
   );
 
@@ -1140,6 +1153,7 @@ export function Chat({
       case "help":
         // A dismissable overlay (not a one-line notice that vanishes on the next keystroke),
         // rendered straight from SLASH_COMMANDS so the list never drifts from the registry.
+        setHelpScroll(0); // each open starts at the top of the list
         setShowHelp(true);
         return;
       case "keys":
@@ -1245,15 +1259,24 @@ export function Chat({
     // their descriptions), and rows never wrap (truncate-end) so a long description
     // cannot orphan half a sentence onto its own line.
     const colW = Math.max(...SLASH_COMMANDS.map((c) => `/${c.name}${c.args ? ` ${c.args}` : ""}`.length)) + 2;
+    // window the list to helpRows (same shape as the composer's menu window): clamp the
+    // start so a shrink can't leave the window past the end, and say what is hidden.
+    const start = Math.min(helpScroll, Math.max(0, SLASH_COMMANDS.length - helpRows));
+    const visible = SLASH_COMMANDS.slice(start, start + helpRows);
+    const below = SLASH_COMMANDS.length - start - visible.length;
     return (
       <Box flexDirection="column" paddingX={1}>
         <Box borderStyle="round" borderColor={colors.bone} flexDirection="column" paddingX={2} paddingY={1}>
           <Text bold color={colors.iqCyan}>commands</Text>
-          {SLASH_COMMANDS.map((c) => (
+          {visible.map((c) => (
             <Text key={c.name} dimColor wrap="truncate-end">{`/${c.name}${c.args ? ` ${c.args}` : ""}`.padEnd(colW)}{c.desc}</Text>
           ))}
           <Box marginTop={1}><Text dimColor>!cmd runs a shell command  ·  /keys for shortcuts</Text></Box>
-          <Box marginTop={1}><Text dimColor>Esc / Enter  close</Text></Box>
+          <Box marginTop={1}>
+            <Text dimColor>
+              {start > 0 || below > 0 ? `↑/↓ scroll (${start} above · ${below} below)  ·  ` : ""}Esc / Enter  close
+            </Text>
+          </Box>
         </Box>
       </Box>
     );

--- a/surfaces/cli/src/views/SessionList.tsx
+++ b/surfaces/cli/src/views/SessionList.tsx
@@ -2,7 +2,7 @@ import React, { useState } from "react";
 import { Box, Text, useInput } from "ink";
 import type { SessionMeta } from "@iqlabs-official/agent-sdk/runtime/contract";
 import { colors, copy, glyph, rule, tag } from "../theme.js";
-import { displayWidth, graphemes } from "../format.js";
+import { displayWidth, padCells, truncateEnd } from "../format.js";
 
 // Compact uppercase age, design-project style: 12S / 5M / 2H / 3D.
 function age(ts: number): string {
@@ -13,19 +13,16 @@ function age(ts: number): string {
   return `${Math.floor(s / 86400)}D`;
 }
 
-// Pad/trim a string to an exact CELL width (Hangul/CJK count 2) so the inverted
-// rows form a solid rectangle.
-function cell(s: string, w: number): string {
-  let out = "";
-  let used = 0;
-  for (const ch of graphemes(s)) {
-    const cw = displayWidth(ch);
-    if (used + cw > w) break;
-    out += ch;
-    used += cw;
-  }
-  return out + " ".repeat(Math.max(0, w - used));
-}
+// One source for the footer keys: the styled row and its width budget both read
+// this list, so the hint can never advertise a key the row does not draw.
+const FOOTER_KEYS: Array<[string, string]> = [
+  ["↑↓", "MOVE"],
+  ["↵", "RESUME"],
+  ["F", "FORK"],
+  ["D", "DELETE"],
+  ["ESC", "BACK"],
+];
+const footerKeysPlain = FOOTER_KEYS.map(([k, v]) => `${k} ${v}`).join("  ");
 
 // Session picker, tab 07 of the design: sessions STACK VERTICALLY, one row each behind
 // bone rules. The selected row inverts edge to edge and grows a meta sub-line (age,
@@ -58,8 +55,36 @@ export function SessionList({
   // A framed panel floating on a cleared screen, not a full-bleed sheet: the wrapper
   // below fills the whole terminal, which pushes the chat into the terminal's own
   // scrollback (scroll up and it's all still there) and gives the picker real margins.
-  const totalW = Math.max(44, Math.min(cols - 8, 84));
+  // Never wider than the terminal: below 52 cols the old 44 floor pushed rows
+  // past the frame and ate the right border.
+  const totalW = Math.min(cols, Math.max(44, Math.min(cols - 8, 84)));
   const w = totalW - 4; // bold border (2) + paddingX(1) each side
+
+  // Column budgets from the frame width. Meta drops whole before the title ever
+  // starves - the title is the row's identity, so it keeps at least TITLE_MIN
+  // cells and cuts with an ellipsis; the age column goes first, the live tag
+  // only under ~25 cols. List-wide flags, so columns stay aligned across rows.
+  const TITLE_MIN = 12;
+  const liveW = displayWidth("● LIVE");
+  const showAge = w - 8 - liveW - 1 >= TITLE_MIN; // 8 = "  " + age slot (4) + "  "
+  const showLive = w - 2 - liveW - 1 >= TITLE_MIN;
+
+  // Header and footer shrink the same way: the meta side goes first (encrypted
+  // note, then the count; the sync label), the keys collapse to a plain
+  // ellipsized row only when even they alone cannot fit.
+  const headTag = tag("sessions");
+  const countLabel = `${sessions.length} SESSION${sessions.length === 1 ? "" : "S"}`;
+  const headRoom = w - displayWidth(headTag) - 2;
+  const headNote =
+    displayWidth(`${countLabel} · ENCRYPTED`) <= headRoom
+      ? `${countLabel} · ENCRYPTED`
+      : displayWidth(countLabel) <= headRoom
+        ? countLabel
+        : "";
+  const syncLabel = cloud ? `SYNC: ${cloud.toUpperCase()} ◉` : "LOCAL ONLY ○";
+  const keysW = displayWidth(footerKeysPlain);
+  const showSync = keysW + 2 + displayWidth(syncLabel) <= w;
+  const styledKeys = keysW <= w;
 
   useInput((input, key) => {
     if (key.escape) return onClose();
@@ -87,8 +112,8 @@ export function SessionList({
     <Box height={Math.max(10, rows - 1)} width={cols} justifyContent="center" alignItems="center">
       <Box flexDirection="column" width={totalW} borderStyle="bold" borderColor={colors.bone} paddingX={1} paddingY={1}>
       <Box justifyContent="space-between">
-        <Text color={colors.bone} bold>{tag("sessions")}</Text>
-        <Text dimColor>{sessions.length} SESSION{sessions.length === 1 ? "" : "S"} · ENCRYPTED</Text>
+        <Text color={colors.bone} bold>{headTag}</Text>
+        {headNote ? <Text dimColor>{headNote}</Text> : null}
       </Box>
       <Text color={colors.bone}>{rule(w)}</Text>
 
@@ -106,10 +131,10 @@ export function SessionList({
             // fixed column now carries the AGE instead (right-aligned so the titles line up);
             // the live session still gets ● LIVE on the right edge.
             const ageSlot = age(s.ts).padStart(4);
-            const liveTag = live ? "● LIVE" : "";
+            const liveTag = live && showLive ? "● LIVE" : "";
 
             if (!focused) {
-              const prefix = `  ${ageSlot}  `;
+              const prefix = showAge ? `  ${ageSlot}  ` : "  ";
               // Trim the title to ONE line. An untruncated long title wraps to 2-3 rows,
               // and enough wrapped rows push the windowed box past the terminal height,
               // which trips ink's full-repaint and smears the whole list into scrollback -
@@ -122,7 +147,7 @@ export function SessionList({
                   <Box width={w} justifyContent="space-between">
                     <Text wrap="truncate-end">
                       <Text dimColor>{prefix}</Text>
-                      <Text color={colors.bone}>{cell(s.title || "untitled", titleMax)}</Text>
+                      <Text color={colors.bone}>{padCells(truncateEnd(s.title || "untitled", titleMax), titleMax)}</Text>
                     </Text>
                     {liveTag ? <Text color={colors.ok}>{liveTag}</Text> : null}
                   </Box>
@@ -132,16 +157,19 @@ export function SessionList({
 
             // Age already shows in the left slot, so the meta line carries engine + device.
             const meta = [`${engine} ${s.cli}`, s.lastDevice?.label].filter(Boolean).join(" · ");
+            const agePart = showAge ? `${ageSlot}  ` : "";
+            const bodyW = Math.max(0, w - 3 - displayWidth(liveTag) - 1);
+            const titleRoom = Math.max(1, bodyW - displayWidth(agePart));
             return (
               <React.Fragment key={s.sessionId}>
                 {vi > 0 ? <Text color={colors.bone}>{rule(w)}</Text> : null}
                 <Text backgroundColor={colors.bone} bold>
                   <Text color={colors.ok}> ❯ </Text>
-                  <Text color={colors.ink}>{cell(`${ageSlot}  ${s.title || "untitled"}`, Math.max(0, w - 3 - displayWidth(liveTag) - 1))}</Text>
+                  <Text color={colors.ink}>{padCells(agePart + truncateEnd(s.title || "untitled", titleRoom), bodyW)}</Text>
                   <Text color={live ? colors.ok : colors.ink}>{liveTag ? `${liveTag} ` : ""}</Text>
                 </Text>
                 <Text backgroundColor={colors.bone} color={colors.ink}>
-                  {cell(`        ${meta}`, w)}
+                  {padCells(truncateEnd(`${showAge ? "        " : "   "}${meta}`, w), w)}
                 </Text>
               </React.Fragment>
             );
@@ -154,14 +182,19 @@ export function SessionList({
       {/* The how-to row: keys read at full strength, verbs stay dim — the guidance has
           to survive next to the inverted selection without shouting over it. */}
       <Box justifyContent="space-between">
-        <Text>
-          <Text color={colors.bone} bold>↑↓</Text><Text dimColor> MOVE  </Text>
-          <Text color={colors.ok} bold>↵</Text><Text dimColor> RESUME  </Text>
-          <Text color={colors.bone} bold>F</Text><Text dimColor> FORK  </Text>
-          <Text color={colors.bone} bold>D</Text><Text dimColor> DELETE  </Text>
-          <Text color={colors.bone} bold>ESC</Text><Text dimColor> BACK</Text>
-        </Text>
-        <Text dimColor>{cloud ? `SYNC: ${cloud.toUpperCase()} ◉` : "LOCAL ONLY ○"}</Text>
+        {styledKeys ? (
+          <Text>
+            {FOOTER_KEYS.map(([k, v], i) => (
+              <React.Fragment key={k}>
+                <Text color={k === "↵" ? colors.ok : colors.bone} bold>{k}</Text>
+                <Text dimColor> {v}{i < FOOTER_KEYS.length - 1 ? "  " : ""}</Text>
+              </React.Fragment>
+            ))}
+          </Text>
+        ) : (
+          <Text dimColor>{truncateEnd(footerKeysPlain, w)}</Text>
+        )}
+        {showSync ? <Text dimColor>{syncLabel}</Text> : null}
       </Box>
       </Box>
     </Box>

--- a/surfaces/cli/src/views/SessionList.tsx
+++ b/surfaces/cli/src/views/SessionList.tsx
@@ -33,6 +33,7 @@ const footerKeysPlain = FOOTER_KEYS.map(([k, v]) => `${k} ${v}`).join("  ");
 // (the chat survives in terminal scrollback) instead of stacking under it.
 export function SessionList({
   sessions,
+  error,
   activeId,
   cloud,
   onResume,
@@ -40,7 +41,11 @@ export function SessionList({
   onFork,
   onClose,
 }: {
-  sessions: SessionMeta[];
+  // null = the first listSessions has not settled: the body says loading, never the
+  // "no sessions yet" empty copy, and the header count waits for a real number.
+  sessions: SessionMeta[] | null;
+  // a failed listSessions read (only shown when there is no settled list to render)
+  error?: string | null;
   activeId?: string;
   cloud: string | null;
   onResume: (id: string) => void;
@@ -48,8 +53,9 @@ export function SessionList({
   onFork: (id: string) => void;
   onClose: () => void;
 }) {
+  const list = sessions ?? []; // mechanics treat pending as empty; render tells them apart
   const [idx, setIdx] = useState(0);
-  const clamped = Math.min(idx, Math.max(0, sessions.length - 1));
+  const clamped = Math.min(idx, Math.max(0, list.length - 1));
   const cols = process.stdout.columns || 80;
   const rows = process.stdout.rows || 24;
   // A framed panel floating on a cleared screen, not a full-bleed sheet: the wrapper
@@ -73,14 +79,20 @@ export function SessionList({
   // note, then the count; the sync label), the keys collapse to a plain
   // ellipsized row only when even they alone cannot fit.
   const headTag = tag("sessions");
-  const countLabel = `${sessions.length} SESSION${sessions.length === 1 ? "" : "S"}`;
+  // the count is a claim about a settled list: while the fetch is pending the header
+  // keeps ENCRYPTED alone instead of asserting "0 SESSIONS".
+  const countLabel = sessions === null ? null : `${list.length} SESSION${list.length === 1 ? "" : "S"}`;
   const headRoom = w - displayWidth(headTag) - 2;
   const headNote =
-    displayWidth(`${countLabel} · ENCRYPTED`) <= headRoom
-      ? `${countLabel} · ENCRYPTED`
-      : displayWidth(countLabel) <= headRoom
-        ? countLabel
-        : "";
+    countLabel === null
+      ? displayWidth("ENCRYPTED") <= headRoom
+        ? "ENCRYPTED"
+        : ""
+      : displayWidth(`${countLabel} · ENCRYPTED`) <= headRoom
+        ? `${countLabel} · ENCRYPTED`
+        : displayWidth(countLabel) <= headRoom
+          ? countLabel
+          : "";
   const syncLabel = cloud ? `SYNC: ${cloud.toUpperCase()} ◉` : "LOCAL ONLY ○";
   const keysW = displayWidth(footerKeysPlain);
   const showSync = keysW + 2 + displayWidth(syncLabel) <= w;
@@ -88,14 +100,14 @@ export function SessionList({
 
   useInput((input, key) => {
     if (key.escape) return onClose();
-    if (sessions.length === 0) return;
+    if (list.length === 0) return;
     if (key.upArrow) return setIdx(() => Math.max(0, clamped - 1));
-    if (key.downArrow) return setIdx(() => Math.min(sessions.length - 1, clamped + 1));
-    if (key.return) onResume(sessions[clamped].sessionId);
-    else if (input === "f") onFork(sessions[clamped].sessionId);
+    if (key.downArrow) return setIdx(() => Math.min(list.length - 1, clamped + 1));
+    if (key.return) onResume(list[clamped].sessionId);
+    else if (input === "f") onFork(list[clamped].sessionId);
     else if (input === "d") {
-      onDelete(sessions[clamped].sessionId);
-      setIdx((i) => Math.max(0, Math.min(i, sessions.length - 2)));
+      onDelete(list[clamped].sessionId);
+      setIdx((i) => Math.max(0, Math.min(i, list.length - 2)));
     }
   });
 
@@ -103,10 +115,10 @@ export function SessionList({
   // rows + rule, the rest 1 + rule, plus the frame's chrome (border 2, paddingY 2,
   // header+rule 2, closing rule+footer 2, MORE indicators 2).
   const maxVisible = Math.max(3, Math.floor((rows - 13) / 2));
-  const start = Math.min(Math.max(0, clamped - Math.floor(maxVisible / 2)), Math.max(0, sessions.length - maxVisible));
-  const visible = sessions.slice(start, start + maxVisible);
+  const start = Math.min(Math.max(0, clamped - Math.floor(maxVisible / 2)), Math.max(0, list.length - maxVisible));
+  const visible = list.slice(start, start + maxVisible);
   const above = start;
-  const below = sessions.length - start - visible.length;
+  const below = list.length - start - visible.length;
 
   return (
     <Box height={Math.max(10, rows - 1)} width={cols} justifyContent="center" alignItems="center">
@@ -117,7 +129,14 @@ export function SessionList({
       </Box>
       <Text color={colors.bone}>{rule(w)}</Text>
 
-      {sessions.length === 0 ? (
+      {/* three honest states on the one reserved row: pending says loading, a read
+          that failed with nothing to show says what failed, and the empty copy may
+          only follow a SETTLED empty list. */}
+      {sessions === null && error ? (
+        <Text color={colors.err}>{truncateEnd(`could not load sessions · ${error}`, w)}</Text>
+      ) : sessions === null ? (
+        <Text dimColor>loading sessions…</Text>
+      ) : list.length === 0 ? (
         <Text dimColor>{copy.emptySessions}</Text>
       ) : (
         <>

--- a/surfaces/cli/src/views/SkillMarket.tsx
+++ b/surfaces/cli/src/views/SkillMarket.tsx
@@ -4,12 +4,12 @@ import type { SkillCard, SkillDetail } from "@iqlabs-official/agent-sdk";
 import type { Reputation, AgentProfile } from "@iqlabs-official/agent-sdk";
 import { maskedHeliusKey, hasDasRpc, saveHeliusKey, getNetwork } from "@iqlabs-official/agent-sdk";
 import { saveGithubToken, loadGithubToken, maskedGithubToken, registerVerifiedWork, parseGithubRepo } from "@iqlabs-official/agent-sdk";
-import { colors, glyph } from "../theme.js";
+import { colors, glyph, tierColor, tierColors } from "../theme.js";
 import { displayWidth, truncateEnd, truncateStart } from "../format.js";
 import type { OwnedSkill } from "../components/WelcomePanel.js";
 import { ChipCarousel } from "../components/ChipCarousel.js";
 import { Band } from "../components/Band.js";
-import { tierInfo, tierGauge } from "./market/tiers.js";
+import { tierInfo, TierGauge } from "./market/tiers.js";
 import { AgentProfileView, type ProfileSub } from "./market/AgentProfileView.js";
 import { SkillDetailView, mainLines, mainViewportH, skillTextLines, commentLines, subViewportH, type DetailSub } from "./market/SkillDetailView.js";
 import { HeliusPanel, HeliusBadge, heliusBadgeText, type RpcStatusLite } from "./market/HeliusPanel.js";
@@ -112,9 +112,11 @@ function SkillChip({
       {/* the big supply number, like the design's card corner count */}
       <Box justifyContent="space-between">
         <Text bold color={colors.bone}>×{card.supply ?? 0}</Text>
+        {/* the grade wears its metal (tierColor), and the ★ count rides the same tint:
+            amber here made a Bronze chip indistinguishable from a Gold one. */}
         <Text>
-          {card.stars ? <Text color={colors.warn}>★{card.stars} </Text> : null}
-          {cur ? <Text color={colors.warn}>[{cur.name}]</Text> : null}
+          {card.stars ? <Text color={tierColor(cur?.name)}>★{card.stars} </Text> : null}
+          {cur ? <Text color={tierColor(cur.name)}>[{cur.name}]</Text> : null}
         </Text>
       </Box>
       <Box justifyContent="space-between">
@@ -1020,7 +1022,9 @@ export function SkillMarket({
                       <Text color={on ? colors.iqCyan : colors.bone} bold={on || you}>
                         {on ? "› " : "  "}{short(a.wallet)}{you ? " // YOU" : ""}
                       </Text>
-                      <Text color={cur ? colors.warn : colors.dim}>
+                      {/* the rank label wears its metal, so a Legendary row finally
+                          matches the green the footer legend promises */}
+                      <Text color={cur ? tierColor(cur.name) : colors.dim}>
                         {cur ? cur.name.toUpperCase() : "UNRANKED"}
                       </Text>
                     </Box>
@@ -1028,7 +1032,7 @@ export function SkillMarket({
                       {"    CREATED "}{a.skillsPublished}{" · COPIES "}{a.totalSupply}
                       {" · ★"}{a.stars ?? 0}{earned ? ` · EARNED ${earned}` : ""}
                     </Text>
-                    {on ? <Text color={colors.warn}>{"    "}{tierGauge(a.stars ?? 0)}</Text> : null}
+                    {on ? <Text>{"    "}<TierGauge stars={a.stars ?? 0} /></Text> : null}
                   </Box>
                 );
               })}
@@ -1041,7 +1045,16 @@ export function SkillMarket({
         </Box>
         <Box justifyContent="space-between">
           <Text dimColor wrap="truncate-end">{agentTyping ? "type to filter · ↵/↓ browse · esc close" : "↑/↓ move · ↵ profile · [/] search · esc back"}</Text>
-          <Text dimColor>BRONZE 3 · SILVER 15 · GOLD 60 · <Text color={colors.ok}>LEGENDARY 250</Text></Text>
+          {/* the legend is the color key the rows obey: every rung in its own metal */}
+          <Text>
+            <Text color={tierColors.bronze}>BRONZE 3</Text>
+            <Text dimColor> · </Text>
+            <Text color={tierColors.silver}>SILVER 15</Text>
+            <Text dimColor> · </Text>
+            <Text color={tierColors.gold}>GOLD 60</Text>
+            <Text dimColor> · </Text>
+            <Text color={tierColors.legendary}>LEGENDARY 250</Text>
+          </Text>
         </Box>
       </Box>
     );
@@ -1235,8 +1248,8 @@ export function SkillMarket({
                       {s.name.slice(0, SKILL_CHIP_W - 4)}
                     </Text>
                     <Box>
-                      {stars ? <Text color={colors.warn}>★{stars} </Text> : null}
-                      {cur ? <Text color={colors.warn}>[{cur.name}]</Text> : <Text dimColor>{stars ? "" : "no grade yet"}</Text>}
+                      {stars ? <Text color={tierColor(cur?.name)}>★{stars} </Text> : null}
+                      {cur ? <Text color={tierColor(cur.name)}>[{cur.name}]</Text> : <Text dimColor>{stars ? "" : "no grade yet"}</Text>}
                     </Box>
                   </Box>
                 );

--- a/surfaces/cli/src/views/SkillMarket.tsx
+++ b/surfaces/cli/src/views/SkillMarket.tsx
@@ -5,6 +5,7 @@ import type { Reputation, AgentProfile } from "@iqlabs-official/agent-sdk";
 import { maskedHeliusKey, hasDasRpc, saveHeliusKey, getNetwork } from "@iqlabs-official/agent-sdk";
 import { saveGithubToken, loadGithubToken, maskedGithubToken, registerVerifiedWork, parseGithubRepo } from "@iqlabs-official/agent-sdk";
 import { colors, glyph } from "../theme.js";
+import { displayWidth, truncateEnd } from "../format.js";
 import type { OwnedSkill } from "../components/WelcomePanel.js";
 import { ChipCarousel } from "../components/ChipCarousel.js";
 import { Band } from "../components/Band.js";
@@ -221,7 +222,9 @@ export function SkillMarket({
   const [ghFlash, setGhFlash] = useState<string | null>(null);
 
   const owned = new Set(ownedNames);
-  const agentRows = useStdout().stdout?.rows || 24; // || not ??: detached pty reports 0
+  const marketStdout = useStdout().stdout; // || not ??: detached pty reports 0 rows/cols
+  const agentRows = marketStdout?.rows || 24;
+  const marketCols = marketStdout?.columns || 80;
   const visibleResults = results.filter((c) => !hideOwned || !owned.has(c.name));
   // index over the FILTERED list - what's on screen is what enter/buy act on
   const clamped = Math.min(idx, Math.max(0, visibleResults.length - 1));
@@ -1213,10 +1216,16 @@ export function SkillMarket({
         <Band label="buy" note="ONE TX: PAY, MINT YOUR COPY, EQUIP IT." inverted />
       </Box>
       <Box justifyContent="space-between">
-        <Text dimColor wrap="truncate-end">
-          {typing
-            ? "type to search · ↵ run · [tab] skills/workflows · ↓ results · esc close"
-            : "←/→ · ↵ open · [b] buy · [tab] switch · [/] search · [a] agents · [p] publish · [h] hide · [s] sort · esc"}
+        {/* the hint is budgeted against the balance and cut with an ellipsis: unbudgeted,
+            the row fused them into one string ("[h] hid7.003 SOL", and at 30 cols
+            "[b] 7.003" read like a price). border 2 + paddingX 2 + a 2-cell gap. */}
+        <Text dimColor>
+          {truncateEnd(
+            typing
+              ? "type to search · ↵ run · [tab] skills/workflows · ↓ results · esc close"
+              : "←/→ · ↵ open · [b] buy · [tab] switch · [/] search · [a] agents · [p] publish · [h] hide · [s] sort · esc",
+            Math.max(4, marketCols - 4 - displayWidth(sol(balance)) - 2),
+          )}
         </Text>
         <Text dimColor>{sol(balance)}</Text>
       </Box>

--- a/surfaces/cli/src/views/SkillMarket.tsx
+++ b/surfaces/cli/src/views/SkillMarket.tsx
@@ -1028,9 +1028,15 @@ export function SkillMarket({
                         {cur ? cur.name.toUpperCase() : "UNRANKED"}
                       </Text>
                     </Box>
-                    <Text dimColor>
-                      {"    CREATED "}{a.skillsPublished}{" · COPIES "}{a.totalSupply}
-                      {" · ★"}{a.stars ?? 0}{earned ? ` · EARNED ${earned}` : ""}
+                    {/* earned SOL is green on the profile ("earned 0.70◎"); the same
+                        datum was dim here. One rule per datum: earned money is green
+                        on both reputation screens. The label stays dim metadata. */}
+                    <Text>
+                      <Text dimColor>
+                        {"    CREATED "}{a.skillsPublished}{" · COPIES "}{a.totalSupply}
+                        {" · ★"}{a.stars ?? 0}{earned ? " · EARNED " : ""}
+                      </Text>
+                      {earned ? <Text color={colors.ok}>{earned}</Text> : null}
                     </Text>
                     {on ? <Text>{"    "}<TierGauge stars={a.stars ?? 0} /></Text> : null}
                   </Box>
@@ -1243,7 +1249,14 @@ export function SkillMarket({
                     borderStyle="round"
                     borderColor={focused ? colors.iqCyan : colors.dim}
                   >
-                    <Text dimColor>[ {(off ? "off" : "owned").toUpperCase()} / SKILL ]</Text>
+                    {/* OWNED asserts ownership, so it is green here like everywhere
+                        else (list chip, profile rows); OFF stays dim, it asserts
+                        the opposite. The brackets stay structural dim. */}
+                    <Text>
+                      <Text dimColor>[ </Text>
+                      <Text color={off ? colors.dim : colors.ok}>{(off ? "off" : "owned").toUpperCase()}</Text>
+                      <Text dimColor> / SKILL ]</Text>
+                    </Text>
                     <Text color={focused ? colors.iqCyan : undefined} bold={focused}>
                       {s.name.slice(0, SKILL_CHIP_W - 4)}
                     </Text>

--- a/surfaces/cli/src/views/SkillMarket.tsx
+++ b/surfaces/cli/src/views/SkillMarket.tsx
@@ -5,7 +5,7 @@ import type { Reputation, AgentProfile } from "@iqlabs-official/agent-sdk";
 import { maskedHeliusKey, hasDasRpc, saveHeliusKey, getNetwork } from "@iqlabs-official/agent-sdk";
 import { saveGithubToken, loadGithubToken, maskedGithubToken, registerVerifiedWork, parseGithubRepo } from "@iqlabs-official/agent-sdk";
 import { colors, glyph } from "../theme.js";
-import { displayWidth, truncateEnd } from "../format.js";
+import { displayWidth, truncateEnd, truncateStart } from "../format.js";
 import type { OwnedSkill } from "../components/WelcomePanel.js";
 import { ChipCarousel } from "../components/ChipCarousel.js";
 import { Band } from "../components/Band.js";
@@ -1149,33 +1149,59 @@ export function SkillMarket({
 
   // ── list ───────────────────────────────────────────────────────────────────
   const onMainnet = `${results.length} ${kind === "skill" ? "SKILL" : "WORKFLOW"}${results.length === 1 ? "" : "S"} ON MAINNET`;
+  // Width bounds for the chrome rows. Unbounded, their pieces wrapped INTO each other at
+  // narrow widths ("MARKE5 SKILLS ON / T MAINNET" at 40 cols); each row now truncates or
+  // drops its least important piece instead. innerW = frame border 2 + paddingX 2.
+  const innerW = Math.max(12, marketCols - 4);
+  const badgePlain = !rpcStatus ? "" : rpcStatus.hasKey ? `● ${rpcStatus.network} · ${rpcStatus.masked}` : "add a Helius key for faster results";
+  const noteRoom = Math.max(0, innerW - displayWidth("MARKET") - 2);
+  const showBadge = badgePlain !== "" && displayWidth(onMainnet) + 3 + displayWidth(badgePlain) <= noteRoom;
+  const shortcuts = "[a] agents  [p] publish  [r] rpc  [g] github";
+  const shortcutRoom = innerW - displayWidth("skills  ·  workflows  ·  ");
+  const sortLabel = marketSort === "stars" ? "★ stars" : "popular";
+  const queryShown = truncateStart(query, Math.max(1, innerW - 10));
+  const searchUsed = 9 + displayWidth(queryShown) + (typing ? 1 : 0);
+  const showHideChip = searchUsed + displayWidth("   [h] hide owned ✓") <= innerW;
+  const showSortChip = showHideChip && searchUsed + displayWidth(`   [h] hide owned ✓   [s] sort ${sortLabel}`) <= innerW;
   return (
     <Box flexDirection="column" paddingX={1} borderStyle="round" borderColor={colors.iqViolet}>
       <Box justifyContent="space-between">
         <Text bold color={colors.bone}>MARKET</Text>
         <Box>
-          <Text dimColor>{onMainnet}   </Text>
-          <HeliusBadge status={rpcStatus} />
+          <Text dimColor>{truncateEnd(onMainnet, noteRoom)}{showBadge ? "   " : ""}</Text>
+          {showBadge ? <HeliusBadge status={rpcStatus} /> : null}
         </Box>
       </Box>
-      {/* tabs */}
+      {/* tabs; the shortcut strip truncates and disappears before the tabs ever wrap */}
       <Box marginTop={1}>
         <Text color={kind === "skill" ? colors.iqCyan : colors.dim} bold={kind === "skill"}>skills</Text>
         <Text dimColor>  ·  </Text>
         <Text color={kind === "workflow" ? colors.iqCyan : colors.dim} bold={kind === "workflow"}>workflows</Text>
-        <Text dimColor>  ·  </Text>
-        <Text color={colors.dim}>[a] agents  [p] publish  [r] rpc  [g] github</Text>
+        {shortcutRoom >= 4 ? (
+          <>
+            <Text dimColor>  ·  </Text>
+            <Text color={colors.dim}>{truncateEnd(shortcuts, shortcutRoom)}</Text>
+          </>
+        ) : null}
       </Box>
-      {/* search box + hide-owned filter */}
+      {/* search box + hide-owned filter; chips drop whole before they can interleave */}
       <Box marginTop={1}>
         <Text color={typing ? colors.iqCyan : colors.dim}>{typing ? "▸ " : "  "}</Text>
         <Text dimColor>search </Text>
-        <Text>{query}</Text>
+        <Text>{queryShown}</Text>
         {typing ? <Text inverse> </Text> : null}
-        <Text dimColor>   [h] hide owned </Text>
-        <Text color={hideOwned ? colors.ok : colors.dim}>{hideOwned ? "✓" : "✗"}</Text>
-        <Text dimColor>   [s] sort </Text>
-        <Text color={marketSort === "stars" ? colors.warn : colors.dim}>{marketSort === "stars" ? "★ stars" : "popular"}</Text>
+        {showHideChip ? (
+          <>
+            <Text dimColor>   [h] hide owned </Text>
+            <Text color={hideOwned ? colors.ok : colors.dim}>{hideOwned ? "✓" : "✗"}</Text>
+          </>
+        ) : null}
+        {showSortChip ? (
+          <>
+            <Text dimColor>   [s] sort </Text>
+            <Text color={marketSort === "stars" ? colors.warn : colors.dim}>{sortLabel}</Text>
+          </>
+        ) : null}
       </Box>
       {/* results - sd-card chip carousel, ←/→ rotates */}
       <Box flexDirection="column" marginTop={1}>

--- a/surfaces/cli/src/views/SkillMarket.tsx
+++ b/surfaces/cli/src/views/SkillMarket.tsx
@@ -99,12 +99,14 @@ function SkillChip({
       borderStyle="round"
       borderColor={focused ? colors.iqCyan : accent}
     >
-      {/* barcode glyph + category/type mark, the card's top strip */}
+      {/* barcode glyph + category/type mark, the card's top strip. truncate, never
+          wrap: when a narrow terminal squeezes the fixed-width chip, a wrapped strip
+          would grow the card a row and push the whole list frame past the screen. */}
       <Box justifyContent="space-between">
-        <Text color={accent}>▐▖▐</Text>
-        <Text dimColor>{cat} / {isWorkflow ? "FLOW" : "SKILL"}</Text>
+        <Text color={accent} wrap="truncate-end">▐▖▐</Text>
+        <Text dimColor wrap="truncate-end">{cat} / {isWorkflow ? "FLOW" : "SKILL"}</Text>
       </Box>
-      <Text color={focused ? colors.iqCyan : colors.bone} bold>
+      <Text color={focused ? colors.iqCyan : colors.bone} bold wrap="truncate-end">
         {card.name.slice(0, SKILL_CHIP_W - 4)}
       </Text>
       {/* the big supply number, like the design's card corner count */}
@@ -1193,6 +1195,23 @@ export function SkillMarket({
   const searchUsed = 9 + displayWidth(queryShown) + (typing ? 1 : 0);
   const showHideChip = searchUsed + displayWidth("   [h] hide owned ✓") <= innerW;
   const showSortChip = showHideChip && searchUsed + displayWidth(`   [h] hide owned ✓   [s] sort ${sortLabel}`) <= innerW;
+  // ── vertical budget ────────────────────────────────────────────────────────
+  // Chrome that always renders: border 2 + header 1 + tabs 1 + card 6 +
+  // footer 1 = 11 rows. Everything else re-enters as terminal rows allow;
+  // read as a drop ladder from the full frame: the blank spacer rows go
+  // first (search's, then tabs', then the band's, then the card's), then the
+  // buy band, then the carousel count row, then the search row. The shortcut
+  // strip shares the tabs row, so it costs no height and only drops by width.
+  // While typing, the search row is the interaction surface and never drops.
+  // A flash reserves two rows; when not even one spare row exists it takes
+  // the footer's hint slot instead of growing the frame.
+  const flashInFooter = flash != null && agentRows < 13;
+  const listSpare = Math.max(0, agentRows - 12 - (flash != null && !flashInFooter ? 2 : 0));
+  const showSearchRow = typing || listSpare >= 1;
+  const showCountRow = listSpare >= 2;
+  const showBand = listSpare >= 3;
+  const spacerRoom = Math.min(4, Math.max(0, listSpare - 3));
+  const hintRoom = Math.max(4, marketCols - 4 - displayWidth(sol(balance)) - 2);
   return (
     <Box flexDirection="column" paddingX={1} borderStyle="round" borderColor={colors.iqViolet}>
       <Box justifyContent="space-between">
@@ -1203,7 +1222,7 @@ export function SkillMarket({
         </Box>
       </Box>
       {/* tabs; the shortcut strip truncates and disappears before the tabs ever wrap */}
-      <Box marginTop={1}>
+      <Box marginTop={spacerRoom >= 3 ? 1 : 0}>
         <Text color={kind === "skill" ? colors.iqCyan : colors.dim} bold={kind === "skill"}>skills</Text>
         <Text dimColor>  ·  </Text>
         <Text color={kind === "workflow" ? colors.iqCyan : colors.dim} bold={kind === "workflow"}>workflows</Text>
@@ -1215,26 +1234,28 @@ export function SkillMarket({
         ) : null}
       </Box>
       {/* search box + hide-owned filter; chips drop whole before they can interleave */}
-      <Box marginTop={1}>
-        <Text color={typing ? colors.iqCyan : colors.dim}>{typing ? "▸ " : "  "}</Text>
-        <Text dimColor>search </Text>
-        <Text>{queryShown}</Text>
-        {typing ? <Text inverse> </Text> : null}
-        {showHideChip ? (
-          <>
-            <Text dimColor>   [h] hide owned </Text>
-            <Text color={hideOwned ? colors.ok : colors.dim}>{hideOwned ? "✓" : "✗"}</Text>
-          </>
-        ) : null}
-        {showSortChip ? (
-          <>
-            <Text dimColor>   [s] sort </Text>
-            <Text color={marketSort === "stars" ? colors.warn : colors.dim}>{sortLabel}</Text>
-          </>
-        ) : null}
-      </Box>
+      {showSearchRow ? (
+        <Box marginTop={spacerRoom >= 4 ? 1 : 0}>
+          <Text color={typing ? colors.iqCyan : colors.dim}>{typing ? "▸ " : "  "}</Text>
+          <Text dimColor>search </Text>
+          <Text>{queryShown}</Text>
+          {typing ? <Text inverse> </Text> : null}
+          {showHideChip ? (
+            <>
+              <Text dimColor>   [h] hide owned </Text>
+              <Text color={hideOwned ? colors.ok : colors.dim}>{hideOwned ? "✓" : "✗"}</Text>
+            </>
+          ) : null}
+          {showSortChip ? (
+            <>
+              <Text dimColor>   [s] sort </Text>
+              <Text color={marketSort === "stars" ? colors.warn : colors.dim}>{sortLabel}</Text>
+            </>
+          ) : null}
+        </Box>
+      ) : null}
       {/* results - sd-card chip carousel, ←/→ rotates */}
-      <Box flexDirection="column" marginTop={1}>
+      <Box flexDirection="column" marginTop={spacerRoom >= 1 ? 1 : 0}>
         {loading ? (
           <Text dimColor>searching…</Text>
         ) : error ? (
@@ -1254,6 +1275,7 @@ export function SkillMarket({
             index={clamped}
             onIndex={setIdx}
             chipWidth={SKILL_CHIP_W}
+            count={showCountRow}
             renderChip={(c, focused) => (
               <SkillChip
                 card={c}
@@ -1265,24 +1287,30 @@ export function SkillMarket({
           />
         )}
       </Box>
-      {flash ? (
-        <Box marginTop={1}><Text color={colors.ok}>{glyph.sparkle} {flash}</Text></Box>
+      {flash && !flashInFooter ? (
+        <Box marginTop={spacerRoom >= 1 ? 1 : 0}><Text color={colors.ok}>{glyph.sparkle} {flash}</Text></Box>
       ) : null}
-      <Box marginTop={1}>
-        <Band label="buy" note="ONE TX: PAY, MINT YOUR COPY, EQUIP IT." inverted />
-      </Box>
+      {showBand ? (
+        <Box marginTop={spacerRoom >= 2 ? 1 : 0}>
+          <Band label="buy" note="ONE TX: PAY, MINT YOUR COPY, EQUIP IT." inverted />
+        </Box>
+      ) : null}
       <Box justifyContent="space-between">
         {/* the hint is budgeted against the balance and cut with an ellipsis: unbudgeted,
             the row fused them into one string ("[h] hid7.003 SOL", and at 30 cols
             "[b] 7.003" read like a price). border 2 + paddingX 2 + a 2-cell gap. */}
-        <Text dimColor>
-          {truncateEnd(
-            typing
-              ? "type to search · ↵ run · [tab] skills/workflows · ↓ results · esc close"
-              : "←/→ · ↵ open · [b] buy · [tab] switch · [/] search · [a] agents · [p] publish · [h] hide · [s] sort · esc",
-            Math.max(4, marketCols - 4 - displayWidth(sol(balance)) - 2),
-          )}
-        </Text>
+        {flashInFooter ? (
+          <Text color={colors.ok}>{glyph.sparkle} {truncateEnd(flash ?? "", hintRoom)}</Text>
+        ) : (
+          <Text dimColor>
+            {truncateEnd(
+              typing
+                ? "type to search · ↵ run · [tab] skills/workflows · ↓ results · esc close"
+                : "←/→ · ↵ open · [b] buy · [tab] switch · [/] search · [a] agents · [p] publish · [h] hide · [s] sort · esc",
+              hintRoom,
+            )}
+          </Text>
+        )}
         <Text dimColor>{sol(balance)}</Text>
       </Box>
     </Box>

--- a/surfaces/cli/src/views/SkillMarket.tsx
+++ b/surfaces/cli/src/views/SkillMarket.tsx
@@ -1352,7 +1352,10 @@ export function SkillMarket({
           {showSortChip ? (
             <>
               <Text dimColor>   [s] sort </Text>
-              <Text color={marketSort === "stars" ? colors.warn : colors.dim}>{sortLabel}</Text>
+              {/* the non-default mode reads at full strength, not amber: amber is a
+                  caution color here (confirm, missing key), and a sort mode is not
+                  a warning. Bold bone = "this is the live mode", no hue claim. */}
+              <Text color={marketSort === "stars" ? colors.bone : colors.dim} bold={marketSort === "stars"}>{sortLabel}</Text>
             </>
           ) : null}
         </Box>

--- a/surfaces/cli/src/views/SkillMarket.tsx
+++ b/surfaces/cli/src/views/SkillMarket.tsx
@@ -10,6 +10,7 @@ import type { OwnedSkill } from "../components/WelcomePanel.js";
 import { ChipCarousel } from "../components/ChipCarousel.js";
 import { Band } from "../components/Band.js";
 import { tierInfo, TierGauge } from "./market/tiers.js";
+import { walletColor, walletFace } from "./market/avatar.js";
 import { AgentProfileView, type ProfileSub } from "./market/AgentProfileView.js";
 import { SkillDetailView, mainLines, mainViewportH, skillTextLines, commentLines, subViewportH, type DetailSub } from "./market/SkillDetailView.js";
 import { HeliusPanel, HeliusBadge, heliusBadgeText, type RpcStatusLite } from "./market/HeliusPanel.js";
@@ -834,7 +835,7 @@ export function SkillMarket({
         // are the one source for both).
         const total = detailSub === "skillText"
           ? skillTextLines(detail, marketCols).length
-          : commentLines(detail.notes ?? [], marketCols).length;
+          : commentLines(detail.notes ?? [], marketCols, walletAddr).length;
         const height = subViewportH(agentRows, total);
         if (key.escape) { setDetailSub("main"); setDetailScroll(0); return; }
         if (key.downArrow) { setDetailScroll((o) => clampScroll(o + 1, total, height)); return; }
@@ -971,6 +972,7 @@ export function SkillMarket({
         sub={profileSub}
         scrollOffset={profileScroll}
         self={agentProfile.self}
+        walletAddr={walletAddr}
       />
     );
   }
@@ -978,6 +980,10 @@ export function SkillMarket({
   // ── agents list ────────────────────────────────────────────────────────────
   if (stage === "agents") {
     const short = (w: string) => `${w.slice(0, 6)}…${w.slice(-4)}`;
+    // wallet-face identity (design tab 20 //AVATAR_): same wallet, same face, every
+    // screen. The face sheds below 40 cols, where the row's width budget is already
+    // spent on the wallet and the rank label.
+    const showFace = marketCols >= 40;
     const filtered = (agents ?? []).filter((a) => !agentQuery.trim() || a.wallet.toLowerCase().includes(agentQuery.toLowerCase()));
     // window to terminal height so every agent stays reachable. Each agent row is now two
     // lines (handle+tier, then stats) plus a gauge line on the selected one, so budget ~2
@@ -1019,8 +1025,14 @@ export function SkillMarket({
                 return (
                   <Box key={a.wallet} flexDirection="column">
                     <Box justifyContent="space-between">
-                      <Text color={on ? colors.iqCyan : colors.bone} bold={on || you}>
-                        {on ? "› " : "  "}{short(a.wallet)}{you ? " // YOU" : ""}
+                      <Text>
+                        <Text color={on ? colors.iqCyan : colors.bone} bold={on || you}>
+                          {on ? "› " : "  "}
+                        </Text>
+                        {showFace ? <Text color={walletColor(a.wallet)}>{walletFace(a.wallet)} </Text> : null}
+                        <Text color={on ? colors.iqCyan : colors.bone} bold={on || you}>
+                          {short(a.wallet)}{you ? " // YOU" : ""}
+                        </Text>
                       </Text>
                       {/* the rank label wears its metal, so a Legendary row finally
                           matches the green the footer legend promises */}
@@ -1212,6 +1224,7 @@ export function SkillMarket({
         firing={firingIds.has(detail.card.id)}
         flash={flash}
         busy={busy}
+        walletAddr={walletAddr}
       />
     );
   }

--- a/surfaces/cli/src/views/SkillMarket.tsx
+++ b/surfaces/cli/src/views/SkillMarket.tsx
@@ -1196,15 +1196,21 @@ export function SkillMarket({
   const showHideChip = searchUsed + displayWidth("   [h] hide owned ✓") <= innerW;
   const showSortChip = showHideChip && searchUsed + displayWidth(`   [h] hide owned ✓   [s] sort ${sortLabel}`) <= innerW;
   // ── vertical budget ────────────────────────────────────────────────────────
-  // Chrome that always renders: border 2 + header 1 + tabs 1 + card 6 +
-  // footer 1 = 11 rows. Everything else re-enters as terminal rows allow;
-  // read as a drop ladder from the full frame: the blank spacer rows go
-  // first (search's, then tabs', then the band's, then the card's), then the
-  // buy band, then the carousel count row, then the search row. The shortcut
-  // strip shares the tabs row, so it costs no height and only drops by width.
+  // Chrome that always renders: border 2 + header 1 + card 6 + footer 1 =
+  // 10 rows. Everything else re-enters as terminal rows allow; read as a
+  // drop ladder from the full frame: the blank spacer rows go first
+  // (search's, then tabs', then the band's, then the card's), then the buy
+  // band, then the carousel count row, then the search row, and LAST the
+  // tabs row itself below 12 terminal rows. The tabs row is the right final
+  // shed: its shortcut strip already drops piecewise by width, the header's
+  // "N SKILLS/WORKFLOWS ON MAINNET" still names the active tab, and the
+  // footer hint still carries [tab] switch, whose key keeps working with the
+  // row hidden. At 11 rows the old 11 row chrome EQUALLED the terminal,
+  // which is already ink's full clear-and-repaint path on every keystroke.
   // While typing, the search row is the interaction surface and never drops.
   // A flash reserves two rows; when not even one spare row exists it takes
   // the footer's hint slot instead of growing the frame.
+  const showTabsRow = agentRows >= 12;
   const flashInFooter = flash != null && agentRows < 13;
   const listSpare = Math.max(0, agentRows - 12 - (flash != null && !flashInFooter ? 2 : 0));
   const showSearchRow = typing || listSpare >= 1;
@@ -1222,17 +1228,19 @@ export function SkillMarket({
         </Box>
       </Box>
       {/* tabs; the shortcut strip truncates and disappears before the tabs ever wrap */}
-      <Box marginTop={spacerRoom >= 3 ? 1 : 0}>
-        <Text color={kind === "skill" ? colors.iqCyan : colors.dim} bold={kind === "skill"}>skills</Text>
-        <Text dimColor>  ·  </Text>
-        <Text color={kind === "workflow" ? colors.iqCyan : colors.dim} bold={kind === "workflow"}>workflows</Text>
-        {shortcutRoom >= 4 ? (
-          <>
-            <Text dimColor>  ·  </Text>
-            <Text color={colors.dim}>{truncateEnd(shortcuts, shortcutRoom)}</Text>
-          </>
-        ) : null}
-      </Box>
+      {showTabsRow ? (
+        <Box marginTop={spacerRoom >= 3 ? 1 : 0}>
+          <Text color={kind === "skill" ? colors.iqCyan : colors.dim} bold={kind === "skill"}>skills</Text>
+          <Text dimColor>  ·  </Text>
+          <Text color={kind === "workflow" ? colors.iqCyan : colors.dim} bold={kind === "workflow"}>workflows</Text>
+          {shortcutRoom >= 4 ? (
+            <>
+              <Text dimColor>  ·  </Text>
+              <Text color={colors.dim}>{truncateEnd(shortcuts, shortcutRoom)}</Text>
+            </>
+          ) : null}
+        </Box>
+      ) : null}
       {/* search box + hide-owned filter; chips drop whole before they can interleave */}
       {showSearchRow ? (
         <Box marginTop={spacerRoom >= 4 ? 1 : 0}>

--- a/surfaces/cli/src/views/SkillMarket.tsx
+++ b/surfaces/cli/src/views/SkillMarket.tsx
@@ -13,7 +13,7 @@ import { tierInfo, tierGauge } from "./market/tiers.js";
 import { AgentProfileView, type ProfileSub } from "./market/AgentProfileView.js";
 import { SkillDetailView, mainLines, mainViewportH, skillTextLines, commentLines, subViewportH, type DetailSub } from "./market/SkillDetailView.js";
 import { HeliusPanel, HeliusBadge, heliusBadgeText, type RpcStatusLite } from "./market/HeliusPanel.js";
-import { GithubPanel, type GithubStatusLite, type GithubFocus } from "./market/GithubPanel.js";
+import { GithubPanel, githubRowAt, githubRowCount, type GithubStatusLite } from "./market/GithubPanel.js";
 import { PublishProgressView, type PublishProgress } from "./market/PublishProgressView.js";
 
 export interface MarketApi {
@@ -219,8 +219,9 @@ export function SkillMarket({
   const [ghTokenInput, setGhTokenInput] = useState("");
   const [ghRepoInput, setGhRepoInput] = useState("");
   const [ghSelected, setGhSelected] = useState<Record<string, boolean>>({}); // mint -> chosen
-  const [ghFocus, setGhFocus] = useState<GithubFocus>("repo");
-  const [ghSkillIdx, setGhSkillIdx] = useState(0);
+  // ONE vertical focus list (order in githubRowAt): token, repo, each skill, register.
+  const [ghFocusIdx, setGhFocusIdx] = useState(0);
+  const [ghTokenEditing, setGhTokenEditing] = useState(false); // replacing a stored token
   const [ghFlash, setGhFlash] = useState<string | null>(null);
 
   const owned = new Set(ownedNames);
@@ -237,10 +238,11 @@ export function SkillMarket({
   // the client-side validity check so a bad repo is caught before any network call.
   // Single source: both the github useInput gate and GithubPanel read this.
   const ghChosen = Object.keys(ghSelected).filter((m) => ghSelected[m]);
+  const ghParsedRepo = parseGithubRepo(ghRepoInput);
   const githubBlockReason: string | null =
     !githubStatus?.hasToken ? "add a GitHub token above first."
     : ghRepoInput.trim().length === 0 ? "enter a repo first: owner/name or a github.com URL."
-    : parseGithubRepo(ghRepoInput) == null ? "that repo is not valid. use owner/name or a github.com URL."
+    : ghParsedRepo == null ? "that repo is not valid. use owner/name or a github.com URL."
     : ownedCollection.length === 0 ? "buy or mint a skill first, then link it here."
     : ghChosen.length === 0 ? "pick at least one skill this repo used."
     : null;
@@ -591,37 +593,63 @@ export function SkillMarket({
 
     // ── github verified work ──────────────────────────────────────────────
     if (stage === "github") {
-      if (key.escape) { setStage("list"); setGhFlash(null); return; }
-      // No token yet: one field to paste the Personal Access Token.
-      if (!githubStatus?.hasToken) {
-        if (key.return) { void doSaveGithubToken(ghTokenInput.trim()); return; }
+      // Token entry: first connect (no token yet) or replacing a stored one via
+      // enter on the token row. Enter saves; while a form exists behind it, esc
+      // cancels and up/down leave the field with the typed text kept.
+      if (!githubStatus?.hasToken || ghTokenEditing) {
+        if (key.escape) {
+          if (githubStatus?.hasToken) { setGhTokenEditing(false); return; }
+          setStage("list"); setGhFlash(null); return;
+        }
+        if (githubStatus?.hasToken && (key.upArrow || key.downArrow)) {
+          setGhTokenEditing(false);
+          setGhFocusIdx(key.downArrow ? 1 : 0);
+          return;
+        }
+        if (key.return) {
+          // replacing a stored token: an empty enter cancels instead of silently
+          // clearing the token ([x] on the token row is the remove).
+          if (ghTokenEditing && ghTokenInput.trim() === "") { setGhTokenEditing(false); return; }
+          setGhTokenEditing(false);
+          void doSaveGithubToken(ghTokenInput.trim());
+          return;
+        }
         if (key.backspace || key.delete) { setGhTokenInput((v) => v.slice(0, -1)); return; }
         if (input && !key.ctrl && !key.meta) { setGhTokenInput((v) => v + input); return; }
         return;
       }
-      // Token present: register-repo form. [tab] cycles token -> repo -> skills.
-      if (key.tab) { setGhFocus((f) => (f === "token" ? "repo" : f === "repo" ? "skills" : "token")); return; }
-      if (ghFocus === "token") {
-        if (input === "x" || key.return) { void doSaveGithubToken(""); return; } // remove token
+      if (key.escape) { setStage("list"); setGhFlash(null); return; }
+      // ONE vertical focus list (order lives in githubRowAt): up/down walk it from
+      // anywhere, including the repo input; tab and shift-tab cycle it as an alternate
+      // but are never required. Enter acts on whichever row holds focus.
+      const ghRows = githubRowCount(ownedCollection.length);
+      const ghIdx = Math.min(ghFocusIdx, ghRows - 1);
+      if (key.upArrow) { setGhFocusIdx(Math.max(0, ghIdx - 1)); return; }
+      if (key.downArrow) { setGhFocusIdx(Math.min(ghRows - 1, ghIdx + 1)); return; }
+      if (key.tab) { setGhFocusIdx(key.shift ? (ghIdx + ghRows - 1) % ghRows : (ghIdx + 1) % ghRows); return; }
+      const ghRow = githubRowAt(ghIdx, ownedCollection.length);
+      if (ghRow.kind === "token") {
+        if (input === "x") { void doSaveGithubToken(""); return; } // remove token
+        if (key.return) { setGhTokenInput(""); setGhTokenEditing(true); return; } // replace it
         return;
       }
-      if (ghFocus === "skills") {
-        if (key.upArrow) { setGhSkillIdx((i) => Math.max(0, i - 1)); return; }
-        if (key.downArrow) { setGhSkillIdx((i) => Math.min(Math.max(0, ownedCollection.length - 1), i + 1)); return; }
-        // Enter toggles the highlighted skill, same as space: with a list cursor on
-        // screen, Enter reads as "pick this one". Registering from here fired the gate
-        // flash instead ("pick at least one skill...") which read as a broken key.
+      if (ghRow.kind === "skill") {
         if (input === " " || key.return) {
-          const cur = ownedCollection[Math.min(ghSkillIdx, Math.max(0, ownedCollection.length - 1))];
+          const cur = ownedCollection[ghRow.skill];
           if (cur) setGhSelected((s) => ({ ...s, [cur.id]: !s[cur.id] }));
           return;
         }
         return;
       }
-      // ghFocus === "repo": text entry, enter registers once the gate is clear. When it
-      // is not, do nothing: the standing blockReason row already says what is missing,
-      // and copying it into the flash printed the same message twice.
-      if (key.return) { if (!githubBlockReason) void doRegisterRepo(); return; }
+      if (ghRow.kind === "register") {
+        // fires only when the gate is clear; a blocked enter stays silent because the
+        // register row itself already says why not, once, right under the cursor.
+        if (key.return && !githubBlockReason) { void doRegisterRepo(); return; }
+        return;
+      }
+      // repo input: printable characters land here ONLY while this row holds focus;
+      // enter moves on to the skills (fill repo, pick skills, register).
+      if (key.return) { setGhFocusIdx(2); return; }
       if (key.backspace || key.delete) { setGhRepoInput((v) => v.slice(0, -1)); return; }
       if (input && !key.ctrl && !key.meta) { setGhRepoInput((v) => v + input); return; }
       return;
@@ -826,7 +854,7 @@ export function SkillMarket({
     if (input === "a") { setStage("agents"); void loadAgents(); return; }
     if (input === "p") { setPubResult(null); setPubProgress(null); setPubField("kind"); setPubKind("skill"); setStage("publish"); return; }
     if (input === "r") { setHeliusFlash(null); setHeliusKeyInput(""); setStage("helius"); return; }
-    if (input === "g") { setGhFlash(null); setGhFocus("repo"); setStage("github"); return; }
+    if (input === "g") { setGhFlash(null); setGhFocusIdx(0); setGhTokenEditing(false); setStage("github"); return; }
     if (input === "h") { setHideOwned((v) => !v); setIdx(0); return; }
     if (input === "s") { const next = marketSort === "stars" ? "supply" : "stars"; setMarketSort(next); void search(query, kind, next); return; }
     if (key.tab) {
@@ -849,14 +877,16 @@ export function SkillMarket({
       <GithubPanel
         status={githubStatus}
         tokenInput={ghTokenInput}
+        tokenEditing={ghTokenEditing}
         repoInput={ghRepoInput}
+        repoLabel={ghParsedRepo ? `${ghParsedRepo.owner}/${ghParsedRepo.name}` : null}
         owned={ownedCollection}
         selected={ghSelected}
-        focus={ghFocus}
-        skillIdx={Math.min(ghSkillIdx, Math.max(0, ownedCollection.length - 1))}
+        focusIdx={Math.min(ghFocusIdx, githubRowCount(ownedCollection.length) - 1)}
         blockReason={githubBlockReason}
         busy={busy}
         flash={ghFlash}
+        width={Math.max(20, marketCols - 4)}
       />
     );
   }

--- a/surfaces/cli/src/views/SkillMarket.tsx
+++ b/surfaces/cli/src/views/SkillMarket.tsx
@@ -11,7 +11,7 @@ import { ChipCarousel } from "../components/ChipCarousel.js";
 import { Band } from "../components/Band.js";
 import { tierInfo, tierGauge } from "./market/tiers.js";
 import { AgentProfileView, type ProfileSub } from "./market/AgentProfileView.js";
-import { SkillDetailView, mainLines, mainViewportH, type DetailSub } from "./market/SkillDetailView.js";
+import { SkillDetailView, mainLines, mainViewportH, skillTextLines, commentLines, subViewportH, type DetailSub } from "./market/SkillDetailView.js";
 import { HeliusPanel, HeliusBadge, type RpcStatusLite } from "./market/HeliusPanel.js";
 import { GithubPanel, type GithubStatusLite, type GithubFocus } from "./market/GithubPanel.js";
 import { PublishProgressView, type PublishProgress } from "./market/PublishProgressView.js";
@@ -761,8 +761,14 @@ export function SkillMarket({
       const isOwned = owned.has(detail.card.name);
       const disposed = disposedNames.has(detail.card.name);
       if (detailSub !== "main") {
-        const total = detailSub === "skillText" ? (detail.skillText ?? "").split("\n").length : (detail.notes ?? []).length;
-        const height = detailSub === "skillText" ? 16 : 12;
+        // clamp against WRAPPED rows, the same lists the subviews render: raw file
+        // lines undercount whenever a line wraps at narrow widths, and the constant
+        // heights overran short terminals (skillTextLines/commentLines/subViewportH
+        // are the one source for both).
+        const total = detailSub === "skillText"
+          ? skillTextLines(detail, marketCols).length
+          : commentLines(detail.notes ?? [], marketCols).length;
+        const height = subViewportH(agentRows, total);
         if (key.escape) { setDetailSub("main"); setDetailScroll(0); return; }
         if (key.downArrow) { setDetailScroll((o) => clampScroll(o + 1, total, height)); return; }
         if (key.upArrow) { setDetailScroll((o) => clampScroll(o - 1, total, height)); return; }

--- a/surfaces/cli/src/views/SkillMarket.tsx
+++ b/surfaces/cli/src/views/SkillMarket.tsx
@@ -12,7 +12,7 @@ import { Band } from "../components/Band.js";
 import { tierInfo, tierGauge } from "./market/tiers.js";
 import { AgentProfileView, type ProfileSub } from "./market/AgentProfileView.js";
 import { SkillDetailView, mainLines, mainViewportH, skillTextLines, commentLines, subViewportH, type DetailSub } from "./market/SkillDetailView.js";
-import { HeliusPanel, HeliusBadge, type RpcStatusLite } from "./market/HeliusPanel.js";
+import { HeliusPanel, HeliusBadge, heliusBadgeText, type RpcStatusLite } from "./market/HeliusPanel.js";
 import { GithubPanel, type GithubStatusLite, type GithubFocus } from "./market/GithubPanel.js";
 import { PublishProgressView, type PublishProgress } from "./market/PublishProgressView.js";
 
@@ -1183,7 +1183,7 @@ export function SkillMarket({
   // narrow widths ("MARKE5 SKILLS ON / T MAINNET" at 40 cols); each row now truncates or
   // drops its least important piece instead. innerW = frame border 2 + paddingX 2.
   const innerW = Math.max(12, marketCols - 4);
-  const badgePlain = !rpcStatus ? "" : rpcStatus.hasKey ? `● ${rpcStatus.network} · ${rpcStatus.masked}` : "add a Helius key for faster results";
+  const badgePlain = heliusBadgeText(rpcStatus);
   const noteRoom = Math.max(0, innerW - displayWidth("MARKET") - 2);
   const showBadge = badgePlain !== "" && displayWidth(onMainnet) + 3 + displayWidth(badgePlain) <= noteRoom;
   const shortcuts = "[a] agents  [p] publish  [r] rpc  [g] github";

--- a/surfaces/cli/src/views/SkillMarket.tsx
+++ b/surfaces/cli/src/views/SkillMarket.tsx
@@ -145,7 +145,10 @@ export function SkillMarket({
   const [kind, setKind] = useState<"skill" | "workflow">("skill");
   const [marketSort, setMarketSort] = useState<"supply" | "stars">("supply"); // GH #89 ranking
   const [query, setQuery] = useState("");
-  const [typing, setTyping] = useState(true);
+  // the list owns first focus: a fresh user's first keystroke means a command ([h], [a],
+  // [p], [b]...), matching the footer. Auto-focusing the search box swallowed it as
+  // query text instead. "/" or the up arrow still moves focus into the search box.
+  const [typing, setTyping] = useState(false);
   const [results, setResults] = useState<SkillCard[]>([]);
   const [loading, setLoading] = useState(false);
   const [error, setError] = useState<string | null>(null);

--- a/surfaces/cli/src/views/SkillMarket.tsx
+++ b/surfaces/cli/src/views/SkillMarket.tsx
@@ -374,6 +374,22 @@ export function SkillMarket({
     );
     setBusy(false);
     if (res.ok) {
+      // count the new comment immediately: postNote returns no payload, so prepend the
+      // note we just wrote (notes are newest-first) instead of waiting for a reload.
+      const now = Date.now();
+      setDetail((d) => d && {
+        ...d,
+        notes: [
+          {
+            id: `${walletAddr}-${now}`,
+            author: walletAddr,
+            text: commentText.trim(),
+            gitLink: commentGitLink.trim() || undefined,
+            timestamp: now,
+          },
+          ...(d.notes ?? []),
+        ],
+      });
       setFlash("comment posted");
       setCommentText("");
       setCommentGitLink("");

--- a/surfaces/cli/src/views/SkillMarket.tsx
+++ b/surfaces/cli/src/views/SkillMarket.tsx
@@ -1181,7 +1181,14 @@ export function SkillMarket({
         ) : error ? (
           <Text color={colors.err}>{error}</Text>
         ) : visibleResults.length === 0 ? (
-          <Text dimColor>no {kind === "skill" ? "skills" : "workflows"} found</Text>
+          // results can exist yet all be hidden by the owned filter (only that filter
+          // empties a non-empty result set). "no skills found" here contradicted the
+          // "N ON MAINNET" header; say what is hidden and name the key that shows it.
+          results.length > 0 ? (
+            <Text dimColor>all {results.length} owned, [h] shows them</Text>
+          ) : (
+            <Text dimColor>no {kind === "skill" ? "skills" : "workflows"} found</Text>
+          )
         ) : (
           <ChipCarousel
             items={visibleResults}

--- a/surfaces/cli/src/views/SkillMarket.tsx
+++ b/surfaces/cli/src/views/SkillMarket.tsx
@@ -142,7 +142,10 @@ export function SkillMarket({
   onBought: () => void;
   onClose: () => void;
   initialStage?: "list" | "agents" | "owned" | "github";
-  owned?: OwnedSkill[];
+  // null = the host is still fetching the wallet's skills (the WelcomePanel convention:
+  // skills === null means loading, [] means fetched and none owned). The owned stage and
+  // the github panel read the difference so neither claims "no skills" mid-fetch.
+  owned?: OwnedSkill[] | null;
 }) {
   const [stage, setStage] = useState<Stage>(initialStage ?? "list");
   // Esc unwinds to where the user actually came from. /github, /agents and /skills
@@ -162,7 +165,10 @@ export function SkillMarket({
   // [p], [b]...), matching the footer. Auto-focusing the search box swallowed it as
   // query text instead. "/" or the up arrow still moves focus into the search box.
   const [typing, setTyping] = useState(false);
-  const [results, setResults] = useState<SkillCard[]>([]);
+  // null = no search has settled yet (the WelcomePanel null-means-loading convention).
+  // The first frame renders before the mount effect fires its search; with [] here that
+  // frame claimed "no skills found" and "0 ON MAINNET" for a fetch that had not begun.
+  const [results, setResults] = useState<SkillCard[] | null>(null);
   const [loading, setLoading] = useState(false);
   const [error, setError] = useState<string | null>(null);
   const [idx, setIdx] = useState(0);
@@ -199,8 +205,10 @@ export function SkillMarket({
   // owned collection stage
   const [ownedIdx, setOwnedIdx] = useState(0);
 
-  // agents stage
-  const [agents, setAgents] = useState<Reputation[]>([]);
+  // agents stage. null = the directory fetch has not settled (same null convention as
+  // results): /agents renders one frame before the mount effect calls loadAgents, and
+  // with [] that frame said "no agents found" while the fetch was still ahead of it.
+  const [agents, setAgents] = useState<Reputation[] | null>(null);
   const [agentIdx, setAgentIdx] = useState(0);
   const [agentQuery, setAgentQuery] = useState("");
   const [agentTyping, setAgentTyping] = useState(false);
@@ -235,10 +243,14 @@ export function SkillMarket({
   const [ghFlash, setGhFlash] = useState<string | null>(null);
 
   const owned = new Set(ownedNames);
+  // the mechanical views of the two nullable lists: mechanics (row math, selection,
+  // filters) treat pending as empty; only the render tells the two apart.
+  const ownedList = ownedCollection ?? [];
+  const ownedLoading = ownedCollection === null;
   const marketStdout = useStdout().stdout; // || not ??: detached pty reports 0 rows/cols
   const agentRows = marketStdout?.rows || 24;
   const marketCols = marketStdout?.columns || 80;
-  const visibleResults = results.filter((c) => !hideOwned || !owned.has(c.name));
+  const visibleResults = (results ?? []).filter((c) => !hideOwned || !owned.has(c.name));
   // index over the FILTERED list - what's on screen is what enter/buy act on
   const clamped = Math.min(idx, Math.max(0, visibleResults.length - 1));
   const selected = visibleResults[clamped];
@@ -253,7 +265,8 @@ export function SkillMarket({
     !githubStatus?.hasToken ? "add a GitHub token above first."
     : ghRepoInput.trim().length === 0 ? "enter a repo first: owner/name or a github.com URL."
     : ghParsedRepo == null ? "that repo is not valid. use owner/name or a github.com URL."
-    : ownedCollection.length === 0 ? "buy or mint a skill first, then link it here."
+    : ownedLoading ? "loading your skills…"
+    : ownedList.length === 0 ? "buy or mint a skill first, then link it here."
     : ghChosen.length === 0 ? "pick at least one skill this repo used."
     : null;
 
@@ -265,7 +278,9 @@ export function SkillMarket({
       setIdx(0);
     } catch (e) {
       setError(e instanceof Error ? e.message : String(e));
-      setResults([]);
+      // back to null, not []: a failed search settled NOTHING, so the header must not
+      // claim "0 ON MAINNET" and the body renders the error, never a fake empty.
+      setResults(null);
     } finally {
       setLoading(false);
     }
@@ -303,6 +318,7 @@ export function SkillMarket({
 
   async function openDetail(mint: string) {
     setLoading(true);
+    setError(null); // a stale error must not outlive the retry it prompted
     try {
       setDetail(await api.getSkillDetail(mint));
       setDetailSub("main");
@@ -466,6 +482,7 @@ export function SkillMarket({
 
   async function loadAgents() {
     setLoading(true);
+    setError(null); // the error branch must only ever show a failure of THIS fetch
     try {
       setAgents(await api.listAgents());
       setAgentIdx(0);
@@ -480,6 +497,7 @@ export function SkillMarket({
 
   async function openAgentProfile(wallet: string) {
     setLoading(true);
+    setError(null); // a stale error must not outlive the retry it prompted
     try {
       setAgentProfile(await api.getAgentProfile(wallet));
       setProfileSub("main");
@@ -603,10 +621,17 @@ export function SkillMarket({
 
     // ── github verified work ──────────────────────────────────────────────
     if (stage === "github") {
+      // Status still unread from disk: a token may exist, so neither the token form
+      // nor its capture may run yet. The panel shows its loading row; esc still backs
+      // out, everything else waits for the status to settle.
+      if (!githubStatus) {
+        if (key.escape) { setGhFlash(null); backOut("github"); }
+        return;
+      }
       // Token entry: first connect (no token yet) or replacing a stored one via
       // enter on the token row. Enter saves; while a form exists behind it, esc
       // cancels and up/down leave the field with the typed text kept.
-      if (!githubStatus?.hasToken || ghTokenEditing) {
+      if (!githubStatus.hasToken || ghTokenEditing) {
         if (key.escape) {
           if (githubStatus?.hasToken) { setGhTokenEditing(false); return; }
           setGhFlash(null); backOut("github"); return;
@@ -632,12 +657,12 @@ export function SkillMarket({
       // ONE vertical focus list (order lives in githubRowAt): up/down walk it from
       // anywhere, including the repo input; tab and shift-tab cycle it as an alternate
       // but are never required. Enter acts on whichever row holds focus.
-      const ghRows = githubRowCount(ownedCollection.length);
+      const ghRows = githubRowCount(ownedList.length);
       const ghIdx = Math.min(ghFocusIdx, ghRows - 1);
       if (key.upArrow) { setGhFocusIdx(Math.max(0, ghIdx - 1)); return; }
       if (key.downArrow) { setGhFocusIdx(Math.min(ghRows - 1, ghIdx + 1)); return; }
       if (key.tab) { setGhFocusIdx(key.shift ? (ghIdx + ghRows - 1) % ghRows : (ghIdx + 1) % ghRows); return; }
-      const ghRow = githubRowAt(ghIdx, ownedCollection.length);
+      const ghRow = githubRowAt(ghIdx, ownedList.length);
       if (ghRow.kind === "token") {
         if (input === "x") { void doSaveGithubToken(""); return; } // remove token
         if (key.return) { setGhTokenInput(""); setGhTokenEditing(true); return; } // replace it
@@ -645,7 +670,7 @@ export function SkillMarket({
       }
       if (ghRow.kind === "skill") {
         if (input === " " || key.return) {
-          const cur = ownedCollection[ghRow.skill];
+          const cur = ownedList[ghRow.skill];
           if (cur) setGhSelected((s) => ({ ...s, [cur.id]: !s[cur.id] }));
           return;
         }
@@ -720,15 +745,15 @@ export function SkillMarket({
 
     // ── agents list ────────────────────────────────────────────────────────
     if (stage === "agents") {
-      const filtered = agents.filter((a) => !agentQuery.trim() || a.wallet.toLowerCase().includes(agentQuery.toLowerCase()));
+      const filtered = (agents ?? []).filter((a) => !agentQuery.trim() || a.wallet.toLowerCase().includes(agentQuery.toLowerCase()));
       if (agentTyping) {
         if (key.return || key.downArrow) { setAgentTyping(false); setAgentIdx(0); return; }
         if (key.backspace || key.delete) { setAgentQuery((q) => q.slice(0, -1)); return; }
-        if (key.escape) { setAgents([]); setError(null); backOut("agents"); return; }
+        if (key.escape) { setAgents(null); setError(null); backOut("agents"); return; }
         if (input && !key.ctrl && !key.meta) { setAgentQuery((q) => q + input); return; }
         return;
       }
-      if (key.escape) { setAgents([]); setError(null); backOut("agents"); return; }
+      if (key.escape) { setAgents(null); setError(null); backOut("agents"); return; }
       if (input === "/") { setAgentTyping(true); return; }
       if (key.upArrow) { if (agentIdx === 0) { setAgentTyping(true); return; } return setAgentIdx((i) => Math.max(0, i - 1)); }
       if (key.downArrow) return setAgentIdx((i) => Math.min(filtered.length - 1, i + 1));
@@ -841,7 +866,7 @@ export function SkillMarket({
 
     // ── owned collection ───────────────────────────────────────────────────
     if (stage === "owned") {
-      const cur = ownedCollection[Math.min(ownedIdx, ownedCollection.length - 1)];
+      const cur = ownedList[Math.min(ownedIdx, ownedList.length - 1)];
       if (key.escape) { backOut("owned"); return; }
       if (key.return && cur) void openDetail(cur.id);
       return;
@@ -892,7 +917,7 @@ export function SkillMarket({
         repoLabel={ghParsedRepo ? `${ghParsedRepo.owner}/${ghParsedRepo.name}` : null}
         owned={ownedCollection}
         selected={ghSelected}
-        focusIdx={Math.min(ghFocusIdx, githubRowCount(ownedCollection.length) - 1)}
+        focusIdx={Math.min(ghFocusIdx, githubRowCount(ownedList.length) - 1)}
         blockReason={githubBlockReason}
         busy={busy}
         flash={ghFlash}
@@ -951,7 +976,7 @@ export function SkillMarket({
   // ── agents list ────────────────────────────────────────────────────────────
   if (stage === "agents") {
     const short = (w: string) => `${w.slice(0, 6)}…${w.slice(-4)}`;
-    const filtered = agents.filter((a) => !agentQuery.trim() || a.wallet.toLowerCase().includes(agentQuery.toLowerCase()));
+    const filtered = (agents ?? []).filter((a) => !agentQuery.trim() || a.wallet.toLowerCase().includes(agentQuery.toLowerCase()));
     // window to terminal height so every agent stays reachable. Each agent row is now two
     // lines (handle+tier, then stats) plus a gauge line on the selected one, so budget ~2
     // display lines per agent under the title/search/bands chrome.
@@ -970,8 +995,12 @@ export function SkillMarket({
           {agentTyping ? <Text inverse> </Text> : null}
         </Box>
         <Box flexDirection="column" marginTop={1}>
-          {loading ? (
-            <Text dimColor>loading agents…</Text>
+          {/* three honest states on the one reserved row: pending says loading (one dim
+              word, also true while a profile opens over this stage), a settled failure
+              says what failed, and "no agents found" may only follow a SETTLED empty
+              fetch. agents === null is the frame before the mount effect fires. */}
+          {loading || (agents === null && !error) ? (
+            <Text dimColor>loading…</Text>
           ) : error ? (
             <Text color={colors.err}>{error}</Text>
           ) : filtered.length === 0 ? (
@@ -1170,22 +1199,27 @@ export function SkillMarket({
 
   // ── owned collection ───────────────────────────────────────────────────────
   if (stage === "owned") {
-    const ownedClamped = Math.min(ownedIdx, Math.max(0, ownedCollection.length - 1));
+    const ownedClamped = Math.min(ownedIdx, Math.max(0, ownedList.length - 1));
     return (
       <Box flexDirection="column" paddingX={1} borderStyle="round" borderColor={colors.iqViolet}>
         <Text bold color={colors.iqMagenta}>❖ my skills</Text>
-        {ownedCollection.length === 0 ? (
+        {/* the host is still fetching the wallet's skills (owned === null): say loading
+            on the row the empty copy uses, never "no skills owned yet" for an unsettled
+            fetch. The empty claim renders only once the fetch settled empty. */}
+        {ownedLoading ? (
+          <Box marginTop={1}><Text dimColor>loading…</Text></Box>
+        ) : ownedList.length === 0 ? (
           <Box marginTop={1}><Text dimColor>no skills owned yet · /market buys one</Text></Box>
         ) : (
           <Box marginTop={1}>
             <ChipCarousel
-              items={ownedCollection}
+              items={ownedList}
               index={ownedClamped}
               onIndex={setOwnedIdx}
               chipWidth={SKILL_CHIP_W}
               renderChip={(s, focused) => {
                 // tier is best-effort: stars live on the market card, not the owned entry
-                const stars = results.find((r) => r.id === s.id)?.stars ?? 0;
+                const stars = (results ?? []).find((r) => r.id === s.id)?.stars ?? 0;
                 const { cur } = tierInfo(stars);
                 const off = disposedNames.has(s.name);
                 return (
@@ -1211,6 +1245,9 @@ export function SkillMarket({
           </Box>
         )}
         {loading ? <Box marginTop={1}><Text dimColor>opening…</Text></Box> : null}
+        {/* a failed openDetail was silent here before: the error the api returned now
+            renders instead of leaving the user staring at a stalled carousel. */}
+        {error && !loading ? <Box marginTop={1}><Text color={colors.err}>{error}</Text></Box> : null}
         {flash ? <Box marginTop={1}><Text color={colors.ok}>{glyph.sparkle} {flash}</Text></Box> : null}
         <Box marginTop={1}>
           <Text dimColor>←/→ rotate · ↵ open detail · esc chat</Text>
@@ -1220,7 +1257,12 @@ export function SkillMarket({
   }
 
   // ── list ───────────────────────────────────────────────────────────────────
-  const onMainnet = `${results.length} ${kind === "skill" ? "SKILL" : "WORKFLOW"}${results.length === 1 ? "" : "S"} ON MAINNET`;
+  // the header count is a claim about a SETTLED fetch: before the first search lands
+  // (results === null) the number is unknown, so an ellipsis holds its place instead
+  // of a false "0 ON MAINNET".
+  const onMainnet = results === null
+    ? `… ${kind === "skill" ? "SKILLS" : "WORKFLOWS"} ON MAINNET`
+    : `${results.length} ${kind === "skill" ? "SKILL" : "WORKFLOW"}${results.length === 1 ? "" : "S"} ON MAINNET`;
   // Width bounds for the chrome rows. Unbounded, their pieces wrapped INTO each other at
   // narrow widths ("MARKE5 SKILLS ON / T MAINNET" at 40 cols); each row now truncates or
   // drops its least important piece instead. innerW = frame border 2 + paddingX 2.
@@ -1304,7 +1346,9 @@ export function SkillMarket({
       ) : null}
       {/* results - sd-card chip carousel, ←/→ rotates */}
       <Box flexDirection="column" marginTop={spacerRoom >= 1 ? 1 : 0}>
-        {loading ? (
+        {loading || (results === null && !error) ? (
+          // pending, including the entry frame before the mount effect fires its first
+          // search: the row says loading, never "no skills found" for an unsettled fetch.
           <Text dimColor>searching…</Text>
         ) : error ? (
           <Text color={colors.err}>{error}</Text>
@@ -1312,8 +1356,8 @@ export function SkillMarket({
           // results can exist yet all be hidden by the owned filter (only that filter
           // empties a non-empty result set). "no skills found" here contradicted the
           // "N ON MAINNET" header; say what is hidden and name the key that shows it.
-          results.length > 0 ? (
-            <Text dimColor>all {results.length} owned, [h] shows them</Text>
+          (results ?? []).length > 0 ? (
+            <Text dimColor>all {(results ?? []).length} owned, [h] shows them</Text>
           ) : (
             <Text dimColor>no {kind === "skill" ? "skills" : "workflows"} found</Text>
           )

--- a/surfaces/cli/src/views/SkillMarket.tsx
+++ b/surfaces/cli/src/views/SkillMarket.tsx
@@ -11,7 +11,7 @@ import { ChipCarousel } from "../components/ChipCarousel.js";
 import { Band } from "../components/Band.js";
 import { tierInfo, tierGauge } from "./market/tiers.js";
 import { AgentProfileView, type ProfileSub } from "./market/AgentProfileView.js";
-import { SkillDetailView, type DetailSub } from "./market/SkillDetailView.js";
+import { SkillDetailView, mainLines, mainViewportH, type DetailSub } from "./market/SkillDetailView.js";
 import { HeliusPanel, HeliusBadge, type RpcStatusLite } from "./market/HeliusPanel.js";
 import { GithubPanel, type GithubStatusLite, type GithubFocus } from "./market/GithubPanel.js";
 import { PublishProgressView, type PublishProgress } from "./market/PublishProgressView.js";
@@ -754,6 +754,14 @@ export function SkillMarket({
         if (key.pageUp) { setDetailScroll((o) => clampScroll(o - height, total, height)); return; }
         return;
       }
+      // main body scroll - same clamp the subviews use, against the same line list the
+      // view renders (mainLines/mainViewportH are the one source for both).
+      const mainTotal = mainLines(detail, owned, marketCols).length;
+      const mainH = mainViewportH(agentRows, mainTotal);
+      if (key.downArrow) { setDetailScroll((o) => clampScroll(o + 1, mainTotal, mainH)); return; }
+      if (key.upArrow) { setDetailScroll((o) => clampScroll(o - 1, mainTotal, mainH)); return; }
+      if (key.pageDown) { setDetailScroll((o) => clampScroll(o + mainH, mainTotal, mainH)); return; }
+      if (key.pageUp) { setDetailScroll((o) => clampScroll(o - mainH, mainTotal, mainH)); return; }
       if (key.escape) { setStage("list"); setDetail(null); return; }
       if (input === "b" && !isOwned) { setStage("confirm"); return; }
       if (input === "c") {

--- a/surfaces/cli/src/views/SkillMarket.tsx
+++ b/surfaces/cli/src/views/SkillMarket.tsx
@@ -145,6 +145,16 @@ export function SkillMarket({
   owned?: OwnedSkill[];
 }) {
   const [stage, setStage] = useState<Stage>(initialStage ?? "list");
+  // Esc unwinds to where the user actually came from. /github, /agents and /skills
+  // open the market already jumped to an inner stage, so the user arrived from CHAT
+  // and never saw the list; esc on that entry stage closes the market (onClose)
+  // instead of stranding them on the list. Entered from the list ([g], [a]), the
+  // same esc returns to the list exactly as before. Deeper stages are untouched.
+  const entryStage: Stage = initialStage ?? "list";
+  function backOut(from: Stage) {
+    if (from === entryStage) onClose();
+    else setStage("list");
+  }
   const [kind, setKind] = useState<"skill" | "workflow">("skill");
   const [marketSort, setMarketSort] = useState<"supply" | "stars">("supply"); // GH #89 ranking
   const [query, setQuery] = useState("");
@@ -599,7 +609,7 @@ export function SkillMarket({
       if (!githubStatus?.hasToken || ghTokenEditing) {
         if (key.escape) {
           if (githubStatus?.hasToken) { setGhTokenEditing(false); return; }
-          setStage("list"); setGhFlash(null); return;
+          setGhFlash(null); backOut("github"); return;
         }
         if (githubStatus?.hasToken && (key.upArrow || key.downArrow)) {
           setGhTokenEditing(false);
@@ -618,7 +628,7 @@ export function SkillMarket({
         if (input && !key.ctrl && !key.meta) { setGhTokenInput((v) => v + input); return; }
         return;
       }
-      if (key.escape) { setStage("list"); setGhFlash(null); return; }
+      if (key.escape) { setGhFlash(null); backOut("github"); return; }
       // ONE vertical focus list (order lives in githubRowAt): up/down walk it from
       // anywhere, including the repo input; tab and shift-tab cycle it as an alternate
       // but are never required. Enter acts on whichever row holds focus.
@@ -714,11 +724,11 @@ export function SkillMarket({
       if (agentTyping) {
         if (key.return || key.downArrow) { setAgentTyping(false); setAgentIdx(0); return; }
         if (key.backspace || key.delete) { setAgentQuery((q) => q.slice(0, -1)); return; }
-        if (key.escape) { setStage("list"); setAgents([]); setError(null); return; }
+        if (key.escape) { setAgents([]); setError(null); backOut("agents"); return; }
         if (input && !key.ctrl && !key.meta) { setAgentQuery((q) => q + input); return; }
         return;
       }
-      if (key.escape) { setStage("list"); setAgents([]); setError(null); return; }
+      if (key.escape) { setAgents([]); setError(null); backOut("agents"); return; }
       if (input === "/") { setAgentTyping(true); return; }
       if (key.upArrow) { if (agentIdx === 0) { setAgentTyping(true); return; } return setAgentIdx((i) => Math.max(0, i - 1)); }
       if (key.downArrow) return setAgentIdx((i) => Math.min(filtered.length - 1, i + 1));
@@ -832,7 +842,7 @@ export function SkillMarket({
     // ── owned collection ───────────────────────────────────────────────────
     if (stage === "owned") {
       const cur = ownedCollection[Math.min(ownedIdx, ownedCollection.length - 1)];
-      if (key.escape) { setStage("list"); return; }
+      if (key.escape) { backOut("owned"); return; }
       if (key.return && cur) void openDetail(cur.id);
       return;
     }
@@ -1165,7 +1175,7 @@ export function SkillMarket({
       <Box flexDirection="column" paddingX={1} borderStyle="round" borderColor={colors.iqViolet}>
         <Text bold color={colors.iqMagenta}>❖ my skills</Text>
         {ownedCollection.length === 0 ? (
-          <Box marginTop={1}><Text dimColor>no skills owned yet · buy one in the market (esc)</Text></Box>
+          <Box marginTop={1}><Text dimColor>no skills owned yet · /market buys one</Text></Box>
         ) : (
           <Box marginTop={1}>
             <ChipCarousel
@@ -1203,7 +1213,7 @@ export function SkillMarket({
         {loading ? <Box marginTop={1}><Text dimColor>opening…</Text></Box> : null}
         {flash ? <Box marginTop={1}><Text color={colors.ok}>{glyph.sparkle} {flash}</Text></Box> : null}
         <Box marginTop={1}>
-          <Text dimColor>←/→ rotate · ↵ open detail · esc market</Text>
+          <Text dimColor>←/→ rotate · ↵ open detail · esc chat</Text>
         </Box>
       </Box>
     );

--- a/surfaces/cli/src/views/SkillMarket.tsx
+++ b/surfaces/cli/src/views/SkillMarket.tsx
@@ -990,6 +990,13 @@ export function SkillMarket({
     // display lines per agent under the title/search/bands chrome.
     const vis = Math.max(2, Math.min(filtered.length, Math.floor((agentRows - 11) / 2)));
     const aStart = Math.max(0, Math.min(agentIdx - Math.floor(vis / 2), Math.max(0, filtered.length - vis)));
+    // Footer budget: the tier legend sheds WHOLE below the width where the full hint
+    // and the full legend both fit (the sort chip and the wallet face shed the same
+    // way); the hint truncates only once the legend is gone. Unmeasured, the two
+    // fused into one wrapped run at 40 cols ("↵ profiBRONZE 3 · SILVER").
+    const agentHint = agentTyping ? "type to filter · ↵/↓ browse · esc close" : "↑/↓ move · ↵ profile · [/] search · esc back";
+    const legendPlain = "BRONZE 3 · SILVER 15 · GOLD 60 · LEGENDARY 250";
+    const showLegend = displayWidth(agentHint) + 2 + displayWidth(legendPlain) <= Math.max(12, marketCols - 4);
     return (
       <Box flexDirection="column" paddingX={1} borderStyle="round" borderColor={colors.iqViolet}>
         <Box justifyContent="space-between">
@@ -1062,17 +1069,19 @@ export function SkillMarket({
           <Band label="rank" note="ONLY VERIFIED GITHUB STARS MOVE THE TIER. COPIES CANNOT BUY IT." inverted />
         </Box>
         <Box justifyContent="space-between">
-          <Text dimColor wrap="truncate-end">{agentTyping ? "type to filter · ↵/↓ browse · esc close" : "↑/↓ move · ↵ profile · [/] search · esc back"}</Text>
+          <Text dimColor wrap="truncate-end">{agentHint}</Text>
           {/* the legend is the color key the rows obey: every rung in its own metal */}
-          <Text>
-            <Text color={tierColors.bronze}>BRONZE 3</Text>
-            <Text dimColor> · </Text>
-            <Text color={tierColors.silver}>SILVER 15</Text>
-            <Text dimColor> · </Text>
-            <Text color={tierColors.gold}>GOLD 60</Text>
-            <Text dimColor> · </Text>
-            <Text color={tierColors.legendary}>LEGENDARY 250</Text>
-          </Text>
+          {showLegend ? (
+            <Text>
+              <Text color={tierColors.bronze}>BRONZE 3</Text>
+              <Text dimColor> · </Text>
+              <Text color={tierColors.silver}>SILVER 15</Text>
+              <Text dimColor> · </Text>
+              <Text color={tierColors.gold}>GOLD 60</Text>
+              <Text dimColor> · </Text>
+              <Text color={tierColors.legendary}>LEGENDARY 250</Text>
+            </Text>
+          ) : null}
         </Box>
       </Box>
     );

--- a/surfaces/cli/src/views/SkillMarket.tsx
+++ b/surfaces/cli/src/views/SkillMarket.tsx
@@ -584,16 +584,20 @@ export function SkillMarket({
       if (ghFocus === "skills") {
         if (key.upArrow) { setGhSkillIdx((i) => Math.max(0, i - 1)); return; }
         if (key.downArrow) { setGhSkillIdx((i) => Math.min(Math.max(0, ownedCollection.length - 1), i + 1)); return; }
-        if (input === " ") {
+        // Enter toggles the highlighted skill, same as space: with a list cursor on
+        // screen, Enter reads as "pick this one". Registering from here fired the gate
+        // flash instead ("pick at least one skill...") which read as a broken key.
+        if (input === " " || key.return) {
           const cur = ownedCollection[Math.min(ghSkillIdx, Math.max(0, ownedCollection.length - 1))];
           if (cur) setGhSelected((s) => ({ ...s, [cur.id]: !s[cur.id] }));
           return;
         }
-        if (key.return) { if (githubBlockReason) setGhFlash(githubBlockReason); else void doRegisterRepo(); return; }
         return;
       }
-      // ghFocus === "repo": text entry, enter submits (or shows why it can't).
-      if (key.return) { if (githubBlockReason) setGhFlash(githubBlockReason); else void doRegisterRepo(); return; }
+      // ghFocus === "repo": text entry, enter registers once the gate is clear. When it
+      // is not, do nothing: the standing blockReason row already says what is missing,
+      // and copying it into the flash printed the same message twice.
+      if (key.return) { if (!githubBlockReason) void doRegisterRepo(); return; }
       if (key.backspace || key.delete) { setGhRepoInput((v) => v.slice(0, -1)); return; }
       if (input && !key.ctrl && !key.meta) { setGhRepoInput((v) => v + input); return; }
       return;

--- a/surfaces/cli/src/views/market/AgentProfileView.tsx
+++ b/surfaces/cli/src/views/market/AgentProfileView.tsx
@@ -4,8 +4,8 @@
 import React from "react";
 import { Box, Text } from "ink";
 import type { AgentProfile, SkillCard, Note } from "@iqlabs-official/agent-sdk";
-import { colors, glyph } from "../../theme.js";
-import { tierInfo, tierGauge, repoGauge, STAR_TIERS } from "./tiers.js";
+import { colors, glyph, tierColor } from "../../theme.js";
+import { tierInfo, TierGauge, repoGauge, STAR_TIERS } from "./tiers.js";
 import { ScrollView } from "./ScrollView.js";
 import { Band } from "../../components/Band.js";
 
@@ -168,7 +168,8 @@ export function AgentProfileView({
           AGENT  <Text color={colors.iqCyan}>{short(r.wallet)}</Text>
           {self ? <Text color={colors.ok}> // YOU</Text> : null}
         </Text>
-        <Text color={cur ? colors.warn : colors.dim}>{cur ? cur.name.toUpperCase() : "UNRANKED"}</Text>
+        {/* the hero badge wears its metal, the same tierColor the directory row uses */}
+        <Text color={cur ? tierColor(cur.name) : colors.dim}>{cur ? cur.name.toUpperCase() : "UNRANKED"}</Text>
       </Box>
       {/* big-number stat row, like the design's profile hero */}
       <Box marginTop={1}>
@@ -177,13 +178,24 @@ export function AgentProfileView({
         <Box width={16}><Text><Text bold color={colors.bone}>{held}</Text><Text dimColor> OWNED</Text></Text></Box>
       </Box>
       <Box marginTop={1}>
-        <Text dimColor>tier  </Text><Text>{tierGauge(stars)}</Text>
+        <Text dimColor>tier  </Text><TierGauge stars={stars} />
         {next ? <Text dimColor>  to {next.name}</Text> : <Text color={colors.ok}>  MAX</Text>}
       </Box>
+      {/* each rung wears its own metal once reached; the rung you stand on is inverted
+          so CURRENT pops out of the flood of rungs passed long ago. Unreached = dim. */}
       <Box>
         <Text dimColor>ladder</Text>
         {STAR_TIERS.map((t) => (
-          <Text key={t.name} color={stars >= t.min ? colors.ok : colors.dim}> {t.name}({t.min})</Text>
+          <Text key={t.name}>
+            {" "}
+            <Text
+              color={stars >= t.min ? tierColor(t.name) : colors.dim}
+              bold={cur?.name === t.name}
+              inverse={cur?.name === t.name}
+            >
+              {t.name}({t.min})
+            </Text>
+          </Text>
         ))}
       </Box>
       <Box marginTop={1}>

--- a/surfaces/cli/src/views/market/AgentProfileView.tsx
+++ b/surfaces/cli/src/views/market/AgentProfileView.tsx
@@ -5,7 +5,8 @@ import React from "react";
 import { Box, Text, useStdout } from "ink";
 import type { AgentProfile, SkillCard, Note } from "@iqlabs-official/agent-sdk";
 import { colors, glyph, tierColor } from "../../theme.js";
-import { tierInfo, TierGauge, repoGauge, STAR_TIERS } from "./tiers.js";
+import { displayWidth } from "../../format.js";
+import { tierInfo, tierGauge, TierGauge, repoGauge, STAR_TIERS } from "./tiers.js";
 import { walletColor, walletFace } from "./avatar.js";
 import { ScrollView } from "./ScrollView.js";
 import { Band } from "../../components/Band.js";
@@ -48,7 +49,8 @@ export function AgentProfileView({
   const r = profile.reputation;
   // wallet-face identity (design tab 20 //AVATAR_): same wallet, same face on the
   // hero and on every comment author. Sheds below 40 cols like the directory rows.
-  const showFace = (useStdout().stdout?.columns || 80) >= 40;
+  const cols = useStdout().stdout?.columns || 80;
+  const showFace = cols >= 40;
   const stars = r.stars ?? 0;
   const { cur, next } = tierInfo(stars);
   // Threads arrive pre-grouped from the host (GH #101). Blog = the agent's own posts;
@@ -178,6 +180,24 @@ export function AgentProfileView({
 
   // main
   const held = self ? profile.createdSkills?.length ?? 0 : heldFromAgent;
+  // The tier row and the ladder are measured against the frame's inner width
+  // (cols minus border 2 and paddingX 2) so a narrow terminal sheds whole
+  // pieces instead of letting ink wrap them mid-word into a two-line jumble.
+  const innerW = Math.max(12, cols - 4);
+  // "  to Silver" is an appendix on the gauge row; it sheds whole when the row
+  // cannot seat it (the gauge's own "74/250" count still names the progress).
+  const showTo = next != null && displayWidth(`tier  ${tierGauge(stars)}  to ${next.name}`) <= innerW;
+  // Ladder rungs shed right to left below the ladder's natural width, the same
+  // idiom the directory row and the hero use for the wallet face: a rung renders
+  // whole (name, count, decorations) or not at all, never as a wrapped fragment.
+  let ladderUsed = displayWidth("ladder");
+  const rungs: typeof STAR_TIERS = [];
+  for (const t of STAR_TIERS) {
+    const w = 1 + displayWidth(`${t.name}(${t.min})`);
+    if (ladderUsed + w > innerW) break;
+    rungs.push(t);
+    ladderUsed += w;
+  }
   return (
     <Box flexDirection="column" paddingX={1} borderStyle="round" borderColor={colors.iqViolet}>
       <Box justifyContent="space-between">
@@ -195,15 +215,17 @@ export function AgentProfileView({
         <Box width={16}><Text><Text bold color={colors.bone}>{r.totalSupply}</Text><Text dimColor> COPIES</Text></Text></Box>
         <Box width={16}><Text><Text bold color={colors.bone}>{held}</Text><Text dimColor> OWNED</Text></Text></Box>
       </Box>
+      {/* the single MAX on this row belongs to the gauge itself (tiers.tsx paints
+          it green); appending another word here is what printed "MAX  MAX" */}
       <Box marginTop={1}>
         <Text dimColor>tier  </Text><TierGauge stars={stars} />
-        {next ? <Text dimColor>  to {next.name}</Text> : <Text color={colors.ok}>  MAX</Text>}
+        {next && showTo ? <Text dimColor>  to {next.name}</Text> : null}
       </Box>
       {/* each rung wears its own metal once reached; the rung you stand on is inverted
           so CURRENT pops out of the flood of rungs passed long ago. Unreached = dim. */}
       <Box>
         <Text dimColor>ladder</Text>
-        {STAR_TIERS.map((t) => (
+        {rungs.map((t) => (
           <Text key={t.name}>
             {" "}
             <Text

--- a/surfaces/cli/src/views/market/AgentProfileView.tsx
+++ b/surfaces/cli/src/views/market/AgentProfileView.tsx
@@ -2,10 +2,11 @@
 // tier tag + gauge + ladder, earned SOL, verified GitHub repos, blog carousel, full
 // comment stack, buy-all with count feedback, self-only "write a blog post" entry.
 import React from "react";
-import { Box, Text } from "ink";
+import { Box, Text, useStdout } from "ink";
 import type { AgentProfile, SkillCard, Note } from "@iqlabs-official/agent-sdk";
 import { colors, glyph, tierColor } from "../../theme.js";
 import { tierInfo, TierGauge, repoGauge, STAR_TIERS } from "./tiers.js";
+import { walletColor, walletFace } from "./avatar.js";
 import { ScrollView } from "./ScrollView.js";
 import { Band } from "../../components/Band.js";
 
@@ -31,6 +32,7 @@ export function AgentProfileView({
   sub,
   scrollOffset,
   self,
+  walletAddr,
 }: {
   profile: AgentProfile;
   owned: Set<string>;
@@ -39,8 +41,14 @@ export function AgentProfileView({
   sub: ProfileSub;
   scrollOffset: number;
   self: boolean;
+  // the VIEWER's wallet: marks their own comments "// YOU" in the threads
+  // (design tab 22); `self` above is about the profile's subject, not the viewer.
+  walletAddr?: string;
 }) {
   const r = profile.reputation;
+  // wallet-face identity (design tab 20 //AVATAR_): same wallet, same face on the
+  // hero and on every comment author. Sheds below 40 cols like the directory rows.
+  const showFace = (useStdout().stdout?.columns || 80) >= 40;
   const stars = r.stars ?? 0;
   const { cur, next } = tierInfo(stars);
   // Threads arrive pre-grouped from the host (GH #101). Blog = the agent's own posts;
@@ -79,10 +87,19 @@ export function AgentProfileView({
   if (sub === "comments") {
     // Each thread: the top-level comment, then its replies indented with an ↳ and
     // (when the reply answered a deeper comment) a → to whom.
+    // every author carries their wallet face, and the viewer's own comments say
+    // // YOU in green (design tab 22's thread identity language).
+    const author = (wallet: string) => (
+      <>
+        {showFace ? <Text color={walletColor(wallet)}>{walletFace(wallet)} </Text> : null}
+        <Text color={colors.iqCyan}>{short(wallet)}</Text>
+        {walletAddr && wallet === walletAddr ? <Text color={colors.ok}> // YOU</Text> : null}
+      </>
+    );
     const lines = commentThreads.flatMap((t) => [
       <Box key={t.note.id} flexDirection="column">
         <Text>
-          <Text color={colors.iqCyan}>{short(t.note.author)}</Text>
+          {author(t.note.author)}
           <Text dimColor>  {noteDate(t.note.timestamp)}</Text>
         </Text>
         {t.note.title ? <Text bold>{t.note.title}</Text> : null}
@@ -93,7 +110,7 @@ export function AgentProfileView({
         <Box key={rep.id} flexDirection="column" marginLeft={2}>
           <Text>
             <Text dimColor>↳ </Text>
-            <Text color={colors.iqCyan}>{short(rep.author)}</Text>
+            {author(rep.author)}
             <Text dimColor>  {noteDate(rep.timestamp)}{rep.parentAuthor ? ` → ${short(rep.parentAuthor)}` : ""}</Text>
           </Text>
           {rep.title ? <Text bold>{rep.title}</Text> : null}
@@ -165,7 +182,8 @@ export function AgentProfileView({
     <Box flexDirection="column" paddingX={1} borderStyle="round" borderColor={colors.iqViolet}>
       <Box justifyContent="space-between">
         <Text bold color={colors.bone}>
-          AGENT  <Text color={colors.iqCyan}>{short(r.wallet)}</Text>
+          AGENT  {showFace ? <Text color={walletColor(r.wallet)}>{walletFace(r.wallet)} </Text> : null}
+          <Text color={colors.iqCyan}>{short(r.wallet)}</Text>
           {self ? <Text color={colors.ok}> // YOU</Text> : null}
         </Text>
         {/* the hero badge wears its metal, the same tierColor the directory row uses */}

--- a/surfaces/cli/src/views/market/GithubPanel.tsx
+++ b/surfaces/cli/src/views/market/GithubPanel.tsx
@@ -6,9 +6,15 @@
 // saveGithubToken/maskedGithubToken 0600 file, and registerVerifiedWork which
 // commits the public .agentnet marker then registers with the indexer); this file
 // is pure render, the same split the CLI's HeliusPanel uses for the RPC key.
+//
+// The register form is ONE vertical focus list walked with up/down: token row,
+// repo input, each owned skill, then a REGISTER action row. Enter acts on the
+// focused row; the focused row renders as the welcome panel's fully inverted
+// band (ink on bone, edge to edge), the design's strongest focus signature.
 import React from "react";
 import { Box, Text } from "ink";
 import { colors, glyph } from "../../theme.js";
+import { displayWidth, truncateEnd } from "../../format.js";
 import type { OwnedSkill } from "../../components/WelcomePanel.js";
 
 // Pre-fills GitHub's new-token page with the repo scope (write to your repos, needed
@@ -21,9 +27,40 @@ export interface GithubStatusLite {
   masked: string | null;
 }
 
-// Which sub-field of the register form has focus. Only meaningful once a token is
-// stored; without one the screen is a single token-entry field.
-export type GithubFocus = "token" | "repo" | "skills";
+// The ONE focus order of the register form, walked with up/down (tab cycles it as an
+// alternate): token, repo, each owned skill, register. Both the SkillMarket input
+// handler and the render below read it from here, so they can never disagree.
+export type GithubRow =
+  | { kind: "token" }
+  | { kind: "repo" }
+  | { kind: "skill"; skill: number }
+  | { kind: "register" };
+
+export function githubRowCount(skillCount: number): number {
+  return 3 + skillCount;
+}
+
+export function githubRowAt(idx: number, skillCount: number): GithubRow {
+  if (idx <= 0) return { kind: "token" };
+  if (idx === 1) return { kind: "repo" };
+  if (idx < 2 + skillCount) return { kind: "skill", skill: idx - 2 };
+  return { kind: "register" };
+}
+
+// The focused row, drawn exactly like a focused welcome panel band: fully inverted,
+// ink on bone, edge to edge. `cursor` appends a block cursor for the text-input row.
+function FocusBand({ width, text, cursor }: { width: number; text: string; cursor?: boolean }) {
+  const room = Math.max(4, width - (cursor ? 1 : 0));
+  const fitted = truncateEnd(text, room);
+  const pad = Math.max(0, width - displayWidth(fitted) - (cursor ? 1 : 0));
+  return (
+    <Text backgroundColor={colors.bone} color={colors.ink} bold>
+      {fitted}
+      {cursor ? <Text backgroundColor={colors.ink} color={colors.bone}> </Text> : null}
+      {" ".repeat(pad)}
+    </Text>
+  );
+}
 
 function GithubBadge({ status }: { status: GithubStatusLite | null }) {
   if (!status) return null;
@@ -36,28 +73,34 @@ function GithubBadge({ status }: { status: GithubStatusLite | null }) {
 export function GithubPanel({
   status,
   tokenInput,
+  tokenEditing,
   repoInput,
+  repoLabel,
   owned,
   selected,
-  focus,
-  skillIdx,
+  focusIdx,
   blockReason,
   busy,
   flash,
+  width,
 }: {
   status: GithubStatusLite | null;
   tokenInput: string;
+  tokenEditing: boolean;
   repoInput: string;
+  repoLabel: string | null; // parsed owner/name once the repo input is valid
   owned: OwnedSkill[];
   selected: Record<string, boolean>;
-  focus: GithubFocus;
-  skillIdx: number;
+  focusIdx: number;
   blockReason: string | null;
   busy: boolean;
   flash: string | null;
+  width: number; // inner row width (terminal cols minus border and padding)
 }) {
   const hasToken = !!status?.hasToken;
   const chosen = Object.values(selected).filter(Boolean).length;
+  const row = githubRowAt(focusIdx, owned.length);
+  const bandW = Math.max(10, width);
   return (
     <Box flexDirection="column" paddingX={1} borderStyle="round" borderColor={colors.iqViolet}>
       <Text bold color={colors.iqMagenta}>❖ GitHub verified work</Text>
@@ -66,8 +109,9 @@ export function GithubPanel({
         <GithubBadge status={status} />
       </Box>
 
-      {!hasToken ? (
-        // No token yet: one field to paste the Personal Access Token.
+      {!hasToken || tokenEditing ? (
+        // Token entry: paste a Personal Access Token (first connect, or replacing a
+        // stored token via enter on the token row).
         <Box flexDirection="column" marginTop={1}>
           <Box>
             <Text color={colors.iqCyan}>▸ </Text>
@@ -82,7 +126,11 @@ export function GithubPanel({
           {flash ? <Box marginTop={1}><Text color={colors.ok}>{flash}</Text></Box> : null}
           {busy ? <Text dimColor>saving...</Text> : null}
           <Box marginTop={1}>
-            <Text dimColor>paste a Personal Access Token · ↵ save · esc back</Text>
+            <Text dimColor>
+              {tokenEditing
+                ? "paste the new token · enter save · esc cancel"
+                : "paste a Personal Access Token · enter save · esc back"}
+            </Text>
           </Box>
         </Box>
       ) : busy ? (
@@ -93,55 +141,68 @@ export function GithubPanel({
           <Box marginTop={1}><Text dimColor>working...</Text></Box>
         </Box>
       ) : (
-        // Token present: register a repo as verified work for the skills it used.
+        // Token present: one vertical focus list, up/down walks it, enter acts.
         <Box flexDirection="column" marginTop={1}>
-          <Box>
-            <Text color={focus === "token" ? colors.iqCyan : colors.dim}>{focus === "token" ? "▸ " : "  "}</Text>
-            <Text dimColor>token </Text>
-            <Text>{status?.masked}</Text>
-            <Text dimColor>  [x] remove</Text>
-          </Box>
-          <Box>
-            <Text color={focus === "repo" ? colors.iqCyan : colors.dim}>{focus === "repo" ? "▸ " : "  "}</Text>
-            <Text dimColor>repo  </Text>
-            <Text dimColor={!repoInput}>{repoInput || "owner/name or github.com URL"}</Text>
-            {focus === "repo" ? <Text inverse> </Text> : null}
-          </Box>
+          {row.kind === "token" ? (
+            <FocusBand width={bandW} text={`  token ${status?.masked ?? ""}`} />
+          ) : (
+            <Box>
+              <Text dimColor>  token </Text>
+              <Text>{status?.masked}</Text>
+            </Box>
+          )}
+          {row.kind === "repo" ? (
+            <FocusBand width={bandW} text={`  repo  ${repoInput}`} cursor />
+          ) : (
+            <Box>
+              <Text dimColor>  repo  </Text>
+              <Text dimColor={!repoInput}>{repoInput || "owner/name or github.com URL"}</Text>
+            </Box>
+          )}
           <Box marginTop={1} flexDirection="column">
-            <Text color={focus === "skills" ? colors.iqCyan : colors.dim}>{focus === "skills" ? "▸ " : "  "}skills this repo used</Text>
+            <Text dimColor>  skills this repo used</Text>
             {owned.length === 0 ? (
-              <Text dimColor>  no owned skills yet</Text>
+              <Text dimColor>    no owned skills yet</Text>
             ) : (
               owned.map((s, i) => {
                 const on = !!selected[s.id];
-                const cursor = focus === "skills" && i === skillIdx;
+                if (row.kind === "skill" && row.skill === i) {
+                  return <FocusBand key={s.id} width={bandW} text={`    ${on ? "[x]" : "[ ]"} ${s.name}`} />;
+                }
                 return (
                   <Box key={s.id}>
-                    <Text color={cursor ? colors.iqCyan : colors.dim}>{cursor ? "  ▸ " : "    "}</Text>
-                    <Text color={on ? colors.ok : colors.dim}>{on ? "[x]" : "[ ]"} </Text>
+                    <Text color={on ? colors.ok : colors.dim}>{"    "}{on ? "[x]" : "[ ]"} </Text>
                     <Text color={on ? colors.bone : colors.dim}>{s.name}</Text>
                   </Box>
                 );
               })
             )}
           </Box>
-          {/* one gate slot: the reason register can't fire yet, or - only when it
-              actually can - the explicit go signal naming the key and the field. */}
-          {blockReason ? (
-            <Box marginTop={1}><Text color={colors.warn}>{blockReason}</Text></Box>
-          ) : (
-            <Box marginTop={1}>
-              <Text color={colors.ok}>ready · ↵ on repo registers {chosen} skill{chosen === 1 ? "" : "s"}</Text>
-            </Box>
-          )}
+          {/* The REGISTER action row, always visible and honest: the go text when it
+              can fire, otherwise the ONE gate reason, rendered here and only here. */}
+          <Box marginTop={1}>
+            {(() => {
+              const label = blockReason
+                ? ` ${blockReason}`
+                : ` register ${chosen} skill${chosen === 1 ? "" : "s"} to ${repoLabel}`;
+              if (row.kind === "register") return <FocusBand width={bandW} text={label} />;
+              return blockReason
+                ? <Text dimColor>{label}</Text>
+                : <Text bold color={colors.ok}>{label}</Text>;
+            })()}
+          </Box>
           {flash ? <Box marginTop={1}><Text color={colors.ok}>{glyph.sparkle} {flash}</Text></Box> : null}
           <Box marginTop={1}>
             <Text dimColor>
-              {focus === "token"
-                ? "↵/[x] remove token · [tab] field · esc back"
-                : focus === "repo"
-                  ? (blockReason ? "[tab] field · esc back" : "↵ register · [tab] field · esc back")
-                  : "↑/↓ move · ↵/[space] toggle · [tab] field · esc back"}
+              {row.kind === "token"
+                ? "up/down move · enter edit token · [x] remove · esc back"
+                : row.kind === "repo"
+                  ? "type the repo · up/down move · enter next · esc back"
+                  : row.kind === "skill"
+                    ? "up/down move · enter toggle · esc back"
+                    : blockReason
+                      ? "up/down move · esc back"
+                      : "enter register · esc back"}
             </Text>
           </Box>
         </Box>

--- a/surfaces/cli/src/views/market/GithubPanel.tsx
+++ b/surfaces/cli/src/views/market/GithubPanel.tsx
@@ -62,7 +62,9 @@ function FocusBand({ width, text, cursor }: { width: number; text: string; curso
 }
 
 function GithubBadge({ status }: { status: GithubStatusLite | null }) {
-  if (!status) return null;
+  // null = the token file has not been read yet: say loading on the status row it
+  // already owns, never the settled "no token" claim for a check still in flight.
+  if (!status) return <Text dimColor>loading…</Text>;
   if (status.hasToken) {
     return <Text color={colors.ok}>{glyph.ok} connected · {status.masked}</Text>;
   }
@@ -88,7 +90,7 @@ export function GithubPanel({
   tokenEditing: boolean;
   repoInput: string;
   repoLabel: string | null; // parsed owner/name once the repo input is valid
-  owned: OwnedSkill[];
+  owned: OwnedSkill[] | null; // null = the host is still fetching the wallet's skills
   selected: Record<string, boolean>;
   focusIdx: number;
   blockReason: string | null;
@@ -98,7 +100,8 @@ export function GithubPanel({
 }) {
   const hasToken = !!status?.hasToken;
   const chosen = Object.values(selected).filter(Boolean).length;
-  const row = githubRowAt(focusIdx, owned.length);
+  const ownedList = owned ?? [];
+  const row = githubRowAt(focusIdx, ownedList.length);
   const bandW = Math.max(10, width);
   return (
     <Box flexDirection="column" paddingX={1} borderStyle="round" borderColor={colors.iqViolet}>
@@ -108,7 +111,12 @@ export function GithubPanel({
         <GithubBadge status={status} />
       </Box>
 
-      {!hasToken || tokenEditing ? (
+      {!status ? (
+        // status pending: the badge above already says loading; rendering the token
+        // form here would claim "no token" and eat keystrokes for a check that has
+        // not settled. The body waits.
+        null
+      ) : !hasToken || tokenEditing ? (
         // Token entry: paste a Personal Access Token (first connect, or replacing a
         // stored token via enter on the token row).
         <Box flexDirection="column" marginTop={1}>
@@ -160,10 +168,15 @@ export function GithubPanel({
           )}
           <Box marginTop={1} flexDirection="column">
             <Text dimColor>  skills this repo used</Text>
-            {owned.length === 0 ? (
+            {/* three honest states on the one reserved row: null = the wallet's skills
+                are still being fetched, so say loading; "no owned skills yet" may only
+                follow a settled empty fetch. */}
+            {owned === null ? (
+              <Text dimColor>    loading…</Text>
+            ) : ownedList.length === 0 ? (
               <Text dimColor>    no owned skills yet</Text>
             ) : (
-              owned.map((s, i) => {
+              ownedList.map((s, i) => {
                 const on = !!selected[s.id];
                 if (row.kind === "skill" && row.skill === i) {
                   return <FocusBand key={s.id} width={bandW} text={`    ${on ? "[x]" : "[ ]"} ${s.name}`} />;

--- a/surfaces/cli/src/views/market/GithubPanel.tsx
+++ b/surfaces/cli/src/views/market/GithubPanel.tsx
@@ -57,6 +57,7 @@ export function GithubPanel({
   flash: string | null;
 }) {
   const hasToken = !!status?.hasToken;
+  const chosen = Object.values(selected).filter(Boolean).length;
   return (
     <Box flexDirection="column" paddingX={1} borderStyle="round" borderColor={colors.iqViolet}>
       <Text bold color={colors.iqMagenta}>❖ GitHub verified work</Text>
@@ -124,10 +125,24 @@ export function GithubPanel({
               })
             )}
           </Box>
-          {blockReason ? <Box marginTop={1}><Text color={colors.warn}>{blockReason}</Text></Box> : null}
+          {/* one gate slot: the reason register can't fire yet, or - only when it
+              actually can - the explicit go signal naming the key and the field. */}
+          {blockReason ? (
+            <Box marginTop={1}><Text color={colors.warn}>{blockReason}</Text></Box>
+          ) : (
+            <Box marginTop={1}>
+              <Text color={colors.ok}>ready · ↵ on repo registers {chosen} skill{chosen === 1 ? "" : "s"}</Text>
+            </Box>
+          )}
           {flash ? <Box marginTop={1}><Text color={colors.ok}>{glyph.sparkle} {flash}</Text></Box> : null}
           <Box marginTop={1}>
-            <Text dimColor>[tab] field · [space] toggle skill · ↵ register · [x] remove token · esc back</Text>
+            <Text dimColor>
+              {focus === "token"
+                ? "↵/[x] remove token · [tab] field · esc back"
+                : focus === "repo"
+                  ? (blockReason ? "[tab] field · esc back" : "↵ register · [tab] field · esc back")
+                  : "↑/↓ move · ↵/[space] toggle · [tab] field · esc back"}
+            </Text>
           </Box>
         </Box>
       )}

--- a/surfaces/cli/src/views/market/GithubPanel.tsx
+++ b/surfaces/cli/src/views/market/GithubPanel.tsx
@@ -47,17 +47,16 @@ export function githubRowAt(idx: number, skillCount: number): GithubRow {
   return { kind: "register" };
 }
 
-// The focused row, drawn exactly like a focused welcome panel band: fully inverted,
-// ink on bone, edge to edge. `cursor` appends a block cursor for the text-input row.
+// The focused row, drawn the way this panel always marked focus: a cyan caret ahead of
+// the row, text bold cyan, no fill. `cursor` appends a block cursor for the text-input
+// row. The caret replaces the row's two leading spaces so nothing shifts on focus.
 function FocusBand({ width, text, cursor }: { width: number; text: string; cursor?: boolean }) {
-  const room = Math.max(4, width - (cursor ? 1 : 0));
-  const fitted = truncateEnd(text, room);
-  const pad = Math.max(0, width - displayWidth(fitted) - (cursor ? 1 : 0));
+  const body = truncateEnd(text.replace(/^  /, ""), Math.max(4, width - 2 - (cursor ? 1 : 0)));
   return (
-    <Text backgroundColor={colors.bone} color={colors.ink} bold>
-      {fitted}
-      {cursor ? <Text backgroundColor={colors.ink} color={colors.bone}> </Text> : null}
-      {" ".repeat(pad)}
+    <Text bold color={colors.iqCyan}>
+      {"\u25b8 "}
+      {body}
+      {cursor ? <Text inverse> </Text> : null}
     </Text>
   );
 }

--- a/surfaces/cli/src/views/market/HeliusPanel.tsx
+++ b/surfaces/cli/src/views/market/HeliusPanel.tsx
@@ -13,12 +13,17 @@ export interface RpcStatusLite {
   network: "devnet" | "mainnet";
 }
 
+// The badge's copy as plain text: HeliusBadge renders exactly this string, and
+// SkillMarket measures displayWidth of it to decide whether the badge fits the header
+// row. One source of truth, so the measurement can never drift from the render.
+export function heliusBadgeText(status: RpcStatusLite | null): string {
+  if (!status) return "";
+  return status.hasKey ? `● ${status.network} · ${status.masked}` : "add a Helius key for faster results";
+}
+
 export function HeliusBadge({ status }: { status: RpcStatusLite | null }) {
   if (!status) return null;
-  if (status.hasKey) {
-    return <Text color={colors.ok}>● {status.network} · {status.masked}</Text>;
-  }
-  return <Text color={colors.warn}>add a Helius key for faster results</Text>;
+  return <Text color={status.hasKey ? colors.ok : colors.warn}>{heliusBadgeText(status)}</Text>;
 }
 
 export function HeliusPanel({

--- a/surfaces/cli/src/views/market/SkillDetailView.tsx
+++ b/surfaces/cli/src/views/market/SkillDetailView.tsx
@@ -8,6 +8,7 @@ import { colors, glyph } from "../../theme.js";
 import { displayWidth, truncateEnd, truncateStart, wrapBlock } from "../../format.js";
 import { ScrollView } from "./ScrollView.js";
 import { Band } from "../../components/Band.js";
+import { walletColor, walletFace } from "./avatar.js";
 
 export type DetailSub = "main" | "skillText" | "comments";
 
@@ -132,14 +133,37 @@ export function skillTextLines(detail: SkillDetail, cols: number): string[] {
   return wrapBlock(detail.skillText ?? "", w);
 }
 
-// Comments subview rows, one node per terminal row (date, wrapped quote rows, wrapped
-// git link rows), for the same reason as skillTextLines: slice math is only true when a
-// slice index equals a screen row, and a note used to be one multi-row node.
-export function commentLines(notes: Note[], cols: number): React.ReactNode[] {
+// Comments subview rows, one node per terminal row (author row, wrapped quote rows,
+// wrapped git link rows), for the same reason as skillTextLines: slice math is only true
+// when a slice index equals a screen row, and a note used to be one multi-row node.
+export function commentLines(notes: Note[], cols: number, selfWallet?: string): React.ReactNode[] {
   const w = Math.max(12, cols - 4);
+  // wallet-face identity sheds first at narrow widths, same rule as the directory rows
+  const showFace = w >= 24;
+  const shortA = (a: string) => (a.length > 9 ? `${a.slice(0, 4)}…${a.slice(-4)}` : a);
   const lines: React.ReactNode[] = [];
   for (const n of notes) {
-    lines.push(<Text key={`${n.id}-d`} dimColor>  {truncateEnd(noteDate(n.timestamp), Math.max(1, w - 2))}</Text>);
+    // each note now leads with WHO wrote it (design tab 22: identity is the thread's
+    // whole language; the comment stream here was anonymous): wallet face + short
+    // wallet, the viewer's own notes marked // YOU in green, the date as a dim tail.
+    // Still exactly ONE terminal row: the tail pieces shed (date first, then the YOU
+    // tag) and the author truncates before the row could ever wrap.
+    const room = Math.max(1, w - 2 - (showFace ? 4 : 0));
+    const authorShown = truncateEnd(shortA(n.author ?? "?"), room);
+    const you = selfWallet && n.author === selfWallet ? " // YOU" : "";
+    const dateTail = `  ${noteDate(n.timestamp)}`;
+    const youShown = displayWidth(authorShown) + displayWidth(you) <= room ? you : "";
+    const tailShown =
+      displayWidth(authorShown) + displayWidth(youShown) + displayWidth(dateTail) <= room ? dateTail : "";
+    lines.push(
+      <Text key={`${n.id}-d`}>
+        {"  "}
+        {showFace ? <Text color={walletColor(n.author ?? "?")}>{walletFace(n.author ?? "?")} </Text> : null}
+        <Text color={colors.iqCyan}>{authorShown}</Text>
+        {youShown ? <Text color={colors.ok}>{youShown}</Text> : null}
+        {tailShown ? <Text dimColor>{tailShown}</Text> : null}
+      </Text>,
+    );
     wrapBlock(`"${n.text}"`, Math.max(1, w - 2)).forEach((l, i) => lines.push(<Text key={`${n.id}-t${i}`}>  {l}</Text>));
     if (n.gitLink) {
       wrapBlock(`${glyph.sparkle} ${n.gitLink}`, Math.max(1, w - 4)).forEach((l, i) =>
@@ -168,6 +192,7 @@ export function SkillDetailView({
   firing,
   flash,
   busy,
+  walletAddr,
 }: {
   detail: SkillDetail;
   owned: Set<string>;
@@ -178,6 +203,8 @@ export function SkillDetailView({
   firing: boolean;
   flash: string | null;
   busy: boolean;
+  // the viewer's wallet: commentLines marks their own notes // YOU
+  walletAddr?: string;
 }) {
   const c = detail.card;
   const notes = detail.notes ?? [];
@@ -204,7 +231,7 @@ export function SkillDetailView({
   }
 
   if (sub === "comments") {
-    const lines = commentLines(notes, colsMain);
+    const lines = commentLines(notes, colsMain, walletAddr);
     const height = subViewportH(rowsMain, lines.length);
     return (
       <Box flexDirection="column" paddingX={1} borderStyle="round" borderColor={colors.iqViolet}>

--- a/surfaces/cli/src/views/market/SkillDetailView.tsx
+++ b/surfaces/cli/src/views/market/SkillDetailView.tsx
@@ -246,10 +246,14 @@ export function SkillDetailView({
   // the count leads the tail so a narrow cut takes [v] SKILL.md and esc back first;
   // those keys still work, the count is the piece with nowhere else to live.
   const hintTail = `[c] comment · [k] comments (${notes.length}) · [v] SKILL.md · esc back`;
+  // narrow fallback: the count is the piece this row exists to carry, so below the
+  // width where the long tail fits it shortens to [k] (N) instead of cutting it off.
+  const hintShort = `[c] comment · [k] (${notes.length}) · [v] SKILL.md · esc back`;
   const hintFull = `${hintLead}${scrolls ? "↑/↓ scroll · " : ""}${hintTail}`;
   const hint = displayWidth(hintFull) <= innerW ? hintFull
     : displayWidth(`${hintLead}${hintTail}`) <= innerW ? `${hintLead}${hintTail}`
-    : truncateEnd(`${hintLead}${hintTail}`, innerW);
+    : displayWidth(`${hintLead}${hintShort}`) <= innerW ? `${hintLead}${hintShort}`
+    : truncateEnd(`${hintLead}${hintShort}`, innerW);
   return (
     <Box flexDirection="column" paddingX={1} borderStyle="round" borderColor={colors.iqViolet}>
       <Box justifyContent="space-between">

--- a/surfaces/cli/src/views/market/SkillDetailView.tsx
+++ b/surfaces/cli/src/views/market/SkillDetailView.tsx
@@ -117,6 +117,42 @@ export function mainViewportH(rows: number, total: number): number {
   return Math.min(Math.max(4, rows - 15), total);
 }
 
+// SKILL.md subview rows: the raw file lines hard-wrapped to the content width, so one
+// array entry is exactly one terminal row. The subview used to slice 16 RAW file lines,
+// and a line that wraps 2-3x at narrow columns pushed the frame past the terminal (top
+// border scrolled off, stale rows survived esc at 40x38). Exported so SkillMarket's key
+// handler clamps the scroll against the same rows the view renders.
+export function skillTextLines(detail: SkillDetail, cols: number): string[] {
+  const w = Math.max(12, cols - 4);
+  return wrapBlock(detail.skillText ?? "", w);
+}
+
+// Comments subview rows, one node per terminal row (date, wrapped quote rows, wrapped
+// git link rows), for the same reason as skillTextLines: slice math is only true when a
+// slice index equals a screen row, and a note used to be one multi-row node.
+export function commentLines(notes: Note[], cols: number): React.ReactNode[] {
+  const w = Math.max(12, cols - 4);
+  const lines: React.ReactNode[] = [];
+  for (const n of notes) {
+    lines.push(<Text key={`${n.id}-d`} dimColor>  {truncateEnd(noteDate(n.timestamp), Math.max(1, w - 2))}</Text>);
+    wrapBlock(`"${n.text}"`, Math.max(1, w - 2)).forEach((l, i) => lines.push(<Text key={`${n.id}-t${i}`}>  {l}</Text>));
+    if (n.gitLink) {
+      wrapBlock(`${glyph.sparkle} ${n.gitLink}`, Math.max(1, w - 4)).forEach((l, i) =>
+        lines.push(<Text key={`${n.id}-g${i}`} dimColor>    {l}</Text>),
+      );
+    }
+  }
+  return lines;
+}
+
+// Subview viewport height: what remains of the terminal after the subview chrome (two
+// border rows, title, two gaps, scroll position row, hint row = 7) plus one row of
+// slack, for the same ink full-repaint reason as mainViewportH. Never taller than the
+// content. Shared by both subviews and the key clamp, replacing the constants 16 and 12.
+export function subViewportH(rows: number, total: number): number {
+  return Math.min(Math.max(4, rows - 9), total);
+}
+
 export function SkillDetailView({
   detail,
   owned,
@@ -144,34 +180,34 @@ export function SkillDetailView({
   const colsMain = stdoutMain?.columns || 80;
   const rowsMain = stdoutMain?.rows || 24;
 
+  // both subviews: wrapped rows sized to the terminal, title and hint bounded to one
+  // row each, so the frame never outgrows the terminal at narrow widths.
+  const subInnerW = Math.max(12, colsMain - 4);
+
   if (sub === "skillText") {
-    const bodyLines = (detail.skillText ?? "").split("\n");
+    const bodyLines = skillTextLines(detail, colsMain);
+    const height = subViewportH(rowsMain, bodyLines.length);
     return (
       <Box flexDirection="column" paddingX={1} borderStyle="round" borderColor={colors.iqViolet}>
-        <Text bold color={colors.iqMagenta}>❖ {c.name} · SKILL.md</Text>
+        <Text bold color={colors.iqMagenta}>{truncateEnd(`❖ ${c.name} · SKILL.md`, subInnerW)}</Text>
         <Box marginTop={1}>
-          <ScrollView lines={bodyLines} height={16} offset={scrollOffset} />
+          <ScrollView lines={bodyLines} height={height} offset={scrollOffset} />
         </Box>
-        <Box marginTop={1}><Text dimColor>↑/↓/PgUp/PgDn scroll · esc back</Text></Box>
+        <Box marginTop={1}><Text dimColor>{truncateEnd("↑/↓/PgUp/PgDn scroll · esc back", subInnerW)}</Text></Box>
       </Box>
     );
   }
 
   if (sub === "comments") {
-    const lines = notes.map((n: Note) => (
-      <Box key={n.id} flexDirection="column">
-        <Text dimColor>  {noteDate(n.timestamp)}</Text>
-        <Text>  "{n.text}"</Text>
-        {n.gitLink ? <Text dimColor>    {glyph.sparkle} {n.gitLink}</Text> : null}
-      </Box>
-    ));
+    const lines = commentLines(notes, colsMain);
+    const height = subViewportH(rowsMain, lines.length);
     return (
       <Box flexDirection="column" paddingX={1} borderStyle="round" borderColor={colors.iqViolet}>
-        <Text bold color={colors.iqMagenta}>❖ {c.name} · comments ({notes.length})</Text>
+        <Text bold color={colors.iqMagenta}>{truncateEnd(`❖ ${c.name} · comments (${notes.length})`, subInnerW)}</Text>
         <Box marginTop={1}>
-          {notes.length === 0 ? <Text dimColor>no comments yet</Text> : <ScrollView lines={lines} height={12} offset={scrollOffset} />}
+          {notes.length === 0 ? <Text dimColor>no comments yet</Text> : <ScrollView lines={lines} height={height} offset={scrollOffset} />}
         </Box>
-        <Box marginTop={1}><Text dimColor>↑/↓/PgUp/PgDn scroll · esc back</Text></Box>
+        <Box marginTop={1}><Text dimColor>{truncateEnd("↑/↓/PgUp/PgDn scroll · esc back", subInnerW)}</Text></Box>
       </Box>
     );
   }

--- a/surfaces/cli/src/views/market/SkillDetailView.tsx
+++ b/surfaces/cli/src/views/market/SkillDetailView.tsx
@@ -235,6 +235,17 @@ export function SkillDetailView({
   const statsRoom = Math.max(0, innerW - fireW - Math.min(displayWidth(c.name), 12));
   const statsShown = displayWidth(statsTail) <= statsRoom ? statsTail : statsRoom >= 4 ? truncateEnd(statsTail, statsRoom) : "";
   const nameShown = truncateEnd(c.name, Math.max(2, innerW - fireW - displayWidth(statsShown)));
+  // the FIXED hint row carries the live comment count: the body's counter line sits
+  // inside the scroll region, so on short terminals a fresh post's increment was
+  // invisible without scrolling down to it. Budgeted to one row: the scroll piece
+  // drops first (the viewport's own arrow row still shows scrollability), then the
+  // row cuts with an ellipsis as the last resort.
+  const hintLead = busy ? "working…" : isOwned ? (disposed ? "[e] re-equip · " : "[d] dispose · ") : "[b] buy · ";
+  const hintTail = `[c] comment · [v] SKILL.md · [k] comments (${notes.length}) · esc back`;
+  const hintFull = `${hintLead}${scrolls ? "↑/↓ scroll · " : ""}${hintTail}`;
+  const hint = displayWidth(hintFull) <= innerW ? hintFull
+    : displayWidth(`${hintLead}${hintTail}`) <= innerW ? `${hintLead}${hintTail}`
+    : truncateEnd(`${hintLead}${hintTail}`, innerW);
   return (
     <Box flexDirection="column" paddingX={1} borderStyle="round" borderColor={colors.iqViolet}>
       <Box justifyContent="space-between">
@@ -257,14 +268,7 @@ export function SkillDetailView({
         />
       </Box>
       <Box marginTop={1}>
-        <Text dimColor>
-          {busy ? "working…" : isOwned
-            ? disposed
-              ? "[e] re-equip · "
-              : "[d] dispose · "
-            : "[b] buy · "}
-          {scrolls ? "↑/↓ scroll · " : ""}[c] comment · [v] SKILL.md · [k] comments · esc back
-        </Text>
+        <Text dimColor>{hint}</Text>
       </Box>
     </Box>
   );

--- a/surfaces/cli/src/views/market/SkillDetailView.tsx
+++ b/surfaces/cli/src/views/market/SkillDetailView.tsx
@@ -114,7 +114,9 @@ export function mainLines(detail: SkillDetail, owned: Set<string>, cols: number)
 // exactly what left stale detail rows smeared behind short terminals. Never taller than
 // the content, so a short detail stays compact. Shared by the render and the key clamp.
 export function mainViewportH(rows: number, total: number): number {
-  return Math.min(Math.max(4, rows - 15), total);
+  // floor of 2: the chrome around the viewport is ~9 rows, so a floor of 4 pushed the
+  // frame to 13 rows and clipped the top border on a 12 row terminal.
+  return Math.min(Math.max(2, rows - 15), total);
 }
 
 // SKILL.md subview rows: the raw file lines hard-wrapped to the content width, so one
@@ -150,7 +152,7 @@ export function commentLines(notes: Note[], cols: number): React.ReactNode[] {
 // slack, for the same ink full-repaint reason as mainViewportH. Never taller than the
 // content. Shared by both subviews and the key clamp, replacing the constants 16 and 12.
 export function subViewportH(rows: number, total: number): number {
-  return Math.min(Math.max(4, rows - 9), total);
+  return Math.min(Math.max(2, rows - 9), total);
 }
 
 export function SkillDetailView({
@@ -241,7 +243,9 @@ export function SkillDetailView({
   // drops first (the viewport's own arrow row still shows scrollability), then the
   // row cuts with an ellipsis as the last resort.
   const hintLead = busy ? "working…" : isOwned ? (disposed ? "[e] re-equip · " : "[d] dispose · ") : "[b] buy · ";
-  const hintTail = `[c] comment · [v] SKILL.md · [k] comments (${notes.length}) · esc back`;
+  // the count leads the tail so a narrow cut takes [v] SKILL.md and esc back first;
+  // those keys still work, the count is the piece with nowhere else to live.
+  const hintTail = `[c] comment · [k] comments (${notes.length}) · [v] SKILL.md · esc back`;
   const hintFull = `${hintLead}${scrolls ? "↑/↓ scroll · " : ""}${hintTail}`;
   const hint = displayWidth(hintFull) <= innerW ? hintFull
     : displayWidth(`${hintLead}${hintTail}`) <= innerW ? `${hintLead}${hintTail}`
@@ -267,7 +271,10 @@ export function SkillDetailView({
           inverted
         />
       </Box>
-      <Box marginTop={1}>
+      {/* on a 12 row terminal every band above keeps its one row only because this
+          gap goes: the hint hugs the buy band instead of pushing the frame to the
+          exact terminal height, where the top border scrolls off. */}
+      <Box marginTop={rowsMain <= 12 ? 0 : 1}>
         <Text dimColor>{hint}</Text>
       </Box>
     </Box>

--- a/surfaces/cli/src/views/market/SkillDetailView.tsx
+++ b/surfaces/cli/src/views/market/SkillDetailView.tsx
@@ -9,6 +9,7 @@ import { displayWidth, truncateEnd, truncateStart, wrapBlock } from "../../forma
 import { ScrollView } from "./ScrollView.js";
 import { Band } from "../../components/Band.js";
 import { walletColor, walletFace } from "./avatar.js";
+import { mintArt } from "./cardart.js";
 
 export type DetailSub = "main" | "skillText" | "comments";
 
@@ -42,7 +43,30 @@ export function mainLines(detail: SkillDetail, owned: Set<string>, cols: number)
   // layout had from its marginTop gaps.
   const gap = (k: string) => { if (lines.length) lines.push(<Text key={k}> </Text>); };
 
+  // design 08/24: the card leads with its art ("THE CARD IS THE PRODUCT"). This is
+  // the deterministic offline layer design 10 names for terminals without an image
+  // protocol: 3 cell rows of mint-hash half-block pixels in the mint's own hue, the
+  // same art for the same mint on every open. Each art row is exactly one line node
+  // so the viewport slice math holds; runs of identical colors collapse into one
+  // span per stretch to keep the frame lean.
+  for (const [ri, row] of mintArt(c.id, Math.min(24, w), 3).entries()) {
+    const spans: React.ReactNode[] = [];
+    let start = 0;
+    for (let x = 1; x <= row.length; x++) {
+      if (x === row.length || row[x].fg !== row[start].fg || row[x].bg !== row[start].bg) {
+        spans.push(
+          <Text key={start} color={row[start].fg} backgroundColor={row[start].bg}>
+            {"▀".repeat(x - start)}
+          </Text>,
+        );
+        start = x;
+      }
+    }
+    lines.push(<Box key={`art-${ri}`}>{spans}</Box>);
+  }
+
   if (c.description) {
+    gap("g-desc");
     wrapBlock(c.description, w).forEach((l, i) => lines.push(<Text key={`d-${i}`}>{l}</Text>));
   }
 

--- a/surfaces/cli/src/views/market/SkillDetailView.tsx
+++ b/surfaces/cli/src/views/market/SkillDetailView.tsx
@@ -5,7 +5,7 @@ import React from "react";
 import { Box, Text, useStdout } from "ink";
 import type { SkillDetail, Note } from "@iqlabs-official/agent-sdk";
 import { colors, glyph } from "../../theme.js";
-import { displayWidth, truncateEnd, wrapBlock } from "../../format.js";
+import { displayWidth, truncateEnd, truncateStart, wrapBlock } from "../../format.js";
 import { ScrollView } from "./ScrollView.js";
 import { Band } from "../../components/Band.js";
 
@@ -219,16 +219,32 @@ export function SkillDetailView({
   const lines = mainLines(detail, owned, colsMain);
   const height = mainViewportH(rowsMain, lines.length);
   const scrolls = lines.length > height;
+  // the two chrome rows above the viewport, budgeted to ONE terminal row each:
+  // unbudgeted, the header (kind + mint + soulbound) wrapped into two fused rows at 30
+  // cols and a long name clipped with no ellipsis. The mint keeps its END visible
+  // (truncateStart): the tail is what identifies it. When everything fits, the shown
+  // strings are the originals, so wide terminals render byte identical.
+  const innerW = Math.max(12, colsMain - 4);
+  const bond = c.type === "workflow" ? " · soulbound token-2022" : " · soulbound";
+  const mintRoom = Math.max(4, innerW - displayWidth(kindWord) - 2);
+  const mintShown = truncateStart(shortMint(c.id), mintRoom);
+  const bondRoom = mintRoom - displayWidth(mintShown);
+  const bondShown = displayWidth(bond) <= bondRoom ? bond : bondRoom >= 4 ? truncateEnd(bond, bondRoom) : "";
+  const fireW = firing ? 2 : 0;
+  const statsTail = `  ×${c.supply ?? 0}${c.stars ? ` · ★${c.stars}` : ""}${isOwned ? (disposed ? " · disposed" : " · owned") : ""}`;
+  const statsRoom = Math.max(0, innerW - fireW - Math.min(displayWidth(c.name), 12));
+  const statsShown = displayWidth(statsTail) <= statsRoom ? statsTail : statsRoom >= 4 ? truncateEnd(statsTail, statsRoom) : "";
+  const nameShown = truncateEnd(c.name, Math.max(2, innerW - fireW - displayWidth(statsShown)));
   return (
     <Box flexDirection="column" paddingX={1} borderStyle="round" borderColor={colors.iqViolet}>
       <Box justifyContent="space-between">
         <Text bold color={colors.bone}>{kindWord}</Text>
-        <Text dimColor>{shortMint(c.id)}{c.type === "workflow" ? " · soulbound token-2022" : " · soulbound"}</Text>
+        <Text dimColor>{mintShown}{bondShown}</Text>
       </Box>
       <Box marginTop={1}>
-        <Text bold color={colors.iqCyan}>{c.name}</Text>
+        <Text bold color={colors.iqCyan}>{nameShown}</Text>
         {firing ? <Text color={colors.iqMagenta}> ✦</Text> : null}
-        <Text dimColor>  ×{c.supply ?? 0}{c.stars ? ` · ★${c.stars}` : ""}{isOwned ? (disposed ? " · disposed" : " · owned") : ""}</Text>
+        <Text dimColor>{statsShown}</Text>
       </Box>
       <ScrollView lines={lines} height={height} offset={scrollOffset} />
 

--- a/surfaces/cli/src/views/market/SkillDetailView.tsx
+++ b/surfaces/cli/src/views/market/SkillDetailView.tsx
@@ -2,9 +2,10 @@
 // required-skills checkmarks + prices + "Collect all", full (scrollable) SKILL.md,
 // full comment stack, dispose/re-equip, firing pulse on owned/deployed.
 import React from "react";
-import { Box, Text } from "ink";
+import { Box, Text, useStdout } from "ink";
 import type { SkillDetail, Note } from "@iqlabs-official/agent-sdk";
 import { colors, glyph } from "../../theme.js";
+import { displayWidth, truncateEnd, wrapBlock } from "../../format.js";
 import { ScrollView } from "./ScrollView.js";
 import { Band } from "../../components/Band.js";
 
@@ -21,6 +22,99 @@ function priceLabel(price?: string | null): string {
 }
 function shortMint(m?: string): string {
   return m && m.length > 12 ? `${m.slice(0, 6)}…${m.slice(-4)}` : m ?? "";
+}
+
+// Every row of the main body, each pre-bounded to exactly ONE terminal row: the viewport
+// below slices this array by index, so a row that wrapped would break the scroll math
+// (and, before this, the hashtag chips and long names wrapped into fragments at narrow
+// widths). Exported so SkillMarket's input handler clamps the scroll against the same
+// list it renders. `cols` is the raw terminal width; the frame's border+padding come off
+// here so both callers agree.
+export function mainLines(detail: SkillDetail, owned: Set<string>, cols: number): React.ReactNode[] {
+  const w = Math.max(12, cols - 4);
+  const c = detail.card;
+  const requiredCards = detail.requiredCards ?? [];
+  const unownedRequired = requiredCards.filter((r) => !owned.has(r.name));
+  const totalSol = unownedRequired.reduce((sum, r) => sum + (r.price ? Number(r.price) / 1e9 : 0), 0);
+  const lines: React.ReactNode[] = [];
+  // one blank row before each block after the first, the same rhythm the unscrolled
+  // layout had from its marginTop gaps.
+  const gap = (k: string) => { if (lines.length) lines.push(<Text key={k}> </Text>); };
+
+  if (c.description) {
+    wrapBlock(c.description, w).forEach((l, i) => lines.push(<Text key={`d-${i}`}>{l}</Text>));
+  }
+
+  if (c.category || (c.hashtags && c.hashtags.length)) {
+    gap("g-chips");
+    const cat = c.category ? truncateEnd(c.category, w) : "";
+    const tagRoom = w - displayWidth(cat) - (cat ? 1 : 0);
+    const tags = tagRoom >= 2 ? truncateEnd((c.hashtags ?? []).map((h) => `#${h}`).join(" "), tagRoom) : "";
+    lines.push(
+      <Box key="chips">
+        {cat ? <Text color={colors.iqViolet}>{cat}{tags ? " " : ""}</Text> : null}
+        {tags ? <Text dimColor>{tags}</Text> : null}
+      </Box>,
+    );
+  }
+
+  if (requiredCards.length) {
+    gap("g-req");
+    lines.push(<Text key="req" dimColor>requires:</Text>);
+    for (const r of requiredCards) {
+      const reqOwned = owned.has(r.name);
+      const tail = reqOwned ? "owned" : r.price ? `${(Number(r.price) / 1e9).toFixed(3)} SOL` : "free";
+      lines.push(
+        <Box key={`r-${r.id}`}>
+          <Text color={reqOwned ? colors.ok : colors.warn}>{reqOwned ? glyph.ok : "○"} </Text>
+          <Text>{truncateEnd(r.name, Math.max(2, w - 2 - displayWidth(tail) - 2))}</Text>
+          <Text dimColor>  {tail}</Text>
+        </Box>,
+      );
+    }
+    if (unownedRequired.length > 0) {
+      lines.push(
+        <Text key="collect" color={colors.iqCyan}>
+          {truncateEnd(`[x] collect all ${unownedRequired.length}${totalSol ? ` · ${totalSol.toFixed(3)} SOL` : ""}`, w)}
+        </Text>,
+      );
+    }
+  }
+
+  if (detail.repos && detail.repos.length) {
+    gap("g-repos");
+    lines.push(<Box key="repos"><Band label="used by" note="VERIFIED REPOS · WHERE STARS COME FROM" /></Box>);
+    for (const r of detail.repos) {
+      const stars = `★${r.stars}`;
+      lines.push(
+        <Box key={`repo-${r.url}`}>
+          <Text color={colors.iqCyan}>  {truncateEnd(`${r.owner}/${r.name}`, Math.max(2, w - 4 - displayWidth(stars) - 2))}</Text>
+          <Text color={colors.warn}>  {stars}</Text>
+        </Box>,
+      );
+    }
+  }
+
+  if (detail.skillText) {
+    gap("g-md");
+    lines.push(<Text key="md" dimColor>{truncateEnd(`── SKILL.md (${detail.skillText.split("\n").length} lines) ──`, w)}</Text>);
+    const preview = detail.skillText.slice(0, 300) + (detail.skillText.length > 300 ? "…" : "");
+    wrapBlock(preview, w).forEach((l, i) => lines.push(<Text key={`md-${i}`}>{l}</Text>));
+    lines.push(<Text key="md-open" color={colors.iqCyan}>[v] view full</Text>);
+  }
+
+  gap("g-k");
+  lines.push(<Text key="k" dimColor>[k] comments ({(detail.notes ?? []).length})</Text>);
+  return lines;
+}
+
+// The main body's viewport height: what remains of the terminal after the fixed chrome
+// (borders, header, name row, gaps, flash, buy band, hints, scroll position row) plus one
+// row of slack - ink switches to its full-repaint path at outputHeight >= rows, which is
+// exactly what left stale detail rows smeared behind short terminals. Never taller than
+// the content, so a short detail stays compact. Shared by the render and the key clamp.
+export function mainViewportH(rows: number, total: number): number {
+  return Math.min(Math.max(4, rows - 15), total);
 }
 
 export function SkillDetailView({
@@ -46,9 +140,9 @@ export function SkillDetailView({
 }) {
   const c = detail.card;
   const notes = detail.notes ?? [];
-  const requiredCards = detail.requiredCards ?? [];
-  const unownedRequired = requiredCards.filter((r) => !owned.has(r.name));
-  const totalSol = unownedRequired.reduce((sum, r) => sum + (r.price ? Number(r.price) / 1e9 : 0), 0);
+  const stdoutMain = useStdout().stdout; // || not ??: detached pty reports 0 rows/cols
+  const colsMain = stdoutMain?.columns || 80;
+  const rowsMain = stdoutMain?.rows || 24;
 
   if (sub === "skillText") {
     const bodyLines = (detail.skillText ?? "").split("\n");
@@ -82,8 +176,13 @@ export function SkillDetailView({
     );
   }
 
-  // main
+  // main - fixed chrome (header, name, band, hints) around a line viewport, the same
+  // shape the skillText/comments subviews use, so a fat detail scrolls on a short
+  // terminal instead of emitting a 44+ row frame ink cannot erase.
   const kindWord = (c.type ?? "skill").toUpperCase();
+  const lines = mainLines(detail, owned, colsMain);
+  const height = mainViewportH(rowsMain, lines.length);
+  const scrolls = lines.length > height;
   return (
     <Box flexDirection="column" paddingX={1} borderStyle="round" borderColor={colors.iqViolet}>
       <Box justifyContent="space-between">
@@ -95,59 +194,7 @@ export function SkillDetailView({
         {firing ? <Text color={colors.iqMagenta}> ✦</Text> : null}
         <Text dimColor>  ×{c.supply ?? 0}{c.stars ? ` · ★${c.stars}` : ""}{isOwned ? (disposed ? " · disposed" : " · owned") : ""}</Text>
       </Box>
-      {c.description ? <Text>{c.description}</Text> : null}
-      {c.category || (c.hashtags && c.hashtags.length) ? (
-        <Box marginTop={1}>
-          {c.category ? <Text color={colors.iqViolet}>{c.category} </Text> : null}
-          {(c.hashtags ?? []).map((h) => (
-            <Text key={h} dimColor>#{h} </Text>
-          ))}
-        </Box>
-      ) : null}
-
-      {requiredCards.length ? (
-        <Box flexDirection="column" marginTop={1}>
-          <Text dimColor>requires:</Text>
-          {requiredCards.map((r) => {
-            const reqOwned = owned.has(r.name);
-            const priceSol = r.price ? (Number(r.price) / 1e9).toFixed(3) : null;
-            return (
-              <Box key={r.id}>
-                <Text color={reqOwned ? colors.ok : colors.warn}>{reqOwned ? glyph.ok : "○"} </Text>
-                <Text>{r.name}</Text>
-                <Text dimColor>  {reqOwned ? "owned" : priceSol ? `${priceSol} SOL` : "free"}</Text>
-              </Box>
-            );
-          })}
-          {unownedRequired.length > 0 ? (
-            <Text color={colors.iqCyan}>[x] collect all {unownedRequired.length}{totalSol ? ` · ${totalSol.toFixed(3)} SOL` : ""}</Text>
-          ) : null}
-        </Box>
-      ) : null}
-
-      {detail.repos && detail.repos.length ? (
-        <Box flexDirection="column" marginTop={1}>
-          <Band label="used by" note="VERIFIED REPOS · WHERE STARS COME FROM" />
-          {detail.repos.map((r) => (
-            <Box key={r.url}>
-              <Text color={colors.iqCyan}>  {r.owner}/{r.name}</Text>
-              <Text color={colors.warn}>  ★{r.stars}</Text>
-            </Box>
-          ))}
-        </Box>
-      ) : null}
-
-      {detail.skillText ? (
-        <Box flexDirection="column" marginTop={1}>
-          <Text dimColor>── SKILL.md ({detail.skillText.split("\n").length} lines) ──</Text>
-          <Text>{detail.skillText.slice(0, 300)}{detail.skillText.length > 300 ? "…" : ""}</Text>
-          <Text color={colors.iqCyan}>[v] view full</Text>
-        </Box>
-      ) : null}
-
-      <Box marginTop={1}>
-        <Text dimColor>[k] comments ({notes.length})</Text>
-      </Box>
+      <ScrollView lines={lines} height={height} offset={scrollOffset} />
 
       {flash ? <Box marginTop={1}><Text color={colors.ok}>{glyph.sparkle} {flash}</Text></Box> : null}
       <Box marginTop={1}>
@@ -164,7 +211,7 @@ export function SkillDetailView({
               ? "[e] re-equip · "
               : "[d] dispose · "
             : "[b] buy · "}
-          [c] comment · [v] SKILL.md · [k] comments · esc back
+          {scrolls ? "↑/↓ scroll · " : ""}[c] comment · [v] SKILL.md · [k] comments · esc back
         </Text>
       </Box>
     </Box>

--- a/surfaces/cli/src/views/market/SkillDetailView.tsx
+++ b/surfaces/cli/src/views/market/SkillDetailView.tsx
@@ -266,7 +266,17 @@ export function SkillDetailView({
       <Box marginTop={1}>
         <Text bold color={colors.iqCyan}>{nameShown}</Text>
         {firing ? <Text color={colors.iqMagenta}> ✦</Text> : null}
-        <Text dimColor>{statsShown}</Text>
+        {/* green asserts ownership everywhere it appears (list chip OWNED, profile
+            skill rows); this " · owned" tail was the one dim outlier. The word turns
+            green only when the width budget kept it whole; a cut tail stays dim. */}
+        {isOwned && !disposed && statsShown.endsWith(" · owned") ? (
+          <>
+            <Text dimColor>{statsShown.slice(0, -"owned".length)}</Text>
+            <Text color={colors.ok}>owned</Text>
+          </>
+        ) : (
+          <Text dimColor>{statsShown}</Text>
+        )}
       </Box>
       <ScrollView lines={lines} height={height} offset={scrollOffset} />
 

--- a/surfaces/cli/src/views/market/SkillDetailView.tsx
+++ b/surfaces/cli/src/views/market/SkillDetailView.tsx
@@ -87,9 +87,12 @@ export function mainLines(detail: SkillDetail, owned: Set<string>, cols: number)
     for (const r of detail.repos) {
       const stars = `★${r.stars}`;
       lines.push(
+        // repo ★ counts are dim metadata, matching the profile's verified-repo rows:
+        // the same datum rendered amber here and dim there taught two codes for one
+        // thing (and amber is reserved for caution on this surface).
         <Box key={`repo-${r.url}`}>
           <Text color={colors.iqCyan}>  {truncateEnd(`${r.owner}/${r.name}`, Math.max(2, w - 4 - displayWidth(stars) - 2))}</Text>
-          <Text color={colors.warn}>  {stars}</Text>
+          <Text dimColor>  {stars}</Text>
         </Box>,
       );
     }

--- a/surfaces/cli/src/views/market/avatar.ts
+++ b/surfaces/cli/src/views/market/avatar.ts
@@ -4,7 +4,8 @@
 // wallet: no storage, no network, and deterministic forever. One wallet, one face.
 
 // FNV-1a 32-bit: tiny, dependency-free, well distributed for short strings.
-function fnv1a(s: string): number {
+// Exported: cardart.ts seeds the mint art from the same hash primitive.
+export function fnv1a(s: string): number {
   let h = 0x811c9dc5;
   for (let i = 0; i < s.length; i++) {
     h ^= s.charCodeAt(i);
@@ -15,7 +16,8 @@ function fnv1a(s: string): number {
 
 // hsl -> hex with saturation/lightness pinned where EVERY hue stays readable on the
 // near-black ground: dark hues would vanish into the ink, neon would fight the bone.
-function hslHex(h: number, s: number, l: number): string {
+// Exported: cardart.ts builds its duotone ramp from the same converter.
+export function hslHex(h: number, s: number, l: number): string {
   const sN = s / 100;
   const lN = l / 100;
   const a = sN * Math.min(lN, 1 - lN);

--- a/surfaces/cli/src/views/market/avatar.ts
+++ b/surfaces/cli/src/views/market/avatar.ts
@@ -1,0 +1,47 @@
+// Wallet-derived identity, design tab 20's //AVATAR_ band: "SAME WALLET, SAME FACE,
+// EVERYWHERE." A pure hash of the wallet address picks a hue and a tiny mirrored ░▒▓█
+// cell strip, so an agent is recognizable at a glance on every screen that shows a
+// wallet: no storage, no network, and deterministic forever. One wallet, one face.
+
+// FNV-1a 32-bit: tiny, dependency-free, well distributed for short strings.
+function fnv1a(s: string): number {
+  let h = 0x811c9dc5;
+  for (let i = 0; i < s.length; i++) {
+    h ^= s.charCodeAt(i);
+    h = Math.imul(h, 0x01000193);
+  }
+  return h >>> 0;
+}
+
+// hsl -> hex with saturation/lightness pinned where EVERY hue stays readable on the
+// near-black ground: dark hues would vanish into the ink, neon would fight the bone.
+function hslHex(h: number, s: number, l: number): string {
+  const sN = s / 100;
+  const lN = l / 100;
+  const a = sN * Math.min(lN, 1 - lN);
+  const f = (n: number) => {
+    const k = (n + h / 30) % 12;
+    const c = lN - a * Math.max(-1, Math.min(k - 3, 9 - k, 1));
+    return Math.round(255 * c)
+      .toString(16)
+      .padStart(2, "0");
+  };
+  return `#${f(0)}${f(8)}${f(4)}`;
+}
+
+// The wallet's hue, spread across the whole wheel so neighboring agents differ.
+export function walletColor(wallet: string): string {
+  return hslHex(fnv1a(wallet) % 360, 62, 62);
+}
+
+const CELLS = ["░", "▒", "▓", "█"] as const;
+
+// 3-cell mirrored strip (a b a): the symmetry is what makes it read as a face rather
+// than noise. 16 patterns x the hue wheel keeps collisions rare at a glance; the hash
+// is salted so the pattern and the hue vary independently.
+export function walletFace(wallet: string): string {
+  const h = fnv1a(wallet + "/face");
+  const a = CELLS[h & 3];
+  const b = CELLS[(h >> 2) & 3];
+  return `${a}${b}${a}`;
+}

--- a/surfaces/cli/src/views/market/cardart.ts
+++ b/surfaces/cli/src/views/market/cardart.ts
@@ -1,0 +1,55 @@
+// Mint-derived card art, design 08/24's "THE CARD IS THE PRODUCT": every card leads
+// with drawn pixels. In a terminal the CLI ships the deterministic layer design 10
+// names for no-image-protocol environments: the mint hash seeds a small SYMMETRIC
+// pixel field rendered as ▀ half-blocks (one cell = two vertical pixels via fg/bg),
+// in a duotone ramp of the mint's own hue so the art sits inside the palette instead
+// of fighting it. Same mint, same art, every open, offline.
+import { fnv1a, hslHex } from "./avatar.js";
+
+// mulberry32: tiny deterministic PRNG so the field is reproducible from the seed.
+function mulberry32(seed: number): () => number {
+  let a = seed >>> 0;
+  return () => {
+    a = (a + 0x6d2b79f5) >>> 0;
+    let t = a;
+    t = Math.imul(t ^ (t >>> 15), t | 1);
+    t ^= t + Math.imul(t ^ (t >>> 7), t | 61);
+    return ((t ^ (t >>> 14)) >>> 0) / 4294967296;
+  };
+}
+
+export interface ArtCell {
+  fg: string; // upper pixel of the ▀ cell
+  bg: string; // lower pixel
+}
+
+// `cols` x `rows` CELLS (so cols x rows*2 pixels). The field is mirrored around its
+// vertical axis, the same symmetry call as the wallet face: mirroring is what makes
+// hash noise read as a deliberate emblem. Mostly-ink ground with sparse bright hits
+// keeps it a quiet banner, not a rainbow block.
+export function mintArt(mint: string, cols: number, rows: number): ArtCell[][] {
+  const h = fnv1a(mint + "/art");
+  const hue = h % 360;
+  const ink = "#0a0a0b";
+  const ramp = [ink, hslHex(hue, 45, 20), hslHex(hue, 55, 40), hslHex(hue, 62, 62)];
+  const rand = mulberry32(h);
+  const pick = () => {
+    const r = rand();
+    return r < 0.4 ? 0 : r < 0.65 ? 1 : r < 0.87 ? 2 : 3;
+  };
+  const pxRows = rows * 2;
+  const half = Math.ceil(cols / 2);
+  const px: number[][] = [];
+  for (let y = 0; y < pxRows; y++) {
+    const left = Array.from({ length: half }, pick);
+    const row = left.concat(left.slice(0, cols - half).reverse());
+    px.push(row);
+  }
+  const cells: ArtCell[][] = [];
+  for (let r = 0; r < rows; r++) {
+    cells.push(
+      Array.from({ length: cols }, (_, x) => ({ fg: ramp[px[r * 2][x]], bg: ramp[px[r * 2 + 1][x]] })),
+    );
+  }
+  return cells;
+}

--- a/surfaces/cli/src/views/market/tiers.tsx
+++ b/surfaces/cli/src/views/market/tiers.tsx
@@ -51,11 +51,15 @@ export function tierGauge(stars: number, segments = 15): string {
 // (they shipped amber-vs-bone). Lit segments signal green, the rest and the count dim.
 export function TierGauge({ stars, segments = 15 }: { stars: number; segments?: number }) {
   const p = tierGaugeParts(stars, segments);
+  // The gauge owns its ONE terminal label: at MAX the word wears the same green as
+  // the lit segments (an achieved state, like owned and earned), while a progress
+  // count ("74/250") stays dim metadata. Render sites must never append their own
+  // MAX beside this component; the profile hero once did and printed "MAX  MAX".
   return (
     <Text>
       <Text color={colors.ok}>{p.lit}</Text>
       <Text dimColor>{p.unlit}</Text>
-      <Text dimColor>{p.label}</Text>
+      {p.label === " MAX" ? <Text color={colors.ok}>{p.label}</Text> : <Text dimColor>{p.label}</Text>}
     </Text>
   );
 }

--- a/surfaces/cli/src/views/market/tiers.tsx
+++ b/surfaces/cli/src/views/market/tiers.tsx
@@ -2,6 +2,9 @@
 // Reputation.stars (summed verified-work GitHub stars) maps to a tier badge + a
 // progress gauge toward the next tier. Kept as pure functions so both the agent
 // directory row and the profile ladder can share one source of truth.
+import React from "react";
+import { Text } from "ink";
+import { colors } from "../../theme.js";
 
 export interface Tier {
   name: string;
@@ -25,14 +28,36 @@ export function tierInfo(stars: number): { cur: Tier | null; next: Tier | null }
   return { cur, next };
 }
 
-// 15-segment gauge string toward the next tier ("MAX" once past Legendary).
-export function tierGauge(stars: number, segments = 15): string {
+// 15-segment gauge toward the next tier ("MAX" once past Legendary), split into its
+// lit/unlit halves so render sites can two-tone it (design tab 21 paints the filled
+// segments signal green and the remainder dim; the gauge is progress, not a flat rune).
+export function tierGaugeParts(stars: number, segments = 15): { lit: string; unlit: string; label: string } {
   const { cur, next } = tierInfo(stars);
-  if (!next) return "█".repeat(segments) + " MAX";
+  if (!next) return { lit: "█".repeat(segments), unlit: "", label: " MAX" };
   const prevMin = cur?.min ?? 0;
   const pct = Math.max(0, Math.min(1, (stars - prevMin) / (next.min - prevMin)));
   const lit = Math.round(pct * segments);
-  return "█".repeat(lit) + "░".repeat(segments - lit) + ` ${stars}/${next.min}`;
+  return { lit: "█".repeat(lit), unlit: "░".repeat(segments - lit), label: ` ${stars}/${next.min}` };
+}
+
+// The joined plain string; the self-check and any text-measuring caller use this.
+export function tierGauge(stars: number, segments = 15): string {
+  const p = tierGaugeParts(stars, segments);
+  return p.lit + p.unlit + p.label;
+}
+
+// The gauge as ink text: ONE component shared by the directory's selected row and the
+// profile hero, so the two reputation screens can never disagree about the gauge again
+// (they shipped amber-vs-bone). Lit segments signal green, the rest and the count dim.
+export function TierGauge({ stars, segments = 15 }: { stars: number; segments?: number }) {
+  const p = tierGaugeParts(stars, segments);
+  return (
+    <Text>
+      <Text color={colors.ok}>{p.lit}</Text>
+      <Text dimColor>{p.unlit}</Text>
+      <Text dimColor>{p.label}</Text>
+    </Text>
+  );
 }
 
 // Per-repo star gauge (verified-repo rows) — separate breakpoints from the agent tier.

--- a/surfaces/cli/tsup.config.ts
+++ b/surfaces/cli/tsup.config.ts
@@ -30,7 +30,18 @@ export default defineConfig({
   // import.meta.url. Approximate (one shared value for the whole bundle, not per-original-
   // file), but this call site only uses it to fail its native-binding lookup gracefully
   // (already-tolerated: see the "bigint: Failed to load bindings" warning on every launch).
+  // Last line: node's punycode DeprecationWarning (whatwg-url inside the inlined core,
+  // reached from node-fetch) fires while the dependency chunks evaluate, BEFORE any src
+  // code runs: ESM hoisting executes cli.js's chunk imports ahead of its body, so even
+  // the first statement of index.tsx is too late and the 122-col warning hits the raw
+  // terminal, wrapping to several rows on narrow windows. This banner is the one piece
+  // of code that runs earlier (it is prepended to every output file, and the first file
+  // to evaluate runs it before any bundled module code), so it swaps node's default
+  // stderr printer for a handler that appends every process warning to
+  // ~/.agentnet/cli-debug.log, the same file quietDiagnosticsToFile in index.tsx uses,
+  // so nothing is silently lost. Warnings only: errors are untouched. AGENTNET_DEBUG
+  // keeps the default terminal printing, same escape hatch as the console redirect.
   banner: {
-    js: "#!/usr/bin/env node\nimport { createRequire as __ar_cr } from 'module';\nimport { fileURLToPath as __ar_ftp } from 'url';\nimport { dirname as __ar_dn } from 'path';\nconst require = __ar_cr(import.meta.url);\nconst exports = {};\nconst __filename = __ar_ftp(import.meta.url);\nconst __dirname = __ar_dn(__filename);\nif (!process.env.AGENTNET_DEBUG) { const __ar_w = console.warn.bind(console); console.warn = (...a) => { if (typeof a[0] === 'string' && a[0].startsWith('bigint: Failed to load bindings')) return; __ar_w(...a); }; }",
+    js: "#!/usr/bin/env node\nimport { createRequire as __ar_cr } from 'module';\nimport { fileURLToPath as __ar_ftp } from 'url';\nimport { dirname as __ar_dn } from 'path';\nconst require = __ar_cr(import.meta.url);\nconst exports = {};\nconst __filename = __ar_ftp(import.meta.url);\nconst __dirname = __ar_dn(__filename);\nif (!process.env.AGENTNET_DEBUG) { const __ar_w = console.warn.bind(console); console.warn = (...a) => { if (typeof a[0] === 'string' && a[0].startsWith('bigint: Failed to load bindings')) return; __ar_w(...a); }; }\nif (!process.env.AGENTNET_DEBUG && !globalThis.__agentnetWarningsToLog) { globalThis.__agentnetWarningsToLog = true; process.removeAllListeners('warning'); process.on('warning', (w) => { try { const fs = require('fs'); const path = require('path'); const dir = path.join(require('os').homedir(), '.agentnet'); fs.mkdirSync(dir, { recursive: true }); fs.appendFileSync(path.join(dir, 'cli-debug.log'), '[' + new Date().toISOString() + '] warning: ' + (w.code ? '[' + w.code + '] ' : '') + w.name + ': ' + w.message + '\\n'); } catch {} }); }",
   },
 });


### PR DESCRIPTION
The full fix ladder from the #167 QA lane: 48 one-fix commits, each with its mechanism and evidence in its own message, ordered so every prefix builds and typechecks (verified commit by commit, so partial merges are safe). Rebased onto 0.1.3, composing with the merged #181 ruler and #182 resize repaint.

## The flow

```mermaid
flowchart TD
  A[boot hygiene: warnings to the log, 1] --> B[help and footer honesty: windowed /help, real ? key, honest hints, 2-7]
  B --> C[transcript truth: denied tools render DENIED, 8]
  C --> D[resume fidelity: a session keeps its model and effort, 9-10]
  D --> E[market: crash root cause, focus, empty states, footer budget, detail scroll, 11-24]
  E --> F[list fits: session list to 30 cols, market to 11 rows, 25-26]
  F --> G[approval frame: the 30x24 repaint storm dead in every path, 27-32]
  G --> H[github panel: one focus list, enter acts, caret focus, 33]
  H --> I[navigation, loading truth, input history, 34-39]
  I --> J[visual identity: tier colors, amber semantics, wallet faces, mint card art, 40-48]
```

## What it fixes, highlights

- The market show owned crash: root caused to ink 5.2.1 leaving a dangling static node after a `<Static>` unmount (use after free in yoga); the transcript Static stays mounted under the market overlay. Repro clean at 80/100/110/157 where main crashes at 100+.
- The 30x24 approval repaint storm (issue 167 round 2): the whole approval frame is budgeted, including the typed deny reason and multi file diff tabs; 0 full clears across every attack scenario the adversarial probes throw.
- Every screen fits every terminal we could construct: session list to 30 cols, market list to 11 rows, skill detail and both subviews scroll and fit, welcome sweeps 16..90 clean.
- Loading screens stopped lying: no more "no agents found" while the fetch is in flight; pending shows loading, empty renders only settled, failures say what failed. Six screens fixed, using the welcome panel's own null convention.
- The github panel is one walked list: arrows move, enter acts on the row, the register row always says what it needs; scheme-less github.com URLs parse (the panel's own hint suggests them).
- Composer history persists across sessions, shell style, capped and 0600.
- Reputation got its visual identity: bronze, silver, gold, legendary each render their own color at every site, gauges are two toned, every wallet derives a deterministic face, skill details lead with mint derived card art. Where a recolor touched something you had shipped deliberately (the footer engine dot), it is reverted in its own commit.

Three commits touch packages/core and say so in their bodies: 1a6b4bc (ToolAction gains an optional denied field, engines stamp it), 4c39dab (SessionMeta persists model and effort), 7ab6a10 (parseRepo accepts scheme-less github.com URLs). All additive, no signatures changed.

## Live screens

| Market, owned cards at 110 cols (the old crash width) | GitHub panel, enter toggles | ? opens windowed help at 80x24 |
|---|---|---|
| ![market with owned cards visible at 110 cols](https://github.com/RemilioNubilio/AgentNet/releases/download/pr-evidence/stack-market.png) | ![github panel with checkbox toggled](https://github.com/RemilioNubilio/AgentNet/releases/download/pr-evidence/stack-github.png) | ![windowed help overlay at 80x24](https://github.com/RemilioNubilio/AgentNet/releases/download/pr-evidence/stack-help.png) |

## Held to five rules, argued against the stack

1. No meaningless wrappers with identical input/output: the stack deletes more wrappers than it adds (ToolCard's bandTitle folded into the shared truncateStart; the helius badge copy now has one source).
2. Scan existing functions first and reuse; never two with one purpose: every fit reuses the format.ts helpers; the loading truth fixes reuse the welcome panel's null convention; the github focus walk reuses the existing histPos and initialStage machinery; nothing was reinvented.
3. No type variables that will not be reused: none added anywhere in the stack.
4. No non essential parameters: signatures unchanged except the three flagged core additions, all optional fields.
5. Keep responsibilities separated; say so when a design call is made: every commit body carries its own said-so, and the two places I changed a design you had shipped on purpose are called out (the logo drop threshold in the welcome panel lineage, the footer dot revert).

## Evidence

| Row | Artifact |
|---|---|
| Before/After screenshots | The three live screens above; the crash, storm, and fit claims each carry their repro numbers in their commit bodies. |
| Video walkthrough (MP4) | N/A, the commit ladder is the walkthrough. |
| Backend logs | Ten adversarial verification rounds ran against this stack as it grew (each round's findings fixed or triaged in the next commits); the standing probe battery is 15 suites, all green on the rebased head: journey, github flow, entry back, loading truth, input history, tier identity, market rows and ladder, session list width, approval storm plus its attack matrix, detail scroll and chrome, subviews, welcome sweeps, resize verifier. |
| Frontend logs | Every prefix of the 48 typechecks (cli and core tsc 0 at each commit); tsup builds at the head; ascii frames byte identical to main wherever a screen was not deliberately changed. |
| Real-LLM trajectory | The approval frame work was driven with a scripted engine harness; one live engine turn at 30x24 remains the honest gap, called out here rather than claimed. |
| Domain artifacts | The stack was built and hardened through daily hands on use of the CLI itself (the github panel flow, the loading lies, and the input history all came from real use finds); the tessera verified work registration in your leaderboard was performed through this build. |

## Known and not claimed

- Terminals under about 12 rows or 20 cols degrade contained (nothing escapes a frame) but not pretty; documented per commit.
- Session open scrollback litter (ink static replay) is untouched, an upstream shaped fix.
- Celebration and card art beyond the deterministic mint blocks is deliberately left for design direction rather than guessed at.

Happy to split any level into its own PR if that reviews easier; every prefix stands alone.
