### PR TITLE
mcp stderr: swallow bigint-buffer's always-firing bindings warning, once (#187, finding F2)

### DIFF
--- a/packages/core/src/core/quietBigintWarning.spec.ts
+++ b/packages/core/src/core/quietBigintWarning.spec.ts
@@ -1,0 +1,35 @@
+import { describe, it, expect, vi, afterEach } from "vitest";
+
+const BIGINT_NOISE = "bigint: Failed to load bindings, pure JS will be used (try npm run rebuild?)";
+
+// The module is a side-effect import (it must hook console.warn BEFORE the solana deps
+// load), so each test stubs console.warn first, then imports a fresh copy.
+describe("quietBigintWarning", () => {
+  afterEach(() => {
+    vi.resetModules();
+    vi.restoreAllMocks();
+  });
+
+  it("swallows exactly the bigint-buffer load warning, once, then restores console.warn", async () => {
+    const warn = vi.spyOn(console, "warn").mockImplementation(() => {});
+    await import("./quietBigintWarning.js");
+
+    console.warn(BIGINT_NOISE);
+    expect(warn).not.toHaveBeenCalled(); // the noise line is dropped
+
+    // the hook stepped out of the way: real warnings reach the original again
+    expect(console.warn).toBe(warn);
+    console.warn("a real warning");
+    expect(warn).toHaveBeenCalledExactlyOnceWith("a real warning");
+  });
+
+  it("passes every other warning through while the hook is armed", async () => {
+    const warn = vi.spyOn(console, "warn").mockImplementation(() => {});
+    await import("./quietBigintWarning.js");
+
+    console.warn("something else entirely");
+    console.warn("bigint: but a different message than the load warning?");
+    expect(warn).toHaveBeenCalledTimes(2);
+    expect(warn).toHaveBeenNthCalledWith(1, "something else entirely");
+  });
+});

--- a/packages/core/src/core/quietBigintWarning.ts
+++ b/packages/core/src/core/quietBigintWarning.ts
@@ -1,0 +1,25 @@
+// Silence ONE known-noise line: bigint-buffer's module-load warning (issue #187 F2).
+//
+// The npm bundle ships no native bigint_buffer addon, so the try/require at the top of
+// bigint-buffer's node.js ALWAYS fails and console.warn's "bigint: Failed to load
+// bindings, pure JS will be used (try npm run rebuild?)" on every spawn. The pure JS
+// fallback is the expected path here, not something the operator can rebuild away, and
+// on an MCP host that reads child stderr the line lands in front of the ready banner
+// looking like an error. Multiplied by per-call spawning it is constant clutter.
+//
+// So: hook console.warn, swallow exactly that one line, and put the original back the
+// moment it fires (the load warning fires at most once per process, at module load).
+// Every other warning passes through untouched, before and after, so nothing real is
+// hidden. Imported for its SIDE EFFECT as the first import of mcp-stdio.ts, which is
+// what places the hook before @solana/web3.js pulls bigint-buffer in.
+
+const realWarn = console.warn;
+console.warn = (...args: unknown[]) => {
+  if (typeof args[0] === "string" && args[0].startsWith("bigint: Failed to load bindings")) {
+    console.warn = realWarn; // one shot: the noise fired, step out of the way
+    return;
+  }
+  realWarn(...args);
+};
+
+export {}; // side-effect module: nothing to export, everything happens above

--- a/packages/core/src/mcp-stdio.ts
+++ b/packages/core/src/mcp-stdio.ts
@@ -26,6 +26,11 @@
 // IMPORTANT: stdout is the JSON-RPC channel — never write to it. All diagnostics go
 // to stderr (console.error).
 
+// FIRST import, above the solana deps: hooks console.warn so bigint-buffer's
+// always-firing "Failed to load bindings" line (no native addon in the bundle, the
+// pure JS fallback is expected) stops fronting every spawn's stderr. One line only;
+// real warnings pass through. See core/quietBigintWarning.ts (issue #187 F2).
+import "./core/quietBigintWarning.js";
 import { Connection } from "@solana/web3.js";
 import { StdioServerTransport } from "@modelcontextprotocol/sdk/server/stdio.js";
 import { resolveRpcUrl } from "./core/rpc.js";


### PR DESCRIPTION
## The problem (#187 F2)

The npm bundle ships no native bigint_buffer addon, so bigint-buffer's module-load try/require always fails and console.warn's "bigint: Failed to load bindings, pure JS will be used (try npm run rebuild?)" is the FIRST stderr line of every spawn. The pure JS fallback is the expected path, the operator cannot rebuild it away, and MCP hosts that surface child stderr log it in front of the ready banner on every single spawn.

## The fix

One new side-effect module, packages/core/src/core/quietBigintWarning.ts, imported as the first import of mcp-stdio.ts so the hook is in place before @solana/web3.js pulls bigint-buffer in. It wraps console.warn, drops exactly the one line matching the bigint-buffer load warning prefix, and restores the original console.warn the moment that line fires (the load warning fires at most once per process, at module load). Every other warning passes through untouched, before and after, so nothing real is hidden. Scope is the stdio entry only: no other surface imports it, and the dependency itself is not patched.

The punycode DEP0040 deprecation the repro log also shows is Node core deprecating a transitive dependency; muting deprecations globally would hide real ones, so it is deliberately left alone.

## The five rules, against this diff

1. No meaningless wrappers: the console.warn wrapper changes behavior (it filters and self-removes); there is no pass-through layer.
2. Existing functions scanned first: nothing in the tree filters stderr today; the only alternative seam is the tsup banner, which cannot carry a testable TypeScript module.
3. No new types: none added.
4. No non-essential parameters: the module takes nothing and exports nothing; the one hook site is the import line.
5. Responsibilities separated: the filter lives in its own file stating exactly what it silences and why; mcp-stdio.ts only gained the import plus a comment. Design note said out loud: if a future bundle ships the native addon, the warning never fires, the hook idles armed, and every warning still passes through, so shipping the addon needs no change here.

## Tests

quietBigintWarning.spec.ts: the bigint line is dropped and console.warn is restored afterward (a following real warning reaches the original exactly once); while armed, other warnings pass through, including bigint-prefixed text that is not the load warning.

## Verification

packages/core tsc --noEmit clean; both specs pass. Bundle rebuilt with tsup and spawned live with a throwaway keyfile: stderr now starts at the DEP0040 line, the bigint line is gone, and the generated-wallet plus ready banner lines are intact. Patch applies clean to origin/main 6a7d018 with git apply --check.
