### PR TITLE
post_skill_comment: file a workflow's comment under the workflows collection (#187, finding F4)

### DIFF
--- a/packages/core/src/skill-market/index.spec.ts
+++ b/packages/core/src/skill-market/index.spec.ts
@@ -35,6 +35,7 @@ vi.mock("../core/chain.js", () => ({
 vi.mock("../core/seed.js", () => ({
   getSkillsCollectionMint: vi.fn().mockReturnValue("skillsCollection111"),
   getWorkflowsCollectionMint: vi.fn().mockReturnValue("workflowsCollection111"),
+  collectionFor: vi.fn((type?: "skill" | "workflow") => (type === "workflow" ? "workflowsCollection111" : "skillsCollection111")),
   getIndexerUrl: vi.fn().mockReturnValue("https://nft-index.example"),
   getNetwork: vi.fn().mockReturnValue("devnet"),
 }));
@@ -215,6 +216,51 @@ describe("skill-market", () => {
     });
     expect(result.isError).toBe(true);
     expect(result.content[0].text).toContain("Must own");
+  });
+
+  // ── omitted collectionId resolves the ITEM's collection, not a skills default (#187 F4) ──
+  it("post_skill_comment on a workflow files under the WORKFLOWS collection when collectionId is omitted", async () => {
+    vi.mocked(searchSkills).mockResolvedValue([{ id: "wf1", creator: "wfCreator111", type: "workflow" }] as any);
+    vi.mocked(postNote).mockResolvedValue("note:wf:123:xyz");
+    const result = await handleToolCall(mockConn, signer, "defaultCreator", "post_skill_comment", {
+      skillId: "wf1",
+      text: "Solid workflow.",
+    });
+    expect(result.isError).toBeUndefined();
+    expect(postNote).toHaveBeenCalledWith(mockConn, signer, {
+      collectionId: "workflowsCollection111",
+      skillId: "wf1",
+      text: "Solid workflow.",
+      gitLink: undefined,
+    });
+  });
+
+  it("post_skill_comment on a skill still files under the skills collection when collectionId is omitted", async () => {
+    // the beforeEach catalog entry for skill1 has no type field: no type is treated as a
+    // skill, the same reading search_skills applies
+    vi.mocked(postNote).mockResolvedValue("note:sk:123:xyz");
+    const result = await handleToolCall(mockConn, signer, "defaultCreator", "post_skill_comment", {
+      skillId: "skill1",
+      text: "Great skill!",
+    });
+    expect(result.isError).toBeUndefined();
+    expect(postNote).toHaveBeenCalledWith(mockConn, signer, {
+      collectionId: "skillsCollection111",
+      skillId: "skill1",
+      text: "Great skill!",
+      gitLink: undefined,
+    });
+  });
+
+  it("post_skill_comment refuses to guess the collection for an item missing from the catalog", async () => {
+    vi.mocked(searchSkills).mockResolvedValue([] as any);
+    const result = await handleToolCall(mockConn, signer, "defaultCreator", "post_skill_comment", {
+      skillId: "ghost1",
+      text: "hello",
+    });
+    expect(result.isError).toBe(true);
+    expect(result.content[0].text).toContain("pass collectionId");
+    expect(postNote).not.toHaveBeenCalled();
   });
 
   it("should handle post_agent_comment tool call", async () => {

--- a/packages/core/src/skill-market/index.ts
+++ b/packages/core/src/skill-market/index.ts
@@ -30,7 +30,7 @@ import { readSkillText } from "../nft/token2022.js";
 import { SkillSync } from "./ingest/index.js";
 import { postNote, postAgentNote } from "../notes/notes.js";
 import { homedir } from "node:os";
-import { getSkillsCollectionMint, getWorkflowsCollectionMint, getIndexerUrl } from "../core/seed.js";
+import { collectionFor, getIndexerUrl } from "../core/seed.js";
 import { indexerSource, ownedSkillMints } from "../core/skillSource.js";
 import { loadHeliusKey } from "../core/rpc.js";
 import { signerAddress } from "../core/chain.js";
@@ -209,7 +209,7 @@ export const SKILL_TOOLS: { name: string; description: string; schema: z.ZodRawS
     description: "Post a comment/review on a skill. You must hold ≥1 of the skill's token to comment.",
     schema: {
       skillId: z.string().describe("The base58 mint address of the skill to comment on."),
-      collectionId: z.string().optional().describe("The collection mint address the skill belongs to (skills or workflows collection). Omit to use the default skills collection."),
+      collectionId: z.string().optional().describe("The collection mint address the item belongs to (skills or workflows collection). Omit to resolve it from the marketplace catalog: skills file under the skills collection, workflows under the workflows collection."),
       text: z.string().describe("The comment text (markdown supported)."),
       gitLink: z.string().optional().describe("Optional GitHub or on-chain git URL to attach to the comment."),
     },
@@ -264,19 +264,21 @@ export function getAgentNetTools() {
 export type MarketEmit = (e: import("../chat/marketMessages.js").MarketEvent) => void;
 
 /**
- * The wallet that published `skillId`, read from the same catalog `search_skills` serves
- * (indexer when there's no DAS key, DAS otherwise). buy_item needs it for the program's
- * has_one on config.creator, and it is NOT in the mint metadata — the catalog is where a
- * caller would have gotten it anyway. Returns null when the skill isn't in the catalog,
- * so the caller can refuse instead of sending a transaction that cannot succeed.
+ * The catalog row for `skillId`, read from the same catalog `search_skills` serves
+ * (indexer when there's no DAS key, DAS otherwise). Two handlers need it: buy_skill
+ * takes `creator` (the program's has_one on config.creator, and it is NOT in the mint
+ * metadata), post_skill_comment takes `type` (skill vs workflow decides which
+ * collection the note is filed under). Neither is in the arguments a caller reliably
+ * has, and the catalog is where they would have gotten either anyway. Returns null
+ * when the skill isn't listed, so the caller can refuse instead of guessing.
  */
-async function skillCreator(conn: Connection, skillId: string): Promise<string | null> {
+async function catalogItem(conn: Connection, skillId: string) {
   let source;
   if (!(await loadHeliusKey())) {
     try { source = indexerSource(getIndexerUrl()); } catch { source = undefined; }
   }
   const skills = await searchSkills(conn, { source }).catch(() => [] as Awaited<ReturnType<typeof searchSkills>>);
-  return skills.find((s) => s.id === skillId)?.creator ?? null;
+  return skills.find((s) => s.id === skillId) ?? null;
 }
 
 export async function handleToolCall(
@@ -346,7 +348,7 @@ export async function handleToolCall(
     // reads, and refuse rather than send a transaction that cannot succeed.
     let creatorWallet = (args?.creatorWallet as string) || "";
     if (!creatorWallet) {
-      creatorWallet = (await skillCreator(conn, skillId)) ?? "";
+      creatorWallet = (await catalogItem(conn, skillId))?.creator ?? "";
       if (!creatorWallet) {
         return {
           isError: true,
@@ -426,12 +428,26 @@ export async function handleToolCall(
 
   if (name === "post_skill_comment") {
     const skillId = args?.skillId as string;
-    const collectionId = (args?.collectionId as string) ||
-      getSkillsCollectionMint() || "";
     const text = args?.text as string;
     const gitLink = args?.gitLink as string | undefined;
     if (!skillId || !text) throw new Error("Missing required argument: skillId and text");
-    if (!collectionId) throw new Error("collectionId is required (skills collection not configured)");
+    // The two collections are distinct mints and reviewsHint keys the review table by
+    // collection, so an omitted collectionId must resolve to the ITEM's collection, not
+    // default to skills: that filed workflow comments where no workflow reader looks
+    // (issue #187 F4). Read the item's type from the same catalog buy_skill resolves the
+    // creator from, and refuse rather than guess when the item isn't listed there.
+    let collectionId = (args?.collectionId as string) || "";
+    if (!collectionId) {
+      const listed = await catalogItem(conn, skillId);
+      if (!listed) {
+        return {
+          isError: true,
+          content: [{ type: "text", text: `Could not find ${skillId} in the marketplace catalog to resolve its collection. Run search_skills to confirm the id, or pass collectionId explicitly.` }],
+        };
+      }
+      collectionId = collectionFor(listed.type);
+    }
+    if (!collectionId) throw new Error("collectionId is required (the item's collection is not configured)");
     try {
       const noteId = await postNote(conn, signer, { collectionId, skillId, text, gitLink });
       return { content: [{ type: "text", text: `Comment posted (id: ${noteId})` }] };


### PR DESCRIPTION
## The problem (#187 F4)

post_skill_comment resolved an omitted collectionId as getSkillsCollectionMint(), unconditionally. The skills and workflows collections are distinct mints, and postNote keys the review table by collection (reviewsHint), so a caller commenting on a workflow who trusted the documented "omit it" default got their note filed under the SKILLS collection: invisible where a workflow reader looks, mis-attributed where it lands.

## The fix

Resolve the item's own collection. The existing catalog lookup buy_skill uses for the creator (the private skillCreator helper) is generalized to return the catalog row and renamed catalogItem; buy_skill takes .creator from it exactly as before, and post_skill_comment now takes .type and maps it through seed.ts's collectionFor, which already exists as "the ONE place that maps skill / workflow to its collection". An item missing from the catalog gets a refusal telling the caller to run search_skills or pass collectionId explicitly, mirroring buy_skill's refusal when the creator cannot be resolved, instead of a silent wrong-collection write. An explicit collectionId is honored unchanged and skips the catalog read. The tool's schema description no longer promises a skills default.

This also removes the file's unused getWorkflowsCollectionMint import (it was imported and never called; collectionFor covers both).

## The five rules, against this diff

1. No meaningless wrappers: none added; catalogItem returns the catalog row itself.
2. Existing functions scanned first and reused: collectionFor already owned the type-to-collection mapping and is now actually used; skillCreator and a would-be skillType lookup would have been two functions doing one catalog read, so they are one function, catalogItem, with two callers.
3. No new types: catalogItem's return type is inferred from searchSkills; nothing declared.
4. No non-essential parameters: tool schema unchanged except wording; catalogItem takes the same two arguments skillCreator took.
5. Responsibilities separated: the catalog read stays in one helper, the type-to-collection mapping stays in seed.ts, the handler only sequences them. Design note said out loud: an explicit collectionId that CONTRADICTS the item's catalog type is still accepted, as before; rejecting that mismatch would spend a catalog read on every explicit call and is a stricter contract worth its own decision.

## Stacking note

Independent of the F1 patch (0001-f1-verify-token.patch): both touch skill-market/index.ts around the buy/comment resolve helpers and the import block, so whichever lands second needs a trivial rebase of the overlapping hunks. They are kept as independent patches on purpose; neither depends on the other's behavior.

## Tests

Three specs added: a workflow with collectionId omitted files under the workflows collection; a skill (and a catalog row with no type field, the "no type is a skill" reading search_skills applies) still files under the skills collection; an item missing from the catalog is refused and postNote is never called. The existing explicit-collectionId and ownership-gate specs pass unchanged.

## Verification

packages/core tsc --noEmit clean; vitest run src/skill-market/index.spec.ts 35 passed (32 baseline plus 3 new); full core suite shows the same 6 pre-existing environment failures as unpatched main, nothing new. Patch applies clean to origin/main 6a7d018 with git apply --check.
