### PR TITLE
core: optional remote signer hook for the stdio MCP server (AGENTNET_WALLET_REMOTE)

### DIFF
--- a/packages/core/src/account/remoteWallet.spec.ts
+++ b/packages/core/src/account/remoteWallet.spec.ts
@@ -1,0 +1,133 @@
+import { describe, it, expect, beforeAll, afterAll } from "vitest";
+import { createServer, type Server } from "node:http";
+import type { IncomingMessage } from "node:http";
+import type { AddressInfo } from "node:net";
+import { Keypair, SystemProgram, Transaction, TransactionInstruction } from "@solana/web3.js";
+import nacl from "tweetnacl";
+import { remoteWallet } from "./remoteWallet.js";
+
+// A stub loopback vault speaking the three-endpoint protocol remoteWallet documents:
+// GET /pubkey, POST /sign-transaction, POST /sign-message. It holds one Keypair and
+// signs for real (web3.js partialSign for transactions, nacl for messages), so the
+// specs check actual signature validity, not just transport plumbing. Flipping
+// `refuse` turns it into a policy vault that says no, the 403 path.
+const remoteKey = Keypair.generate();
+let refuse = false;
+let server: Server;
+let base: string;
+
+function readBody(req: IncomingMessage): Promise<string> {
+  return new Promise((resolve, reject) => {
+    const chunks: Buffer[] = [];
+    req.on("data", (c) => chunks.push(c));
+    req.on("end", () => resolve(Buffer.concat(chunks).toString("utf8")));
+    req.on("error", reject);
+  });
+}
+
+// A minimal legacy transaction the stub can sign: remote key as fee payer, one
+// no-op instruction (compileMessage refuses an empty instruction list), plus an
+// optional extra required signer for the partial-signature round-trip spec.
+function newTx(extraSigner?: Keypair): Transaction {
+  return new Transaction({
+    feePayer: remoteKey.publicKey,
+    // any 32-byte base58 string is a valid blockhash shape for offline serialization
+    recentBlockhash: Keypair.generate().publicKey.toBase58(),
+  }).add(
+    new TransactionInstruction({
+      keys: extraSigner ? [{ pubkey: extraSigner.publicKey, isSigner: true, isWritable: false }] : [],
+      programId: SystemProgram.programId,
+      data: Buffer.alloc(0),
+    }),
+  );
+}
+
+beforeAll(async () => {
+  server = createServer((req, res) => {
+    void (async () => {
+      if (refuse) {
+        res.writeHead(403, { "Content-Type": "application/json" });
+        res.end(JSON.stringify({ error: "policy: spend cap exceeded" }));
+        return;
+      }
+      if (req.method === "GET" && req.url === "/pubkey") {
+        res.writeHead(200, { "Content-Type": "application/json" });
+        res.end(JSON.stringify({ address: remoteKey.publicKey.toBase58() }));
+        return;
+      }
+      const body = JSON.parse(await readBody(req)) as Record<string, unknown>;
+      if (req.method === "POST" && req.url === "/sign-transaction") {
+        const tx = Transaction.from(Buffer.from(String(body.transaction), "base64"));
+        tx.partialSign(remoteKey);
+        res.writeHead(200, { "Content-Type": "application/json" });
+        res.end(JSON.stringify({
+          transaction: tx.serialize({ requireAllSignatures: false, verifySignatures: false }).toString("base64"),
+        }));
+        return;
+      }
+      if (req.method === "POST" && req.url === "/sign-message") {
+        const msg = Buffer.from(String(body.message), "base64");
+        const signature = nacl.sign.detached(Uint8Array.from(msg), remoteKey.secretKey);
+        res.writeHead(200, { "Content-Type": "application/json" });
+        res.end(JSON.stringify({ signature: Buffer.from(signature).toString("base64") }));
+        return;
+      }
+      res.writeHead(404);
+      res.end();
+    })().catch(() => {
+      res.writeHead(500);
+      res.end();
+    });
+  });
+  await new Promise<void>((resolve) => server.listen(0, "127.0.0.1", resolve));
+  base = `http://127.0.0.1:${(server.address() as AddressInfo).port}`;
+});
+
+afterAll(async () => {
+  await new Promise<void>((resolve) => server.close(() => resolve()));
+});
+
+describe("remoteWallet", () => {
+  it("resolves the wallet address from the signer's /pubkey (trailing slash tolerated)", async () => {
+    const { wallet, address } = await remoteWallet(`${base}/`);
+    expect(address).toBe(remoteKey.publicKey.toBase58());
+    expect(wallet.publicKey.equals(remoteKey.publicKey)).toBe(true);
+  });
+
+  it("sign-transaction round trip keeps a co-signer's pre-added partial signature", async () => {
+    const { wallet } = await remoteWallet(base);
+    const cosigner = Keypair.generate();
+    const tx = newTx(cosigner);
+    // the mint/minter-style signature added BEFORE the vault ever sees the tx
+    tx.partialSign(cosigner);
+    const before = tx.signatures.find((s) => s.publicKey.equals(cosigner.publicKey))?.signature;
+    expect(before).toBeTruthy();
+
+    const signed = await wallet.signTransaction(tx);
+    expect(signed).toBe(tx); // same object mutated and returned, keypairWallet's contract
+    const after = signed.signatures.find((s) => s.publicKey.equals(cosigner.publicKey))?.signature;
+    expect(after && before && after.equals(before)).toBe(true); // the partial sig survived
+    expect(signed.signatures.find((s) => s.publicKey.equals(remoteKey.publicKey))?.signature).toBeTruthy();
+    expect(signed.verifySignatures()).toBe(true); // both signatures verify over the same bytes
+  });
+
+  it("sign-message returns the signer's ed25519 signature over the exact fixed message", async () => {
+    const { wallet } = await remoteWallet(base);
+    const msg = new TextEncoder().encode("agentnet session key derivation, one fixed message");
+    const sig = await wallet.signMessage(msg);
+    expect(sig).toHaveLength(64);
+    expect(nacl.sign.detached.verify(msg, sig, remoteKey.publicKey.toBytes())).toBe(true);
+  });
+
+  it("surfaces a policy refusal with the vault's own reason text (403 path)", async () => {
+    const { wallet } = await remoteWallet(base); // handshake first, while the vault still answers
+    refuse = true;
+    try {
+      await expect(wallet.signTransaction(newTx())).rejects.toThrow(
+        /remote signer refused \(403\): policy: spend cap exceeded/,
+      );
+    } finally {
+      refuse = false;
+    }
+  });
+});

--- a/packages/core/src/account/remoteWallet.ts
+++ b/packages/core/src/account/remoteWallet.ts
@@ -1,0 +1,97 @@
+// Build a Wallet from a REMOTE SIGNER over loopback HTTP, the out-of-process
+// counterpart of keypairWallet (local Keypair) and webWallet (browser provider).
+// The secret key lives behind a service the operator runs, typically a policy
+// vault (spend caps, allowlists, approval queues); this process never sees it.
+// Protocol, all JSON:
+//
+//   GET  {url}/pubkey            -> { "address": "<base58>" }
+//   POST {url}/sign-transaction  { "transaction": "<base64>" }
+//                                -> { "transaction": "<base64 signed>" }
+//   POST {url}/sign-message      { "message": "<base64>" }
+//                                -> { "signature": "<base64>" }   (optional)
+//
+// sign-transaction serializes with requireAllSignatures:false so partial
+// signatures already added by mint/minter keypairs survive the round trip,
+// the same rule webWallet's provider path follows. sign-message is optional
+// on purpose: a vault that signs transactions under policy but refuses raw
+// messages answers non-200, the error here stays clean, and mcp-stdio already
+// downgrades to marketplace-only when the vault band cannot open.
+
+import { PublicKey, Transaction, VersionedTransaction } from "@solana/web3.js";
+import type { Wallet } from "../runtime/contract.js";
+
+// Deadline on every signer call, the same shape as the read-path timeout fix: a
+// hung or wedged signer process must fail this call with a clear error instead of
+// stalling the spawn forever (there is no user watching a stdio server's fetch).
+// A policy vault that queues human approvals should answer within this window or
+// answer with a refusal; holding the socket open is not a protocol state.
+const SIGNER_TIMEOUT_MS = 30_000;
+
+async function postJson(url: string, body: object): Promise<Record<string, unknown>> {
+  const res = await fetch(url, {
+    method: "POST",
+    headers: { "Content-Type": "application/json" },
+    body: JSON.stringify(body),
+    signal: AbortSignal.timeout(SIGNER_TIMEOUT_MS),
+  });
+  const text = await res.text();
+  if (!res.ok) {
+    // Surface the signer's own refusal text (a policy vault says WHY it said no).
+    let detail = text;
+    try {
+      detail = String((JSON.parse(text) as { error?: unknown }).error ?? text);
+    } catch {
+      // not JSON, keep the raw body
+    }
+    throw new Error(`remote signer refused (${res.status}): ${detail}`);
+  }
+  return JSON.parse(text) as Record<string, unknown>;
+}
+
+export async function remoteWallet(url: string): Promise<{ wallet: Wallet; address: string }> {
+  const base = url.replace(/\/+$/, "");
+  const res = await fetch(`${base}/pubkey`, { signal: AbortSignal.timeout(SIGNER_TIMEOUT_MS) });
+  if (!res.ok) throw new Error(`remote signer at ${base} did not answer /pubkey (${res.status})`);
+  const { address } = (await res.json()) as { address?: string };
+  if (!address) throw new Error(`remote signer at ${base} returned no address`);
+  const publicKey = new PublicKey(address); // throws on a junk address, fail fast
+
+  async function signOne<T extends Transaction | VersionedTransaction>(tx: T): Promise<T> {
+    const versioned = "version" in tx;
+    const bytes = versioned
+      ? (tx as VersionedTransaction).serialize()
+      : (tx as Transaction).serialize({ requireAllSignatures: false, verifySignatures: false });
+    const out = await postJson(`${base}/sign-transaction`, {
+      transaction: Buffer.from(bytes).toString("base64"),
+    });
+    const signed = Buffer.from(String(out.transaction ?? ""), "base64");
+    if (signed.length === 0) throw new Error("remote signer returned no transaction");
+    // Copy signatures back onto the caller's object, the way keypairWallet
+    // mutates and returns the same tx.
+    if (versioned) {
+      (tx as VersionedTransaction).signatures = VersionedTransaction.deserialize(signed).signatures;
+    } else {
+      (tx as Transaction).signatures = Transaction.from(signed).signatures;
+    }
+    return tx;
+  }
+
+  const wallet: Wallet = {
+    address,
+    publicKey,
+    async signMessage(msg) {
+      const out = await postJson(`${base}/sign-message`, {
+        message: Buffer.from(msg).toString("base64"),
+      });
+      const signature = Buffer.from(String(out.signature ?? ""), "base64");
+      if (signature.length === 0) throw new Error("remote signer returned no signature");
+      return Uint8Array.from(signature);
+    },
+    signTransaction: signOne,
+    async signAllTransactions<T extends Transaction | VersionedTransaction>(txs: T[]): Promise<T[]> {
+      for (const tx of txs) await signOne(tx);
+      return txs;
+    },
+  };
+  return { wallet, address };
+}

--- a/packages/core/src/mcp-stdio.ts
+++ b/packages/core/src/mcp-stdio.ts
@@ -14,6 +14,10 @@
 //   AGENTNET_WALLET_KEYFILE  path to a Solana keypair JSON. Absent → the Solana CLI
 //                            default (~/.config/solana/id.json). Missing file → a new
 //                            keypair is generated there (never overwrites a valid one).
+//   AGENTNET_WALLET_REMOTE   URL of a remote signer endpoint (account/remoteWallet.ts).
+//                            When set, that endpoint holds the key and signs; the
+//                            keyfile is never read or created. Unset keeps the
+//                            keyfile path exactly as before.
 //   AGENTNET_MCP_READONLY    "0" | "false" turns WRITE/SPEND tools on (buy/publish/
 //                            comment/unequip/install). Anything else — including unset —
 //                            stays READ-ONLY (search/verify only), so the safe mode is
@@ -31,7 +35,9 @@ import { StdioServerTransport } from "@modelcontextprotocol/sdk/server/stdio.js"
 import { resolveRpcUrl } from "./core/rpc.js";
 import { init as initChain } from "./core/chain.js";
 import { localWallet } from "./account/localWallet.js";
+import { remoteWallet } from "./account/remoteWallet.js";
 import { login } from "./account/login.js";
+import type { Wallet } from "./runtime/contract.js";
 import { createAgentMcpServer, newVerifyGuard } from "./skill-market/index.js";
 import type { VaultDeps } from "./vault/tools.js";
 import { injectExternalHosts } from "./vault/inject.js";
@@ -42,9 +48,19 @@ function readOnlyFromEnv(): boolean {
 }
 
 async function main(): Promise<void> {
+  const remote = process.env.AGENTNET_WALLET_REMOTE?.trim() || undefined;
   const keyfile = process.env.AGENTNET_WALLET_KEYFILE?.trim() || undefined;
-  const { wallet, address, created } = await localWallet(keyfile);
-  if (created) console.error(`[agentnet-mcp] generated a new wallet keypair at ${keyfile ?? "the default path"}`);
+  let wallet: Wallet;
+  let address: string;
+  if (remote) {
+    ({ wallet, address } = await remoteWallet(remote));
+    console.error(`[agentnet-mcp] signing through the remote signer at ${remote}`);
+  } else {
+    const loaded = await localWallet(keyfile);
+    wallet = loaded.wallet;
+    address = loaded.address;
+    if (loaded.created) console.error(`[agentnet-mcp] generated a new wallet keypair at ${keyfile ?? "the default path"}`);
+  }
   const conn = new Connection(await resolveRpcUrl(), "confirmed");
   initChain(conn); // writes go through chain.ts's singleton; idempotent
   const readOnly = readOnlyFromEnv();


### PR DESCRIPTION
## What this does

One new file plus its spec plus one construction-seam hook, nothing downstream touched.

- `packages/core/src/account/remoteWallet.ts` (new, 97 lines): builds a `Wallet` from a loopback signer endpoint. Three-endpoint JSON protocol: `GET /pubkey`, `POST /sign-transaction` (base64 in, base64 signed out), `POST /sign-message` (optional). Serializes with `requireAllSignatures:false` so partial signatures already added by mint/minter keypairs survive the round trip, the same rule webWallet's provider path follows. Every fetch carries an `AbortSignal.timeout` deadline (`SIGNER_TIMEOUT_MS`, 30s, a fixed constant mirroring the read-path timeout fix), so a hung or wedged signer process fails the call with a clear error instead of stalling a spawn forever.
- `packages/core/src/account/remoteWallet.spec.ts` (new): offline spec against a stub loopback vault, see Tests below.
- `packages/core/src/mcp-stdio.ts`: when `AGENTNET_WALLET_REMOTE` is set, `main()` builds the wallet from `remoteWallet(url)` instead of `localWallet(keyfile)`. Unset keeps the keyfile path byte-identical: same `localWallet` call, same generated-keypair log line, same wiring into `login` and `createAgentMcpServer`.

## Why

The env contract in mcp-stdio.ts already names the gap: "the wallet keyfile itself is the spend ceiling the operator chose to expose. (Lamport caps are an open question in #84 sE.)" An operator who wants a real spend ceiling (caps, allowlists, an approval queue) needs the key held by a policy vault while this server keeps signing the exact same transactions. The codebase is already shaped for it: `Wallet` in runtime/contract.ts IS the external-signer shape (WalletSigner plus address plus signMessage), every write path takes `SignerInput`, and webWallet proves a non-Keypair `Wallet` works end to end. So no signer abstraction is added here; this is only the third `Wallet` constructor, at the one construction seam the stdio server has.

A concrete counterpart exists and was tested against this exact protocol (a governed-vault signer daemon that enforces per-agent policy server-side and returns the refusal reason in the error body). The hook stays vault-agnostic on purpose: any process that answers the three endpoints works, and this repo ships no daemon and takes on nothing to maintain.

## The five rules, against this diff

1. No meaningless wrappers: `remoteWallet` is not input-out-the-other-side; it owns the pubkey handshake, serialize/deserialize with partial-sig preservation, and turning the signer's refusal body into a readable error. Its one helper, `postJson`, is shared by both POST endpoints.
2. Existing functions scanned first: `keypairWallet` and `webWallet` remain the only other `Wallet` builders and both were considered. `webWallet` was not reusable here: it requires a pre-cached signature over the one fixed session-key message and throws on versioned transactions, so bending it around live HTTP would have produced exactly the wrapper rule 1 forbids. What WAS reused: its `requireAllSignatures:false` serialization rule, the `Wallet` contract, and the mcp-stdio downgrade path for a closed vault band.
3. No throwaway type variables: zero new types. The function returns the existing `Wallet` and a base58 string; the inline response shapes are anonymous object types at their single use sites.
4. No non-essential parameters: `remoteWallet(url)` takes exactly one argument. No options bag, no retry knobs, no header configuration; the 30s call deadline is a fixed module constant (the same shape as the read-path timeout fix), not a parameter.
5. Responsibilities separated: transport lives in account/remoteWallet.ts beside its siblings; the env decision lives in `main()` next to the existing keyfile decision; chain.ts, skill-market, token2022, notes are untouched. Design note, said out loud: cli/localhost/vscode bootstrap through `localWallet` too, and the same seam exists there. This PR deliberately hooks only the stdio server; widening it is a separate call once someone actually wants it.

## Core change, flagged

This edits `main()` of the stdio MCP server, the wallet bootstrap. The hook is opt-in by env: with `AGENTNET_WALLET_REMOTE` unset there is no behavior change at all, and read-only mode (the default) never signs, so the hook only matters when an operator has already flipped `AGENTNET_MCP_READONLY` off.

## Deployment note: authenticate the loopback endpoint

`AGENTNET_WALLET_REMOTE` points at a loopback port, and a loopback port is
reachable by every process on the machine. The hook stays vault-agnostic and
this diff adds no header plumbing, so the security posture is the operator's
endpoint choice: bind the signer URL to an endpoint that authenticates its
callers. The tested counterpart daemon does this by default: it requires a
shared-secret header (`x-steward-bridge-token`, a fresh random token per
session, or `STEWARD_SIGNER_BRIDGE_TOKEN` from the env so both processes read
one var) and answers 401 before the signer is touched; running it open for
this headerless consumer is an explicit `token: null` opt-in on the daemon
side. That authenticated shape is the recommended deployment until a later
PR teaches this consumer to send the header itself.

## Deliberately NOT done

- No signer daemon in this repo, no new nav or chrome, nothing permanent to maintain. The endpoint is whatever the operator runs on loopback.
- `sign-message` support is optional by protocol. A vault that signs transactions under policy but refuses raw messages answers non-200; the error stays clean and mcp-stdio's existing try/catch downgrades to marketplace-only (soul and memory stay off, the marketplace works). Documented in the file header rather than papered over with a local key.
- No lamport caps here. Policy belongs to the vault behind the endpoint; this PR only makes such a vault possible.

## Tests

remoteWallet.spec.ts, inside this patch, runs offline against a stub loopback vault (node:http on 127.0.0.1, ephemeral port) that signs for real: web3.js partialSign for transactions, tweetnacl (already a core dependency) for messages. Four specs: the /pubkey handshake resolves the wallet address (trailing slash tolerated); a sign-transaction round trip keeps a co-signer's PRE-ADDED partial signature and both signatures verify over the same bytes (verifySignatures true, same tx object mutated and returned, keypairWallet's contract); sign-message returns a real ed25519 signature over the exact fixed message, verified against the signer's pubkey; a 403 policy refusal surfaces the vault's own reason text in the thrown error.

## Verification (offline, no chain writes)

- `packages/core` `tsc --noEmit` clean with the patch applied to main; `vitest run src/account/remoteWallet.spec.ts` 4 passed.
- End-to-end against a stub vault on 127.0.0.1: pubkey handshake; legacy tx with a co-signing keypair partial-signed first, all signatures valid after the round trip; v0 versioned tx signed; a policy refusal propagates with the vault's reason text in the thrown error; sign-message refusal downgrades cleanly; every vault call carried broadcast:false; a token-armed signer endpoint refuses this headerless consumer with 401 before the signer is touched (the deployment note above).
