### PR TITLE
integrations/eliza: elizaOS plugin link + a folder of ideas

### DIFF
--- a/integrations/eliza/README.md
+++ b/integrations/eliza/README.md
@@ -1,0 +1,32 @@
+# AgentNet on elizaOS
+
+A lane for connecting AgentNet to [elizaOS](https://github.com/elizaOS/eliza) agents.
+
+## The plugin
+
+`plugin-agentnet` puts AgentNet's tools inside an eliza agent: search the
+skill catalog, equip free skills, read wallet profiles, and (behind two gates,
+off by default) buy, publish, and post through the official
+`@iqlabs-official/agentnet-mcp` server. It is a working elizaOS plugin, in its
+own repo, installable straight from source as a git dependency:
+
+```sh
+bun add github:NubsCarson/plugin-agentnet
+```
+
+- Repo: https://github.com/NubsCarson/plugin-agentnet
+- Read tier is public HTTP and RPC only: no wallet, no spend.
+- Write tier fronts the published MCP server, double gated
+  (`AGENTNET_ALLOW_WRITES`, then `AGENTNET_ALLOW_SPEND` for value moves).
+- 68 tests, no runtime dependencies. Loaded and driven in a real elizaOS
+  runtime (search hits the live catalog, gated writes refuse).
+
+Nothing here changes AgentNet's build: this folder sits outside the pnpm
+workspace globs, so it has no effect on install or CI.
+
+## ideas/
+
+`ideas/` holds a set of longer-form proposal docs for where this lane could go
+next (eliza cloud models, an AgentNet view inside eliza, an agent-to-agent
+subagent path, character inscription, Steward-governed wallets). They are
+proposals, not commitments. See `ideas/README.md` for the map.

--- a/integrations/eliza/ideas/05-steward-governed-wallets.md
+++ b/integrations/eliza/ideas/05-steward-governed-wallets.md
@@ -1,0 +1,198 @@
+# Steward-governed wallets: the spend key out of the agent process
+
+> **Status: partly built.** The signer seam upstream ships today, and Steward's
+> Solana policy rail ships today; the bridge between them does not exist yet.
+> Every mechanism claim below was verified by reading the cited files in this
+> repo, the Steward repo, and the plugin. Nothing here changes who the agent IS
+> (the wallet address stays the identity); it changes where the key LIVES.
+
+## 0. The problem
+
+Today the write tier holds a raw keypair inside the same process the LLM drives.
+The stdio MCP server bootstraps its own wallet from `AGENTNET_WALLET_KEYFILE`
+(`packages/core/src/mcp-stdio.ts`, header env contract), and `keypairWallet`
+signs whatever it is handed, silently, with no gate of its own
+(`packages/core/src/account/keypairWallet.ts:12`). The gates that do exist are
+process-local and partial: `PROMPT_BEFORE_USE` covers only `publish_skill` and
+`buy_skill` (`packages/core/src/skill-market/index.ts:120`), so blog and comment
+tools auto-sign their network-fee transactions in every mode. The plugin's
+whole spend-safety story is two settings plus advice: gate flags off by default
+and "fund the keyfile with only what it may spend" (plugin-agentnet README,
+Safety section). The keyfile balance as ceiling is honest but crude: one prompt
+injection on a funded key signs until the balance is gone, with no per-tx cap,
+no allowlist, no audit trail.
+
+Steward is exactly the missing half: a signing service where the key never
+enters the agent process, every signature passes a policy engine, and every
+decision is audited. This doc is the bridge.
+
+## 1. The seam upstream (exists, this repo)
+
+Core never assumed a local keypair:
+
+- `Wallet` is a four-member interface: `address`, `publicKey`, `signMessage`,
+  `signTransaction`/`signAllTransactions`
+  (`packages/core/src/runtime/contract.ts:19`, extending iqlabs-sdk's
+  `WalletSigner`). Everything on-chain routes through the injected `Wallet`.
+- Core deliberately re-exports `SignerInput` instead of declaring its own
+  signer type (`packages/core/src/core/types.ts:7`).
+- The `keypairWallet.ts` header states the design intent: interactive
+  front-ends (Phantom, mobile) implement `Wallet` directly instead of via a
+  Keypair. A remote policy signer is the same move, one more implementation.
+
+So a `stewardWallet` is a drop-in: no core surgery, just a different object
+handed to `connect()` / the stdio bootstrap.
+
+## 2. What Steward ships (exists, steward repo, read at HEAD)
+
+- **Solana signing route**: `POST /vault/:agentId/sign-solana`
+  (`packages/api/src/routes/vault.ts:7622`), reachable through the SDK as
+  `StewardClient.signSolanaTransaction` (`packages/sdk/src/client.ts:2538`,
+  base64 serialized tx in, signature out, optional broadcast). Auth is the
+  agent-scoped token (`requireAgentAccess`); token model is 15m access / 30d
+  agent / 30d refresh, tenant-scoped (`packages/auth/src/jwt.ts`).
+- **Spoof resistance**: caller-supplied `to`/`value` are advisory only. The
+  authoritative policy fields are decoded from the transaction bytes
+  (`parseSolanaTransaction`, `deriveSolanaPolicyFields` in
+  `packages/vault/src/solana-instructions.ts:903`), including `programIds`
+  collected explicitly "for allowed-program style policy" (line 888), plus a
+  priority-fee cap assertion. SPL and Token-2022 transfers are decoded
+  natively (`packages/vault/src/solana.ts:594`).
+- **Fail-closed default**: a transaction whose instructions cannot all be
+  decoded sets `fullyParsed: false` and is refused (`vault.ts:7751`) unless
+  the tenant opts into audited blind signing
+  (`STEWARD_ALLOW_UNSAFE_SOLANA_BLIND_SIGNING`, `vault.ts:194`), which then
+  requires a caller-supplied envelope.
+- **Policy engine**: core rule types include `spending-limit`,
+  `approved-addresses`, `auto-approve-threshold`, `time-window`, `rate-limit`,
+  `contract-allowlist` (`packages/policy-engine/src/policy-rule-registry.ts:50`),
+  with manual-approval flow, spend recording, and audit events on the signing
+  paths (`writeAuditEvent` throughout `vault.ts`).
+- **Eliza precedent**: Steward already ships `@stwd/eliza-plugin` with
+  `sign-transaction`, `transfer`, `check-spend`, `request-approval`,
+  `list-approvals` actions (`packages/eliza-plugin/src/actions/`). Governed
+  signing inside eliza is their own product direction; this idea plugs
+  AgentNet into it rather than inventing a parallel rail.
+
+## 3. Mechanism
+
+`AGENTNET_SIGNER` selects the wallet implementation at the stdio server's
+bootstrap. Default `keyfile` is exactly today's behavior; `steward` swaps in
+the bridge. The plugin already has the forwarding seam: its transport spawns
+the server with `{ ...process.env, ...this.env }` and an overridable command
+(`plugin-agentnet/src/lib/mcp-client.js:23`), and all settings resolve through
+`runtime.getSetting` (README, Config table), so three new pass-through settings
+(`STEWARD_API_URL`, `STEWARD_AGENT_ID`, `STEWARD_AGENT_TOKEN`) ride the
+existing pattern.
+
+```mermaid
+sequenceDiagram
+    participant E as eliza action<br/>(write tier)
+    participant M as agentnet-mcp<br/>AGENTNET_SIGNER=steward
+    participant W as stewardWallet<br/>(bridge, new)
+    participant S as Steward vault<br/>/sign-solana
+    participant P as policy engine
+
+    E->>M: buy_skill (gates + verify pass)
+    M->>M: build tx via chain.ts as today
+    M->>W: wallet.signTransaction(tx)
+    W->>S: POST base64 tx, agent token, broadcast false
+    S->>P: decode bytes, derive to/value/programIds
+    alt policy passes
+        P-->>S: allow (auto-approve under threshold)
+        S-->>W: signature
+        W-->>M: signed tx, core broadcasts
+    else needs approval or violates
+        P-->>S: pending or deny
+        S-->>W: pending id / refusal
+        W-->>M: throws, tool reports the refusal
+    end
+```
+
+The bridge sets `broadcast: false` so core keeps its own send-and-confirm path
+(`chain.ts` singleton via `initChain`) and nothing downstream of signing
+changes. `signAllTransactions` loops `signTransaction`; multi-sig-per-tx flows
+(publish) just make N policy-checked calls.
+
+## 4. Two honest frictions
+
+**Encryption key vs spend key.** Core derives the vault/session encryption key
+from a deterministic ed25519 signature over fixed bytes
+(`wallet.signMessage` into `deriveX25519Keypair`,
+`packages/core/src/core/crypto.ts:22`; the fixed `SESSION_KEY_MESSAGE` is
+visible in `chat/ui/onboarding.ts:234`). Steward is deliberately hostile to
+headless arbitrary-message signing: `sign-message` is disabled by default and
+demands an owner/admin session with recent MFA (`vault.ts:5064`), and
+`sign-raw-digest` needs two unsafe env opt-ins plus MFA plus a
+`raw-signing-chain` policy, and signs a 32-byte digest, not a message
+(`vault.ts:5257`). So the bridge cannot mint the storage key per boot, and
+should not try. The honest v1: a one-time attended ENROLLMENT step per device
+performs the single `signMessage`, derives the x25519 seed, and caches it
+locally (mode 600, same treatment as `tokens/` files in `core/paths.ts`).
+Transaction signing stays per-call and headless. This split is actually the
+right trust shape: Steward governs the capability that moves money; the cached
+seed only decrypts the operator's own session data. A domain-bound
+deterministic sign endpoint under policy would remove the enrollment step, but
+that is a Steward-side feature request, not something to fake around.
+
+**Program decode.** AgentNet's economic transactions are IQ program
+instructions (code-in chunks, inventory writes) plus Token-2022 mints. Steward
+decodes the token layer but not the IQ program, so these transactions land
+`fullyParsed: false` and are refused by default (`vault.ts:7751`). Two exits:
+a Steward-side decoder entry for the IQ program family, which makes
+`programIds` allowlisting plus lamport caps fully honest; or the audited
+blind-signing opt-in with a caller-supplied envelope, acceptable for devnet
+bring-up only, because it reduces Steward to a spend meter on the advisory
+envelope. Say which one a deployment is running. Never present blind-sign
+bring-up as the shipped story.
+
+## 5. Exists today / needs building / needs zo
+
+**Exists today** (verified in source):
+
+- the `Wallet` seam and its explicit foreign-signer intent
+  (`runtime/contract.ts:19`, `keypairWallet.ts` header, `core/types.ts:7`)
+- the stdio server's env-driven bootstrap and the plugin's env forwarding +
+  command override (`mcp-stdio.ts`, `mcp-client.js:23`, README Config)
+- Steward end to end: sign-solana route with byte-derived policy fields and
+  fail-closed parse gate, policy rule set, approvals, audit, SDK method,
+  agent-scoped tokens, and their own eliza plugin precedent (paths in section 2)
+
+**Needs building** (ours, bridge-sized):
+
+- `stewardWallet`: implements `Wallet` over `StewardClient`; address and
+  publicKey from the agent's Solana wallet address, `signTransaction` via
+  sign-solana with `broadcast: false`, `signMessage` served from the
+  enrollment cache, clear errors for pending-approval and policy-refusal
+- the enrollment command (attended, once per device) that mints and caches the
+  encryption seed
+- plugin config rows for the three Steward settings, forwarded to the spawned
+  server like the existing `AGENTNET_*` rows
+
+**Needs zo:**
+
+- `AGENTNET_SIGNER` accepted into the published `@iqlabs-official/agentnet-mcp`
+  bootstrap (keyfile default, steward opt-in), and whether the bridge lives in
+  core as `account/stewardWallet.ts` or stays an external package
+- the double-approval UX call: when Steward policy says manual-approve and the
+  local `PROMPT_BEFORE_USE` card also fires, who is the source of truth
+- whether the CLI/webview surfaces should show "governed wallet" state
+
+**Needs Steward lane** (their repo, their review):
+
+- IQ program decoder entry so AgentNet transactions evaluate as fully parsed
+- optionally, a policy-scoped domain-bound message-sign to retire enrollment
+
+## Shortest path
+
+The bridge package plus a devnet demo, zero upstream changes. The plugin's
+`AGENTNET_MCP_COMMAND` already points at any local build (README, Config), so:
+fork the stdio server's bootstrap locally, swap `localWallet` for
+`stewardWallet` behind `AGENTNET_SIGNER` (the `Wallet` type makes this a
+ten-line change), enroll once, set a Steward `spending-limit` policy of a few
+hundred thousand lamports with blind-signing opt-in ON and labeled as
+bring-up, then run one gated write (a comment post) and one refused overspend.
+The demo proves the three claims that matter: the key never entered the agent
+process, the cap was enforced by the signer not the prompt, and every
+signature left an audit row. That evidence is the argument for both upstream
+asks at once: zo's `AGENTNET_SIGNER` switch and Steward's IQ decoder entry.

--- a/integrations/eliza/ideas/README.md
+++ b/integrations/eliza/ideas/README.md
@@ -1,0 +1,93 @@
+# Eliza x AgentNet: idea docs
+
+Five candidate plans for the AgentNet `plans/` folder, all on the same lane:
+connecting AgentNet (the on-chain skill marketplace and its runtime) with the
+elizaOS ecosystem (the agent framework, its cloud gateway, and Steward's
+governed wallets). Each doc is grounded in code actually read in all three
+repos, separates exists-today from needs-building from needs-zo, and ends with
+the minimal correct increment that ships first. Nothing in this folder is a
+commitment; these are proposals in plans-doc form.
+
+Context: `plugin-agentnet` (sibling folder) is finished and tested. It puts
+AgentNet's tools INTO eliza agents. Ideas 01, 03, and 05 are about the other
+directions of the same relationship; 02 and 04 extend the plugin itself.
+
+Maturity labels: **sketch** = mechanisms verified but the product call is
+open. **grounded** = every seam read in source, increments are PR-sized.
+**partly built** = one or both sides of the bridge already ship.
+
+## The five
+
+| # | Doc | One line | Maturity |
+|---|---|---|---|
+| 01 | [Eliza Cloud auth + models](01-eliza-cloud-auth-and-models.md) | run the existing engines on Eliza Cloud credits via wallet sign-in | grounded |
+| 02 | [AgentNet view in eliza](02-agentnet-view-in-eliza.md) | an AgentNet market panel inside the eliza app | grounded |
+| 03 | [AgentNet as coding subagent](03-agentnet-as-coding-subagent.md) | one thin ACP binary makes AgentNet an eliza coding backend | grounded |
+| 04 | [Character inscription](04-character-inscription.md) | a public on-chain Eliza character, wallet-signed and permanent | sketch |
+| 05 | [Steward-governed wallets](05-steward-governed-wallets.md) | the spend key out of the agent process, policy at the signer | partly built |
+
+**01 Eliza Cloud auth + models.** Eliza Cloud's gateway already speaks both
+engines' wire protocols (an Anthropic-compatible `/v1/messages` and an
+OpenAI-compatible `/v1/chat/completions` with tools), and its SIWS route
+issues an API key from a Solana wallet signature, which the agent already is.
+So a user with no vendor subscription gets a full model suite by signing one
+nonce: env/flag injection at the two existing spawn seams, no third engine,
+no union changes. Gated on two live probes before any PR.
+
+**02 AgentNet view in eliza.** eliza plugins ship UI first-class (view
+bundles, app iframes, `preview` maturity gating), so an AgentNet surface fits
+without shell changes. Two shapes: embed the real webview SPA via the app
+viewer iframe (blocked on zo publishing the sdk and a runnable localhost bin),
+or a native read-tier panel backed by the plugin's tested indexer code, which
+ships today with zero zo dependency.
+
+**03 AgentNet as coding subagent.** eliza's orchestrator drives coding
+backends over ACP, newline JSON-RPC on stdio, and every seam the binary needs
+(runtime, engines, approval channel, headless wallet, session capture) already
+exists in `packages/core`. One new `acp-stdio.ts` entry mirrors the existing
+MCP entry; a demo needs zero upstream changes via the backend command
+override, and every eliza coding run then lands as an encrypted session in a
+wallet.
+
+**04 Character inscription.** The vault soul stays the private master; this
+adds a deliberate, spend-gated public snapshot: an allowlist-sanitized Eliza
+character JSON inscribed via code-in under the wallet's signature, discovered
+through a pointer self-note, adoptable by any foreign Eliza through two public
+gateway routes the plugin already wraps. Every rail exists in core; the open
+question is doctrine (public identity as a product), which is why it is a
+sketch and proposed last.
+
+**05 Steward-governed wallets.** The write tier currently holds a raw keypair
+in the LLM's process; Steward ships a Solana signing route that decodes policy
+fields from the transaction bytes, enforces spending limits and allowlists,
+and audits every signature. Core's `Wallet` interface was built for foreign
+signers, so the bridge is one `stewardWallet` implementation plus an
+`AGENTNET_SIGNER` switch. Two honest frictions are documented: the encryption
+key needs a one-time attended enrollment, and Steward needs an IQ program
+decoder entry before policy is fully honest for AgentNet transactions.
+
+## Suggested order of proposal
+
+1. **03 subagent**: smallest ask with the strongest strategic hook. The demo
+   runs with zero changes to her repos, and the payoff lands directly on her
+   north star: real coding sessions captured to wallets from someone else's
+   deployment.
+2. **01 cloud auth**: removes the vendor-subscription onboarding wall, which
+   is her stated stage-1 pain. Probe-first plan means the proposal arrives
+   with evidence, not speculation.
+3. **02 view**: Shape B ships alone inside the plugin and is a visible win;
+   raising it also motivates the sdk publish that unblocks Shape A, which she
+   has to want anyway for any external host.
+4. **05 steward**: the safety upgrade the write tier genuinely needs, but it
+   spans three repos and two review lanes; bring the devnet demo from its
+   Shortest path as the opener.
+5. **04 inscription**: pure product doctrine (public identity vs private
+   soul). Propose once the plugin relationship is established and the cheaper
+   ideas have built trust; it is a one-tool increment whenever she says yes.
+
+## House rules these docs follow
+
+Terse, mechanism first, mermaid where a flow needs it, no em or en dashes
+anywhere, real file paths only (every citation was read, not guessed), honest
+maturity labels, and a Shortest path section closing each doc with the
+minimal correct increment that ships first.

--- a/integrations/eliza/ideas/agentnet-view-in-eliza.md
+++ b/integrations/eliza/ideas/agentnet-view-in-eliza.md
@@ -1,0 +1,212 @@
+# AgentNet view inside the eliza app
+
+Goal: an AgentNet surface inside the eliza app so an eliza agent's owner can
+see the market, their equipped skills, and their profile without leaving the
+app. Two shapes are possible; both are sketched below with what each really
+needs. plugin-agentnet (the finished read/write plugin) is the carrier for
+either shape.
+
+Status: idea doc. Nothing here is built. Every claim below is grounded in
+code that was actually read; paths cite the elizaOS `develop` worktree
+(`/Users/nubs/Git/eliza-oidc-work`) and the AgentNet worktree (`wt-183`).
+
+## The key fact: eliza plugins ship UI first-class
+
+The plugin contract already carries views, apps, nav tabs, and widgets. No
+shell changes are needed to put a new surface in the app.
+
+- `Plugin.views?: ViewDeclaration[]`
+  (`packages/core/src/types/plugin.ts:1512`). A view is a compiled JS bundle
+  at `bundlePath` (convention `dist/views/bundle.js`), served by the agent at
+  `/api/views/<id>/bundle.js`, dynamically `import()`ed by the shell and
+  mounted via `componentExport` (`packages/ui/src/components/views/DynamicViewLoader.tsx`).
+  Registry: `packages/agent/src/api/views-registry.ts`.
+- Maturity is a declared field: `viewKind: "system" | "release" | "developer"
+  | "preview"` (`packages/core/src/types/view-kind.ts`). `preview` is hidden
+  until the user flips the Settings toggle. A new AgentNet panel ships as
+  `preview`, honestly.
+- `Plugin.app?: PluginApp` + `appBridge?: PluginAppBridge`
+  (`plugin.ts:1063,445`): an "app" with a `viewer: { url, sandbox,
+  postMessageAuth }` iframe embed. `appBridge.prepareLaunch` runs before
+  launch (spawn a process, return the launch URL), `stopRun` tears it down.
+  The shell embeds `viewer.url` through `EmbeddedAppViewer`
+  (`packages/ui/src/components/apps/EmbeddedAppViewer.tsx`, default sandbox
+  `allow-scripts allow-same-origin allow-popups`) with an origin-pinned
+  postMessage auth handshake (`packages/ui/src/components/apps/viewer-auth.ts`).
+- Working reference: plugin-todos declares one view
+  (`plugins/plugin-todos/src/index.ts:23`), builds it with the shared vite
+  config (`packages/scripts/view-bundle-vite.config.ts`; react, `@elizaos/ui`,
+  `lucide-react` stay external, the shell provides them), and the view
+  component fetches its data from a plain agent HTTP route
+  (`TodosView.tsx` reads `GET {base}/api/lifeops/todos`). Plugin `routes`
+  (`Plugin.routes?: Route[]`) are served under the plugin-name prefix.
+
+One restriction to carry honestly: dynamic bundle and frame URLs are filtered
+out on store builds (iOS App Store, Google Play) per the `ViewDeclaration`
+contract comment (`plugin.ts:875`). Both shapes below are web/desktop first.
+
+## Shape A: embed the real AgentNet webview
+
+The webview (`wt-183/surfaces/webview`) is a Vite React SPA served by
+`surfaces/localhost` (`src/index.ts`): a local node process on port 4317
+(`AGENTNET_PORT`) that serves `webview/dist` static and speaks SSE
+`GET /events` + `POST /rpc` with cursor replay
+(`webview/src/transport/client.ts`, all paths origin-relative). The SPA is
+the full product: chat, market, agent directory, profile
+(`webview/src/market/MarketScreen.tsx`, `AgentDirectory.tsx`,
+`SkillDetailView.tsx`).
+
+What it needs at runtime, verified in `surfaces/localhost/src/index.ts`:
+
+- The localhost server process. It boots with NO wallet: a guest device key
+  whose transaction signing fails closed (`deviceGuestWallet`, line 179), so
+  market reads work immediately.
+- A real wallet only for on-chain actions. Two paths exist: browser-extension
+  `connectWallet {address, signature}` (Phantom/Solflare, needs a real
+  browser), or `makeLocalWallet` (line 1114): adopt a device keypair at
+  `~/.config/solana/id.json`, generated if missing, persisted as wallet mode
+  and auto-reconnected on restart (line 1291).
+- Claude/Codex CLIs only for chat. Market browse does not need them.
+
+### How the embed works
+
+The honest first version is the app viewer iframe, not the view registry:
+view-registry `sandboxed-iframe` isolation grants `allow-scripts` but never
+`allow-same-origin` (`packages/ui/src/components/views/SandboxedViewFrame.tsx`,
+`surface-manifest.ts`), which gives the SPA an opaque origin; its relative
+`/events` and `/rpc` calls become cross-origin and `surfaces/localhost` sets
+no CORS headers, so the SPA breaks. The `PluginApp` viewer path keeps the
+SPA on its true `127.0.0.1:4317` origin and everything works as-is.
+
+```mermaid
+sequenceDiagram
+  participant S as eliza app shell
+  participant B as plugin-agentnet appBridge
+  participant L as agentnet-localhost :4317
+  participant W as webview SPA in iframe
+  S->>B: launch app AgentNet
+  B->>L: ensure process (spawn or health check)
+  B-->>S: viewer.url = http://127.0.0.1:4317
+  S->>W: iframe src, sandbox allow-same-origin
+  W->>L: GET /events (client id, SSE)
+  W->>L: POST /rpc ready
+  L-->>W: sessions, wallet, market state
+  W->>L: POST /rpc makeLocalWallet (optional)
+  L-->>W: walletConnected
+```
+
+### Wallet handoff
+
+No protocol needed for v1, the handoff is the filesystem: plugin-agentnet's
+write tier signs with `AGENTNET_WALLET_KEYFILE`, default
+`~/.config/solana/id.json` (plugin README, `src/lib/mcp-client.js` spawn
+env), and the webview's `makeLocalWallet` adopts the same default path. One
+keypair, one AgentNet identity, shared by the agent's actions and the
+embedded UI. A real postMessage handoff (eliza injecting an identity into
+the SPA) has shell support (`PluginAppViewer.postMessageAuth`,
+`resolveViewerAuthMessage`) but no listener in the SPA. That is hers to add.
+
+### What blocks Shape A
+
+`surfaces/localhost` is a private workspace package
+(`surfaces/localhost/package.json`: `"private": true`, depends on
+`@iqlabs-official/agent-sdk` as `workspace:*`). The plugin cannot spawn what
+users cannot install. Until she publishes the sdk plus a runnable
+`agentnet-localhost` bin (or a bundled dist), Shape A only works on machines
+with an AgentNet checkout. Label: blocked on publish.
+
+## Shape B: native read-tier panel
+
+If the full embed is too heavy, a small native panel ships today from
+plugin-agentnet alone, using the read tier that already exists and is
+tested (`src/lib/indexer.js`: `fetchCatalog`, `searchCatalog`,
+`fetchInscription`, `fetchUserProfile`, `fetchUserPosts`;
+`src/lib/chain.js`: `fetchMintMetadata`; `src/lib/skillfile.js`: equipped
+skill listing). No wallet, no localhost server, no AgentNet checkout.
+
+Panel contents, mirroring the webview's market screens at reduced depth:
+
+- Market search: query box over the catalog, tile list (name, supply, price,
+  free/priced badge). Data: indexer.
+- Owned / equipped: the locally equipped AgentNet skills from `skillsDir`,
+  with unequip hint routed to chat (actions stay the agent's job).
+- Profile card: gateway profile + created items for the configured wallet
+  (the write-tier keyfile address when set, else lookup by pasted address).
+
+```mermaid
+flowchart LR
+  subgraph shell [eliza app shell]
+    V[agentnet.market view bundle]
+  end
+  subgraph agent [agent server, plugin routes]
+    R1[GET catalog?q=]
+    R2[GET profile/:wallet]
+    R3[GET equipped]
+  end
+  subgraph net [public AgentNet surfaces]
+    I[nft-index.iqlabs.dev]
+    G[gateway.iqlabs.dev]
+  end
+  V --> R1 --> I
+  V --> R2 --> G
+  V --> R3 --> FS[(skillsDir SKILL.md)]
+```
+
+Mechanism: three GET routes in `Plugin.routes` fronting the existing lib
+functions (the view never talks to the public internet directly, same
+pattern as todos), one React panel component, one vite view-bundle config
+copied from plugin-todos, and a `views` entry:
+
+```
+views: [{
+  id: "agentnet.market",
+  label: "AgentNet",
+  path: "/agentnet",
+  viewKind: "preview",
+  bundlePath: "dist/views/bundle.js",
+  componentExport: "AgentNetPanel",
+  tags: ["market", "skills", "solana"],
+}]
+```
+
+Note: the plugin is currently a local scaffold, so bundle-path resolution
+uses the directory-loaded binding (`bindPluginPackageDirectory`,
+`views-registry.ts`); once it has an npm name, set `Plugin.packageName`.
+
+## Exists today
+
+- eliza: full plugin view system (declaration, registry, serving, dynamic
+  mount, view manager), `viewKind` maturity gating, plugin routes, app
+  viewer iframe with sandbox + postMessage auth, shared view-bundle build.
+- AgentNet: the webview SPA with market/profile/directory screens, the
+  localhost server with guest-mode reads, `makeLocalWallet`, SSE replay.
+- plugin-agentnet: read-tier libs with offline + live tests, config
+  resolution through `runtime.getSetting`, write tier behind gates.
+
+## Needs building (ours)
+
+- Shape B: three read routes + `AgentNetPanel` component + vite view config
+  + `views` declaration in plugin-agentnet. All additive.
+- Shape A: `app` + `appBridge` block in plugin-agentnet (ensure process,
+  health check `GET /`, `stopRun` kill), config for an existing checkout
+  path until publish.
+
+## Needs zo
+
+- npm publish of `@iqlabs-official/agent-sdk` and a runnable
+  `agentnet-localhost` package (hard blocker for Shape A off-machine).
+- CORS headers on `/events` + `/rpc` if she ever wants the sandboxed
+  view-registry embed instead of the app viewer.
+- A postMessage auth/wallet listener in the SPA if identity injection
+  should replace the shared-keyfile handoff.
+- Optional: an `?embed=1` chrome-light mode of the SPA (market only, no
+  chat) for a tighter in-app fit.
+
+## Shortest path
+
+Shape B, market search only: one GET route (`catalog?q=` fronting
+`fetchCatalog` + `searchCatalog`), one panel component with a search box and
+tile list, `viewKind: "preview"`, shipped inside plugin-agentnet. No wallet,
+no new processes, no zo dependency, and the view/route/bundle plumbing it
+proves out is exactly what the owned-skills list, the profile card, and
+later the Shape A launcher build on.

--- a/integrations/eliza/ideas/eliza-character-inscription.md
+++ b/integrations/eliza/ideas/eliza-character-inscription.md
@@ -1,0 +1,215 @@
+# Eliza character inscription: a public on-chain identity, bound to the wallet
+
+> **Status: IDEATION.** Idea doc, written outside the repo. Nothing below is built
+> unless the "exists today" section says so. Companion to
+> `plans/soul-memory-portability.md` (the private persona rail) and
+> `plans/onchain-format/skill-nft-json.md` (the inscription format this reuses).
+
+## 0. The claim
+
+An Eliza character file is the one persona format that is already structured JSON
+(`plans/soul-memory-portability.md` §2 table). That makes it the natural candidate for a
+**public, permanent identity inscription** under the agent wallet: code-in the sanitized
+character JSON, signed by the wallet, readable by anyone via the gateway. Any Eliza
+runtime anywhere can then boot "the agent that wallet X says it is" from chain, with the
+wallet signature as provenance.
+
+The direction is already half-decided in code: the stdio server accepts
+`AGENTNET_ELIZA_CHARACTER` (a character.json path) and merges the vault soul into it at
+inject time (`packages/core/src/vault/inject.ts`, the Eliza branch around line 66). The
+soul to characterfile render exists (`packages/core/src/soul/convert/eliza.ts`,
+`soulToElizaPersona` / `writeElizaCharacter`). What does not exist is the public half:
+today the persona only ever lands in a local file or the encrypted vault.
+
+## 1. Two products. Keep them separate.
+
+| | Vault soul (exists) | Character inscription (this doc) |
+|---|---|---|
+| What | working persona, SOUL.md master | identity claim, sanitized character JSON |
+| Where | encrypted blob `soul` on the user's own storage (`packages/core/src/soul/store.ts`) | code-in inscription on Solana, signed by the wallet |
+| Who reads | the wallet's own runtimes, after `deriveSessionKey` | anyone, `GET {gateway}/data/{sig}` |
+| Mutability | free rewrite, last-writer-wins, `SOUL_TEXT_MAX` 32k | immutable; a new version = a new inscription, paid again |
+| Cost | zero on-chain | rent-dominated, roughly 0.2 SOL per 5KB (see §5) |
+| Right when | the persona is private, still changing, day-to-day identity travel across runtimes | the agent wants a verifiable public self: directories, other agents, provenance |
+
+These are different products, not two grades of the same one. The vault tools were
+deliberately specified as touching **nothing on-chain**
+(`packages/core/src/vault/tools.ts` header), and `soul_set` is a whole-document
+overwrite of a *private* doc. A "public soul" flag on that rail would put one accidental
+tool call between a private persona and a permanent public record. Do not blend them:
+the inscription is an explicit, separately gated, spend-prompted act.
+
+Direction of flow: vault soul stays the master. The inscription is a **snapshot** of the
+Eliza render of that master (or of a hand-maintained character.json), taken deliberately
+at milestones. It is not a sync mechanism.
+
+## 2. The inscription shape
+
+Reuse the decided format wholesale (`plans/onchain-format/skill-nft-json.md` §2): one
+standard NFT JSON with an extension field, stored by `codeIn`
+(`packages/core/src/core/chain.ts`), exactly as `buildItemJson` does for skills
+(`packages/core/src/nft/skill.ts`):
+
+```jsonc
+{
+  "name": "eliza",
+  "description": "Public character of wallet 3Bpj...",
+  "attributes": [
+    { "trait_type": "kind", "value": "eliza-character" }   // the marker
+  ],
+  "character": { /* sanitized Eliza Character JSON, §3 */ }
+}
+```
+
+- `attributes` marker: the existing trait vocabulary is `category` / `skill` /
+  `requiredSkill` (skill-nft-json.md §4/§4b). `kind: eliza-character` is one new
+  repeated-shape trait any JSON reader understands and the indexer could learn later.
+- Extension field `character` instead of `skillText`: same pattern (standard fields plus
+  one extension), different payload. One code-in read returns everything.
+- **No mint.** A character is not a market good: nothing to buy, no supply to rank, no
+  collection to scan. The binding is the code-in signature itself, wallet-signed, plus
+  the pointer row in §4. Skipping the mint also skips 2 txs and the whole Token-2022
+  surface.
+
+## 3. Sanitization: allowlist or nothing
+
+The elizaOS `Character` type carries live secrets: top-level `secrets` and
+`settings.secrets` (`packages/core/src/types/agent.ts` in the elizaOS repo,
+`CharacterSettings`). An inscription is public and permanent, so the sanitizer must be
+an **allowlist**, never a strip-the-bad-keys denylist:
+
+```
+allow: name, username, system, bio, topics, adjectives,
+       style, postExamples, messageExamples
+drop:  secrets, settings, plugins, templates, id,
+       documents, knowledge, everything unrecognized
+```
+
+`plugins` and `settings` leak operational config; `documents`/`knowledge` are bulky and
+may be private; `templates` can be callbacks that do not serialize anyway
+(elizaOS `packages/core/src/schemas/character.ts` notes JSON-loaded characters carry
+strings only). Unrecognized keys drop, fail closed. The existing merge code already
+models the boundary from the other side: `writeElizaCharacter` owns only the persona
+fields and leaves plugins/settings/secrets untouched
+(`packages/core/src/soul/convert/eliza.ts`). The sanitizer is that same field set,
+read direction.
+
+## 4. Binding and discovery
+
+```mermaid
+flowchart LR
+  subgraph private [private rail, exists]
+    SOUL[vault soul blob] -->|soulToElizaPersona| CJ[character.json on disk]
+  end
+  subgraph public [public rail, this doc]
+    CJ -->|sanitize allowlist| SAN[persona-only JSON]
+    SOUL -->|no file? render direct| SAN
+    SAN -->|codeIn, wallet signs| INS[inscription txid]
+    INS -->|self-note meta.kind| ROW[reviews:agent:wallet row]
+  end
+  ROW -->|newest wins| READER[any reader]
+  READER -->|gateway /data/sig| INS
+  READER -->|parseAndValidateCharacter| BOOT[foreign Eliza boots the character]
+```
+
+Two bindings, both already-existing mechanisms:
+
+1. **Signature binding**: the code-in txs are signed by the agent wallet (the code-in
+   program keys inventory per user, `getUserInventoryPda` usage in
+   `packages/core/src/nft/skill.ts`). Nobody else can inscribe *as* the wallet.
+2. **Latest pointer**: a self-note on the wallet's own profile table
+   (`reviews:agent:[wallet]`) carrying `meta: { kind: "eliza-character", sig }`.
+   `postAgentNote` already accepts free-form `meta` and self-notes are ungated
+   (`packages/core/src/notes/notes.ts`, `PostAgentNoteInput.meta`). Newest such note is
+   the current character; older inscriptions remain as free history. Note the MCP
+   `post_blog` tool does NOT pass `meta` (`packages/core/src/skill-market/index.ts`,
+   post_blog handler), so the inscribe tool calls `postAgentNote` directly in core.
+
+Read path for a foreign runtime: wallet -> `{gateway}/user/{pk}/posts` -> newest
+`meta.kind == "eliza-character"` -> `{gateway}/data/{sig}` -> validate with elizaOS
+`parseAndValidateCharacter` (strict top-level schema,
+`packages/core/src/schemas/character.ts`) -> merge persona fields only. The finished
+plugin already has both HTTP halves as tested read-tier code:
+`fetchUserProfile` and `fetchInscription` in `plugin-agentnet/src/lib/indexer.js`.
+
+## 5. Cost, honestly
+
+Measured on mainnet (2026-08-15, two ~4.8KB code-in bodies): **0.429 SOL total, so
+roughly 0.2 SOL per ~5KB body**. The dominant cost is rent on the permanent inscription
+chunk accounts (a ~5KB body is on the order of 100 chunk accounts, each rent-exempt);
+the finalize fee alone measures ~0.004 SOL and badly under-reports. Scale linearly:
+
+- trimmed persona (name/bio/style/system, ~2KB): ~0.1 SOL
+- persona + messageExamples (~5KB): ~0.2 SOL
+- a fat character with long examples (10KB+): 0.4 SOL and up; trim first
+
+Every re-inscription pays the full body again. Consequences: the tool belongs in the
+`PROMPT_BEFORE_USE` spend tier next to `publish_skill`, it should print a size + SOL
+estimate before signing (the chunk math is already exact in `estimatePublishSigns` /
+`chunkCount`, `packages/core/src/nft/skill.ts`), and the recommended rhythm is
+milestone snapshots, not inscribe-on-every-soul_set. Small bodies under the inline
+threshold (~700B, skill-nft-json.md §8) are one tx and nearly free, but a real
+character will not fit there.
+
+## 6. Three shapes considered
+
+- **(A) New item type** (third collection beside skills/workflows, mint per character):
+  heaviest, drags in Token-2022 + collection + market surfaces, and collides with the
+  in-flight marketplace generalization work. Buy/sell semantics are also wrong for an
+  identity. Defer; if characters ever become tradeable templates, that is a different
+  product and can wrap this same inscription later.
+- **(B) Soul variant** (a "public: true" soul): rejected, §1. Breaks the vault's
+  nothing-on-chain contract and puts one flag between private persona and permanent
+  publication.
+- **(C) Plain inscription + marker attribute + pointer self-note**: everything it needs
+  already exists in core (`codeIn`, `buildItemJson` pattern, `postAgentNote` with meta,
+  gateway `/data` + `/user` routes). The indexer learning the `kind` trait is optional
+  polish, not a gate. **Recommended.**
+
+## 7. Exists today / needs building / needs zo
+
+**Exists today** (verified in source):
+- code-in write + read + gateway resolution: `codeIn`, `readCodeIn`,
+  `inscriptionSigOf` (`packages/core/src/core/chain.ts`)
+- the standard NFT JSON + extension-field format and its decided rationale
+  (`plans/onchain-format/skill-nft-json.md`, `buildItemJson` in
+  `packages/core/src/nft/skill.ts`)
+- private persona rail end to end: `SoulStore` (`packages/core/src/soul/store.ts`),
+  `soul_get`/`soul_set` MCP tools (`packages/core/src/vault/tools.ts`),
+  Eliza render + `AGENTNET_ELIZA_CHARACTER` inject (`packages/core/src/soul/convert/eliza.ts`,
+  `packages/core/src/vault/inject.ts`)
+- wallet-keyed public pointer rail: `postAgentNote` self-notes with `meta`
+  (`packages/core/src/notes/notes.ts`)
+- foreign read half: `fetchUserProfile` + `fetchInscription` in the Eliza plugin
+  (`plugin-agentnet/src/lib/indexer.js`), character validation in elizaOS
+  (`packages/core/src/schemas/character.ts`)
+
+**Needs building:**
+- the allowlist sanitizer (§3), shared shape with `soulToElizaPersona`
+- one MCP tool `inscribe_character` on the stdio server: source = the
+  `AGENTNET_ELIZA_CHARACTER` file when set, else the vault soul rendered through
+  `soulToElizaPersona`; sanitize, wrap (§2), `codeIn`, pointer self-note (§4);
+  spend tier, size + SOL estimate before the first signature
+- plugin read action (adopt-by-wallet): resolve pointer, fetch, validate, merge
+  persona fields; ships in the plugin repo independently
+
+**Needs zo:**
+- the marker convention itself (`kind: eliza-character` vs something else): one new
+  trait in a format where every trait so far was a discussion decision
+- indexer support for the marker (separate `agentnet-nft-indexer` repo), if character
+  discovery should ever be searchable rather than wallet-addressed
+- whether the webview/CLI profile page surfaces "this agent has a public character"
+- plans/ acceptance of the split in §1 (public identity vs private soul) as product
+  doctrine
+
+## Shortest path
+
+One spend-gated MCP tool, nothing else. `inscribe_character` reads the character file
+`AGENTNET_ELIZA_CHARACTER` already names (or renders the vault soul through the existing
+Eliza converter), applies the §3 allowlist, wraps it in the §2 JSON, calls `codeIn`, and
+posts the pointer self-note. No mint, no new collection, no soul changes, no indexer
+work, no gateway changes: every rail it touches ships in core today, so the increment
+is one tool plus one sanitizer plus tests. A foreign Eliza can adopt the result the
+same day using two public gateway routes the plugin already wraps. Marker indexing,
+profile-page surfacing, and any tradeable-character product wrap this later without
+reshaping what was inscribed.

--- a/integrations/eliza/ideas/eliza-cloud-model-suite.md
+++ b/integrations/eliza/ideas/eliza-cloud-model-suite.md
@@ -1,0 +1,183 @@
+# Eliza Cloud sign-in + model suite (a metered gateway for the engines)
+
+> **Status: research/idea - no source-code changes here.** Every mechanism claim below was
+> verified by reading the cited files in this repo, the elizaOS repo, and the Steward repo.
+> The two live-probe items in "Shortest path" are the only unverified assumptions, and they
+> are gated first on purpose.
+
+## 0. Thesis
+
+Today both engines run on the USER's own vendor login: claude on their subscription OAuth
+(`packages/core/src/account/claudeAuth.ts`), codex on device auth in `~/.codex`
+(`packages/core/src/account/codexAuth.ts`). A user with neither subscription has a wallet,
+skills, and no brain to run them.
+
+Eliza Cloud (api.elizacloud.ai, source `packages/cloud` in the elizaOS repo) is a billed
+inference gateway with accounts, API keys, and a credit balance - and it already speaks
+BOTH of our engines' wire protocols. Its Solana sign-in issues an API key from a wallet
+signature, and the agent already IS a wallet. So the whole feature collapses to:
+
+> Sign one nonce with the wallet -> hold one `eliza_*` key -> point the EXISTING engines'
+> token traffic at the gateway. One balance, a suite of models, no new engine.
+
+## 1. Where auth enters the engine layer today (this repo, read)
+
+- `packages/core/src/runtime/spawn.ts:167` - the whole engine switch:
+  `opts.cli === "claude" ? claudeEngine(opts) : codexEngine(opts)`. One `Engine`
+  interface, surfaces never import SDK types.
+- claude path: agent SDK `query()` with `pathToClaudeCodeExecutable: resolveExecutable("claude")`;
+  `claudeEnv` is built by spreading `process.env` (spawn.ts:399) explicitly to keep
+  "PATH / ANTHROPIC creds". Env injection is already the designed seam.
+- codex path: spawns `codex app-server --stdio`; `opts.apiKey` becomes
+  `childEnv.OPENAI_API_KEY` (spawn.ts:553). So a key-fed engine ALREADY exists
+  (the "Stage 1 Codex API Key" in `runtime/contract.ts:170`).
+- Process-scoped config overrides on the codex spawn are also proven:
+  `codexMcpFlags()` (spawn.ts:520) injects `-c mcp_servers.<name>...` without touching
+  `~/.codex/config.toml`. The same `-c` mechanism carries `model_providers.*` overrides.
+- Model catalogs are live probes per engine: `runtime/claudeModels.ts`
+  (`supportedModels()` over the SDK control channel) and `runtime/codexModels.ts`
+  (`model/list` JSON-RPC). Both fall back to a static baseline on failure.
+- Key storage precedent: `account/codexAuth.ts` persists an API key at
+  `tokenFile("codex-key")` (`core/paths.ts:29`, mode 600). An eliza key gets the same
+  treatment, `tokens/eliza-cloud.json`.
+- The engine id union `"claude" | "codex"` is baked through
+  `runtime/contract.ts` (startSession, SessionHandle, ChatMessage.cli, SessionMeta,
+  CanonicalSession), `runtime/detect.ts`, prefs, and the CLI `/engine` command
+  (`surfaces/cli/src/commands.ts:22`). Anything that adds a THIRD engine touches all of
+  it - that is why stage 1 below deliberately does not.
+
+## 2. What the gateway offers (elizaOS repo, read at HEAD)
+
+- **Anthropic wire**: `packages/cloud/api/v1/messages/route.ts`. Its header states it is
+  an Anthropic Messages API compatible endpoint, built precisely so Claude Code and
+  Anthropic SDK clients can spend elizaOS Cloud credits without a custom proxy.
+- **OpenAI wire**: `packages/cloud/api/v1/chat/completions/route.ts`. Full agentic
+  shape: `tools`, `tool_choice`, `tool_calls`, streaming, usage-based billing with a
+  20 percent platform markup (stated in the route header).
+- **Responses shim**: `packages/cloud/api/v1/responses/route.ts` exists but its typed
+  request is text-only (no tool passthrough) and it adapts onto the completions handler.
+  Codex must therefore ride the chat wire, not the responses wire. Honest gap, see 5.
+- **Catalog**: `packages/cloud/api/v1/models/route.ts`, OpenAI-format model list, public.
+- **Account + balance**: `packages/cloud/api/v1/api-keys/route.ts` (create returns
+  `plainKey` once), `packages/cloud/api/credits/balance/route.ts` (works with API-key
+  auth), credit reserve + off-path billing per `packages/cloud/api/docs/inference-hot-path.md`.
+- **Sign-in, three doors**:
+  - `api/auth/siws/verify/route.ts`: validates a Sign-In-With-Solana message + ed25519
+    signature, finds-or-creates the user BY WALLET ADDRESS, and issues an API key.
+    This is the door made for us: the agent wallet signs, no browser, no email.
+  - `api/auth/cli-session/*`: a device-style CLI login flow (create, complete in
+    browser, poll), for users who want their existing cloud account instead.
+  - `api/auth/steward-session/route.ts` + `steward-nonce-exchange` + `steward-refresh`:
+    Eliza Cloud already accepts Steward JWTs and syncs the user in.
+
+## 3. Steward's role (steward repo, read)
+
+`packages/auth/src` is a wide identity surface (SIWE guard, passkey, Apple/OAuth/OIDC/SAML,
+email, phone, TOTP; `jwt.ts` defines 15m access / 30d agent / 30d refresh tokens with tenant
+and agent scopes). But Steward has NO inference credit ledger: its balance objects are
+wallet groupings (`packages/db/src/schema.ts`, `digitalAssetAccounts`). And Eliza Cloud
+already consumes Steward JWTs (2 above). Conclusion: Steward is a sign-in provider IN FRONT
+of the same cloud balance, not a second balance layer. We integrate the balance once
+(Eliza Cloud) and get Steward sign-in transitively, for free. Its credential-injecting
+proxy (`packages/proxy/src/index.ts`) is a later option for org-held keys, not stage 1.
+
+## 4. Mechanism: a gateway profile, not a new engine
+
+Both vendor CLIs support pointing their token traffic at a compatible base URL. Claude Code
+via `ANTHROPIC_BASE_URL` + `ANTHROPIC_AUTH_TOKEN` (its documented LLM-gateway mode); codex
+via a `model_providers` entry with `base_url`, `env_key`, `wire_api = "chat"` selected by
+`model_provider` (its documented custom-provider mode, same `-c` override channel we
+already use for MCP). The engines keep doing everything else exactly as now: same
+approval gates, same sandbox, same session jsonl, same inject/resume. Only the HTTPS
+destination of the model calls changes.
+
+```mermaid
+flowchart LR
+    W["agent wallet<br/>(already in core/account)"] -->|"sign SIWS nonce"| V["cloud auth/siws/verify"]
+    V -->|"eliza_* key, shown once"| T["tokens/eliza-cloud.json<br/>(paths.ts tokenFile, 600)"]
+    T --> P["engine profile: eliza-cloud ON"]
+    P -->|"claude spawn: ANTHROPIC_BASE_URL<br/>+ ANTHROPIC_AUTH_TOKEN in claudeEnv"| C1["claude CLI -> gateway /v1/messages"]
+    P -->|"codex spawn: -c model_provider=eliza<br/>-c model_providers.eliza.*"| C2["codex app-server -> gateway /v1/chat/completions"]
+    C1 --> B["one credit balance<br/>credits/balance route"]
+    C2 --> B
+```
+
+Surface work rides existing patterns: merge the gateway `/v1/models` catalog into the
+per-engine pickers with a CLOUD tag (same fallback contract as `claudeModels.ts`), one
+`//ELIZA_` status band on boot (tab 01 already stacks `//WALLET_ //CLAUDE_ //CODEX_
+//STORAGE_` bands, see plans/cli-design-parity.md), a balance line in `/account`.
+`detect.ts` learns that engine + eliza key counts as "ok" even with `no-login`, which is
+the actual user-facing win: onboarding without a vendor subscription.
+
+## 5. Honest risks, checked before code
+
+- **Path mapping is unverified.** The cloud routes mount under `/api/v1/*` in source;
+  what the deployed host exposes at `api.elizacloud.ai` must be probed live before
+  writing a line (Claude Code appends `/v1/messages` to its base URL). Probe-first,
+  per house empiricism.
+- **Claude CLI with key auth.** Claude Code accepts token env auth without subscription
+  OAuth, but the exact behavior of a logged-out CLI + `ANTHROPIC_AUTH_TOKEN` needs one
+  clean-machine test. `claudeModels.ts` supportedModels() should still answer (it is the
+  CLI's own catalog), but verify.
+- **Codex on the chat wire.** `wire_api = "chat"` is codex's supported path for
+  third-party providers, and the gateway's completions route carries tools. Responses-only
+  niceties (native reasoning summaries) may degrade; label the profile beta until a full
+  agentic session is exercised.
+- **Meter accuracy.** `defaultWindow()` (spawn.ts:224) hardcodes per-engine windows when
+  the engine does not report one; gateway model ids may need entries or the context meter
+  lies.
+- **Cost honesty.** Credit reserve per call + 20 percent markup, and an agentic session is
+  MANY calls. Show the balance, never hide the burn.
+- **Positioning.** `claudeAuth.ts` states the product point: your OWN subscription, tokens
+  never proxied off-device. The eliza profile must stay opt-in and additive - a second way
+  to run, never a silent reroute. Reselling vendor models is the gateway's compliance
+  surface, not ours; ours is not lying about where tokens go.
+
+## Exists today
+
+- Engine env/flag seams: `claudeEnv` spread (spawn.ts:399), `opts.apiKey` ->
+  `OPENAI_API_KEY` (spawn.ts:553), `-c` overrides (spawn.ts:520).
+- Key persistence pattern: `account/codexAuth.ts` + `core/paths.ts` tokens dir.
+- Wallet signing in core (the agent identity itself), so SIWS costs no new dependency.
+- Gateway side, all shipped in elizaOS `packages/cloud`: Anthropic wire, OpenAI wire with
+  tools, models catalog, SIWS key issuance, CLI device login, Steward JWT bridge, API-key
+  management, credit balance + billing pipeline.
+- Eliza-side reach into AgentNet already exists as `plugin-agentnet` (read tier live);
+  this idea is the reverse direction: AgentNet consuming eliza inference.
+
+## Needs building (PR-sized, this repo)
+
+- `account/elizaCloudAuth.ts`: SIWS nonce fetch + wallet sign + key store, mirroring
+  `codexAuth.ts` shape (connect, isConnected, key getter, disconnect).
+- A provider profile on `SpawnOpts` (or an env toggle first): inject the two claude env
+  vars and the codex `-c model_providers` flags at the two spawn points.
+- Catalog merge: gateway `/v1/models` -> `ChatModelOption[]` with a CLOUD tag, only when
+  the profile is on.
+- Surfaces: `//ELIZA_` boot band, `/account` balance line, onboarding rung for
+  "no subscription? sign in with your wallet".
+- `detect.ts`: treat engine + eliza key as runnable.
+
+## Needs zo
+
+- Whether the profile is per-session, per-engine, or per-wallet state (session-settings
+  is her active surface).
+- A third FIRST-CLASS engine (a real `"eliza"` in the cli union) is her runtime rework to
+  accept; her claudex branch already reshapes spawn/contract for engine number three, so
+  the union change should ride HER shape, not precede it.
+- Any commercial arrangement with Eliza Cloud (markup share, promoted default, none).
+- Whether marketplace-side LLM calls (validation gate, verify) should meter through the
+  same account.
+
+## Shortest path
+
+Probe, then a two-seam patch. No union changes, no new engine, sessions and approvals
+untouched.
+
+1. Zero-code probe with a personal key: run the stock claude CLI with
+   `ANTHROPIC_BASE_URL` + `ANTHROPIC_AUTH_TOKEN` at the gateway, then codex with the
+   `-c model_providers` override, one real tool-using turn each; confirm output AND a
+   `credits/balance` delta. This settles risks 1-3 with evidence before any PR exists.
+2. If both pass: one small opt-in PR - key file + env/flag injection at the two spawn
+   points behind `AGENTNET_MODEL_GATEWAY=eliza`, README note, `/account` balance line.
+3. Follow-ups in her order: SIWS onboarding rung, catalog merge, boot band, then the
+   first-class engine conversation on top of the claudex shape.

--- a/integrations/eliza/ideas/eliza-subagent-acp.md
+++ b/integrations/eliza/ideas/eliza-subagent-acp.md
@@ -1,0 +1,169 @@
+# Eliza coding sub-agent: AgentNet over ACP
+
+> Idea doc, not a commitment. Make AgentNet a selectable coding backend inside
+> elizaOS's agent orchestrator, next to Claude Code / Codex / opencode / eliza-code.
+> Every path below was read on 2026-08-17 (eliza `develop`, AgentNet working tree),
+> not guessed. Sibling lane: the marketplace plugin (`eliza-lane/plugin-agentnet`)
+> puts our TOOLS into eliza chats; this one puts our RUNTIME under eliza's coding
+> tasks.
+
+## The pitch
+
+Eliza's orchestrator farms coding work out to sub-agent CLIs. The contract is ACP
+(Agent Client Protocol): newline JSON-RPC over a spawned subprocess's stdio. Any
+binary that speaks it becomes a backend an eliza agent can select, drive, approve,
+and verify. We already have the entire runtime such a binary needs: headless wallet,
+engine passthrough (claude/codex on the user's own subscription), encrypted session
+capture to the wallet, NFT skills equipped into the run, skill-shopping MCP. The
+missing piece is ONE thin stdio entry that speaks ACP.
+
+Ship it and every eliza deployment is a potential AgentNet session: their coding
+runs land in a wallet and sync across devices, our skills equip into real work, and
+verified-work gets real material.
+
+## How eliza drives coding sub-agents today
+
+Read from `elizaOS/eliza` develop, `plugins/plugin-agent-orchestrator`.
+
+| Piece | File (under `plugins/plugin-agent-orchestrator/src`) | Mechanism |
+|---|---|---|
+| backend set | `services/task-agent-frameworks.ts` | closed union `SupportedTaskAgentAdapter`: `elizaos / pi-agent / claude / codex / opencode`. Per-backend capability profiles (implementation, research, verification, ... scored 0..1) matched against task signals to auto-pick |
+| selection | `services/coding-backend-routing.ts` | precedence: explicit `framework:` prefix → character routing → operator pin `ELIZA_ACP_DEFAULT_AGENT` → planner guess |
+| gate | `services/task-agent-routing.ts` | `KNOWN_ADAPTER_TYPES` = the same 5. `actions/tasks.ts parseAgentPrefix` drops unknown prefixes as plain text, so a new first-class backend needs a set entry there |
+| spawn | `services/acp-native-transport.ts` | `NativeAcpClient` spawns the backend command with `stdio:["pipe","pipe","pipe"]`, sends `initialize {protocolVersion:1, clientCapabilities:{fs, terminal}}`, then `session/new {cwd, mcpServers}` → `{sessionId}`, then `session/prompt {sessionId, prompt:[{type:"text",text}]}` → `{stopReason}`. Default prompt timeout 300 s |
+| transcript | `services/acp-service.ts` (~3613) | consumes `session/update` notifications, payload under `params.update.sessionUpdate`: `agent_message_chunk`, `agent_thought_chunk`, `plan`, `tool_call` / `tool_call_update` |
+| approvals | `acp-native-transport.ts resolvePermission` | the AGENT asks `session/request_permission {options, toolCall}`; eliza picks an option from its `ApprovalPreset` (`readonly / standard / permissive / autonomous / verifier`, `services/types.ts`). `fs/read_text_file`, `fs/write_text_file`, `terminal/*` are client-side methods gated by the same preset |
+| command | `services/acp-service.ts nativeAgentCommand` | per-type override `ELIZA_<TYPE>_ACP_COMMAND`; defaults: claude → `npx @agentclientprotocol/claude-agent-acp`, codex → `npx @agentclientprotocol/codex-acp`, opencode → `opencode acp`, elizaos → `eliza-code-acp` on PATH |
+| detection | `task-agent-frameworks.ts hasFrameworkBinary` | a backend is "installed" when its binary is on PATH or its `*_ACP_COMMAND` resolves to an executable |
+| conformance | `__tests__/fixtures/fake-acp-agent.mjs` | eliza's own fake agent: the minimal shape a backend must speak (initialize → `{protocolVersion, agentCapabilities, agentInfo}`, session/new → `{sessionId}`, session/prompt → updates then `{stopReason:"end_turn"}`), no LLM |
+
+Two facts worth keeping:
+
+- eliza vendors an opencode FORK as a git submodule
+  (`plugins/plugin-agent-orchestrator/vendor/opencode`, `.gitmodules`) just to have
+  a coding backend it controls. External backends are a first-class concept there,
+  and ACP is the only door.
+- their own comment in `acp-service.ts`: "The elizaOS CLI has no ACP mode; the
+  separately installed eliza-code ACP server is the native adapter." Backends are
+  separate small binaries by design. Ours would be the same shape.
+
+## What we already expose headlessly
+
+| Piece | File (AgentNet) | State |
+|---|---|---|
+| runtime factory | `packages/core/src/index.ts` `connect(wallet) → AgentRuntime` | exists |
+| headless wallet | `packages/core/src/account/localWallet.ts`; bootstrapped with zero UI by `packages/core/src/mcp-stdio.ts` (keyfile env, generate-if-missing) | exists |
+| session drive | `packages/core/src/runtime/contract.ts` `AgentRuntime.startSession → SessionHandle` (`send / onMessage / onTurnEnd / onUsage / interrupt / stop`) | exists |
+| engine passthrough | `packages/core/src/runtime/spawn.ts`: claude via agent-sdk `query()`, codex via `codex app-server --stdio` JSON-RPC; runs on the user's subscription, no API key | exists |
+| approvals seam | `packages/core/src/runtime/approval/channel.ts` `ApprovalChannel`: swappable decision source, the header itself lists "an auto-policy in CI" as an intended channel | exists |
+| skills into runs | `spawn.ts SpawnOpts` `mcpServers / allowedTools / enabledSkills`; the runtime equips owned NFT skills and the skill-shopping MCP per spawn | exists |
+| session capture | runtime auto-saves encrypted pages to wallet storage on every turn end (`contract.ts startSession` contract) | exists |
+| headless stdio precedent | `packages/core/src/mcp-stdio.ts`: an entry an EXTERNAL host spawns; its header already names Eliza as such a host | exists |
+| ACP speaker | nothing in the repo speaks ACP | missing |
+
+## Transport: what is honest, what is not
+
+Three candidate integrations. One survives.
+
+1. **Pty-drive our Ink TUI** (`surfaces/cli`). No. The CLI is a fixed-height
+   repainting frame (`plans/cli-design-parity.md` house rule 2); scraping it is
+   screen-scraping our own product with no protocol, and it breaks on every reskin.
+2. **Bridge eliza to `surfaces/localhost`** (HTTP-RPC + SSE,
+   `surfaces/localhost/src/index.ts`). Real protocol, wrong shape twice over:
+   eliza's `NativeAcpClient` only spawns stdio subprocesses (there is no HTTP
+   client mode in `acp-native-transport.ts`), and the localhost host deliberately
+   boots with NO wallet until a browser POSTs `connectWallet` (index.ts header).
+   Bridging means adding a port, a lifecycle, and an auth story eliza never asked
+   for. localhost stays what it is: the webview / Android host.
+3. **New headless ACP entry over `packages/core`.** Matches eliza's spawn contract
+   exactly and mirrors `mcp-stdio.ts` in shape: stdio JSON-RPC, `localWallet`
+   bootstrap, stdout reserved for the protocol. This is the pick.
+
+```mermaid
+sequenceDiagram
+    participant E as eliza orchestrator<br/>(NativeAcpClient)
+    participant A as agentnet-acp<br/>(new stdio entry)
+    participant R as packages/core<br/>AgentRuntime
+    participant C as claude / codex engine
+
+    E->>A: spawn + initialize {v1, fs, terminal}
+    A-->>E: {protocolVersion, agentInfo}
+    E->>A: session/new {cwd, mcpServers}
+    A->>R: connect(localWallet) once, startSession({cli, cwd})
+    A-->>E: {sessionId}
+    E->>A: session/prompt {text}
+    A->>R: handle.send(text)
+    R->>C: user turn
+    C-->>R: ChatMessage stream
+    A-->>E: session/update (message / thought / tool_call)
+    C->>R: tool wants to run
+    R->>A: ApprovalChannel.request(req)
+    A->>E: session/request_permission {options, toolCall}
+    E-->>A: picked option (preset-resolved)
+    A-->>R: ApprovalDecision
+    R-->>A: onTurnEnd (session auto-saved to wallet storage)
+    A-->>E: {stopReason: "end_turn"}
+```
+
+## The mapping (every seam already exists)
+
+| ACP, eliza side | AgentNet core |
+|---|---|
+| `initialize` | reply `{protocolVersion:1, agentCapabilities, agentInfo}`; engine presence via `runtime/detect.ts detectCli` |
+| `session/new {cwd, mcpServers}` | first call: `connect(localWallet())`; then `runtime.startSession({cli, cwd, ...})`. Forward eliza's `mcpServers` into `SpawnOpts.mcpServers` so the sub-agent inherits the parent's tools (the exact parity eliza built the field for) |
+| `session/prompt {text}` | `handle.send(text)`; resolve `{stopReason:"end_turn"}` on `onTurnEnd` |
+| `session/update` ← | `ChatMessage.role` map: `assistant` → `agent_message_chunk`, `thinking` → `agent_thought_chunk`, `tool` → `tool_call` / `tool_call_update` |
+| `session/request_permission` ← | `AcpApprovalChannel implements ApprovalChannel`: `request()` sends the ask with allow-once / allow-always / deny options; the picked option maps onto `ApprovalDecision.outcome` (`once / always / deny`), `kind:"plan"` requests ride as `plan` updates |
+| `session/cancel` | `handle.interrupt()` (turn stops, session lives) |
+| process close / `session/close` | `handle.stop()`; the log is already in wallet storage |
+
+Because everything routes through `AgentRuntime.startSession`, these ride along with
+zero extra code: encrypted session capture to the operator's wallet + drive
+(resumable later from our CLI / vscode / webview), owned NFT skills equipped into
+the run, skill-shopping MCP when the toggle is on, raw material for verified-work.
+
+## Exists today / needs building / needs zo
+
+**Exists today** (verified above): eliza's whole selection + spawn + transcript +
+approval machinery, including their conformance fixture. Our runtime, engines,
+approval seam, headless wallet, stdio-entry precedent, skills-into-runs.
+
+**Needs building** (ours, small):
+
+1. `packages/core/src/acp-stdio.ts` (bin `agentnet-acp`): the JSON-RPC loop, four
+   request methods (`initialize`, `session/new`, `session/prompt`,
+   `session/cancel`), three update kinds, and `AcpApprovalChannel`. Bootstrap
+   copied from `mcp-stdio.ts` (localWallet → rpc → connect). stdout is protocol,
+   diagnostics to stderr, same rule as the MCP entry.
+2. Engine pick for headless: claude when `detectCli` finds it, else codex; honor a
+   `AGENTNET_ACP_ENGINE` env override.
+3. Approval default: the spawned entry always ASKS (eliza answers from its preset);
+   `autoApprove` only as the documented fallback when the host never responds.
+
+**Needs zo**:
+
+- The positioning call: does AgentNet present itself as a coding backend inside
+  other orchestrators at all? Nothing changes about whose subscription runs the
+  model; what changes is WHO spawns us.
+- Bin naming + npm publish, same lane as `@iqlabs-official/agentnet-mcp`.
+- The eliza-side PR for a first-class `agentnet` entry: one set member in
+  `KNOWN_ADAPTER_TYPES` (`task-agent-routing.ts`), plus adapter union + label +
+  capability profile + `hasFrameworkBinary` + `normalizePreflightAdapterId`
+  (`task-agent-frameworks.ts`) and `DEFAULT_AGENTS` (`acp-service.ts`). Mechanical,
+  but their repo and their review. Not needed for a demo:
+  `ELIZA_ELIZAOS_ACP_COMMAND=agentnet-acp` routes the elizaos slot to us today with
+  zero upstream changes. Honest label: it works but shows as eliza-code in their
+  UI, so it is demo-only, never the shipped story.
+
+## Shortest path
+
+The minimal correct increment is `acp-stdio.ts` speaking exactly what eliza's own
+`fake-acp-agent.mjs` speaks: `initialize`, `session/new`, `session/prompt` with
+`agent_message_chunk` updates and an `end_turn` stop, permissions asked and mapped.
+No plan updates, no `terminal/*`, no resume, one engine, localWallet only. Prove it
+twice: (1) a pipe test driving the binary with the same newline JSON-RPC
+`NativeAcpClient` sends; (2) a local eliza with `ELIZA_ELIZAOS_ACP_COMMAND` pointed
+at it completes one real coding task, and that session then appears in our CLI's
+session list straight from wallet storage. That round trip is the demo AND the
+argument for the upstream adapter PR: registration lands after, with the working
+binary in hand.


### PR DESCRIPTION
A small, self-contained add under a new `integrations/eliza/` folder. Two parts:

**1. The plugin.** A pointer to [`plugin-agentnet`](https://github.com/NubsCarson/plugin-agentnet), an elizaOS plugin that puts AgentNet's tools inside eliza agents. Read tier is public only (search, free equip, profiles); write tier fronts the published `agentnet-mcp` server, double gated off by default. 68 tests, loaded and driven in a real eliza runtime (search hits the live catalog, gated writes refuse). It lives in its own repo and installs as a git dependency, so this PR only links it.

**2. An `ideas/` folder.** Five longer proposal docs for where the eliza lane could go: cloud models, an AgentNet view inside eliza, an agent to agent subagent path, character inscription, and steward governed wallets.

Honest note on the ideas: I had my agent write these up from directions I gave it, grounded in the actual code across the repos. They are proposals, not asks. Take any that interest you, ignore the rest, or point me at your own direction and I will build toward that instead.

Zero build impact: the whole folder sits outside the pnpm workspace globs, so install and CI are untouched.
