### PR TITLE
remoteWallet: optional bearer secret for token-guarded signer endpoints

### DIFF
--- a/packages/core/src/account/remoteWallet.ts
+++ b/packages/core/src/account/remoteWallet.ts
@@ -10,6 +10,11 @@
 //   POST {url}/sign-message      { "message": "<base64>" }
 //                                -> { "signature": "<base64>" }   (optional)
 //
+// Auth: when the signer requires a shared secret (a token-guarded loopback
+// bridge), AGENTNET_WALLET_REMOTE_TOKEN is sent as a standard
+// `Authorization: Bearer <token>` header on every call. Unset means no header,
+// for signers that bind an unguarded loopback port.
+//
 // sign-transaction serializes with requireAllSignatures:false so partial
 // signatures already added by mint/minter keypairs survive the round trip,
 // the same rule webWallet's provider path follows. sign-message is optional
@@ -27,10 +32,14 @@ import type { Wallet } from "../runtime/contract.js";
 // answer with a refusal; holding the socket open is not a protocol state.
 const SIGNER_TIMEOUT_MS = 30_000;
 
-async function postJson(url: string, body: object): Promise<Record<string, unknown>> {
+function authHeaders(token?: string): Record<string, string> {
+  return token ? { Authorization: `Bearer ${token}` } : {};
+}
+
+async function postJson(url: string, body: object, token?: string): Promise<Record<string, unknown>> {
   const res = await fetch(url, {
     method: "POST",
-    headers: { "Content-Type": "application/json" },
+    headers: { "Content-Type": "application/json", ...authHeaders(token) },
     body: JSON.stringify(body),
     signal: AbortSignal.timeout(SIGNER_TIMEOUT_MS),
   });
@@ -48,9 +57,12 @@ async function postJson(url: string, body: object): Promise<Record<string, unkno
   return JSON.parse(text) as Record<string, unknown>;
 }
 
-export async function remoteWallet(url: string): Promise<{ wallet: Wallet; address: string }> {
+export async function remoteWallet(url: string, token?: string): Promise<{ wallet: Wallet; address: string }> {
   const base = url.replace(/\/+$/, "");
-  const res = await fetch(`${base}/pubkey`, { signal: AbortSignal.timeout(SIGNER_TIMEOUT_MS) });
+  const res = await fetch(`${base}/pubkey`, {
+    headers: authHeaders(token),
+    signal: AbortSignal.timeout(SIGNER_TIMEOUT_MS),
+  });
   if (!res.ok) throw new Error(`remote signer at ${base} did not answer /pubkey (${res.status})`);
   const { address } = (await res.json()) as { address?: string };
   if (!address) throw new Error(`remote signer at ${base} returned no address`);
@@ -63,7 +75,7 @@ export async function remoteWallet(url: string): Promise<{ wallet: Wallet; addre
       : (tx as Transaction).serialize({ requireAllSignatures: false, verifySignatures: false });
     const out = await postJson(`${base}/sign-transaction`, {
       transaction: Buffer.from(bytes).toString("base64"),
-    });
+    }, token);
     const signed = Buffer.from(String(out.transaction ?? ""), "base64");
     if (signed.length === 0) throw new Error("remote signer returned no transaction");
     // Copy signatures back onto the caller's object, the way keypairWallet
@@ -82,7 +94,7 @@ export async function remoteWallet(url: string): Promise<{ wallet: Wallet; addre
     async signMessage(msg) {
       const out = await postJson(`${base}/sign-message`, {
         message: Buffer.from(msg).toString("base64"),
-      });
+      }, token);
       const signature = Buffer.from(String(out.signature ?? ""), "base64");
       if (signature.length === 0) throw new Error("remote signer returned no signature");
       return Uint8Array.from(signature);

--- a/packages/core/src/mcp-stdio.ts
+++ b/packages/core/src/mcp-stdio.ts
@@ -15,6 +15,8 @@
 //                            default (~/.config/solana/id.json). Missing file → a new
 //                            keypair is generated there (never overwrites a valid one).
 //   AGENTNET_WALLET_REMOTE   URL of a remote signer endpoint (account/remoteWallet.ts).
+//   AGENTNET_WALLET_REMOTE_TOKEN   optional shared secret for that endpoint, sent
+//                            as an Authorization Bearer header on every call.
 //                            When set, that endpoint holds the key and signs; the
 //                            keyfile is never read or created. Unset keeps the
 //                            keyfile path exactly as before.
@@ -54,6 +56,7 @@ function readOnlyFromEnv(): boolean {
 
 async function main(): Promise<void> {
   const remote = process.env.AGENTNET_WALLET_REMOTE?.trim() || undefined;
+  const remoteToken = process.env.AGENTNET_WALLET_REMOTE_TOKEN?.trim() || undefined;
   const keyfile = process.env.AGENTNET_WALLET_KEYFILE?.trim() || undefined;
   let wallet: Wallet;
   let address: string;
@@ -64,7 +67,7 @@ async function main(): Promise<void> {
   let signer: { wallet: Wallet; address: string } | undefined;
   if (remote) {
     try {
-      signer = await remoteWallet(remote);
+      signer = await remoteWallet(remote, remoteToken);
       console.error(`[agentnet-mcp] signing through the remote signer at ${remote}`);
     } catch (err) {
       console.error(


### PR DESCRIPTION
Rebased onto current main (composes with a4224f3, the keyfile fallback).

Follow-up to #191, found by running the remote signer hook against a real policy vault bridge for the first time (Steward's `@stwd/solana-signer` loopback bridge). That bridge fail-closed requires a shared secret on every call, and `remoteWallet` sent no headers, so the handshake 401s.

With a4224f3 now merged, a 401 no longer crashes the spawn: it falls back to the local keyfile. That makes token support MORE useful, not less: without it, an operator who set `AGENTNET_WALLET_REMOTE` for a token-guarded vault would silently get the local keyfile path instead of their vault. With it, the vault path actually succeeds.

The fix, additive and off by default: when `AGENTNET_WALLET_REMOTE_TOKEN` is set, every signer call (`/pubkey`, `/sign-transaction`, `/sign-message`) carries it as a standard `Authorization: Bearer` header. Unset means no header and behavior identical to today, including the new fallback. It threads through the existing try/catch, so an unreachable OR unauthorized signer both fall back exactly the same way. Standard bearer keeps the client vendor-neutral; the Steward side that accepts bearer is Steward-Fi/steward#559 (merged).

Proven end to end with no workarounds against the token-guarded bridge: full mode boots through the remote wallet, 13 tools, live mainnet search, zero key material on disk. Auth matrix: bare 401, wrong bearer 401, correct bearer 200.
