### PR TITLE
fix(account): keep session meta faithful across re-key; fix 6 red core tests

### DIFF
--- a/packages/core/src/account/migrate.spec.ts
+++ b/packages/core/src/account/migrate.spec.ts
@@ -73,9 +73,11 @@ describe("account/migrate — session re-key between wallets", () => {
     // A fresh store under B reads everything back — identity fields and full transcript.
     const dst = storeFor(walletB);
     const listed = await dst.listMine();
-    expect(listed.map((s) => s.sessionId)).toEqual(["s1", "s2"]); // ts-desc order
-    expect(listed[0]).toMatchObject({ title: "long session", cli: "claude", ts: 2000, lastDevice: { id: "device-A", label: "Device A" } });
-    expect(listed[1]).toMatchObject({ title: "short session", cli: "claude", ts: 1000 });
+    expect(listed.map((s) => s.sessionId)).toEqual(["s1", "s2"]); // last-activity ts, desc
+    // listMine reports LAST-ACTIVITY ts (the newest message's ts), not the meta creation
+    // ts; the meta ts is preserved on disk and still comes back via load() below.
+    expect(listed[0]).toMatchObject({ title: "long session", cli: "claude", ts: msg(over - 1).ts, lastDevice: { id: "device-A", label: "Device A" } });
+    expect(listed[1]).toMatchObject({ title: "short session", cli: "claude", ts: msg(2).ts });
 
     const srcS1 = await storeFor(walletA).load("s1");
     const dstS1 = await dst.load("s1");

--- a/packages/core/src/account/migrate.ts
+++ b/packages/core/src/account/migrate.ts
@@ -36,6 +36,12 @@ export async function migrateSessions(
         report.skipped += 1;
         continue;
       }
+      // Write the SOURCE's stored meta (load(): newest readable page wins) into the
+      // destination, not the listMine row: listMine derives ts from last activity
+      // (store.ts lastActivityTs), so stamping ITS ts into the copy would replace the
+      // session's stored creation ts. load()'s meta is the stored truth, ts/model/
+      // effort included, which keeps the copy meta-faithful to the source.
+      const { messages: _msgs, ...srcMeta } = session;
       let start = 0;
       if (existing.has(meta.sessionId)) {
         const current = await destination.load(meta.sessionId);
@@ -53,10 +59,10 @@ export async function migrateSessions(
         start = current.messages.length; // resume: append only the missing tail
       }
       if (session.messages.length === 0) {
-        await destination.recordMeta(meta); // meta-only session still shows up in lists
+        await destination.recordMeta(srcMeta); // meta-only session still shows up in lists
       } else {
         for (const m of session.messages.slice(start)) {
-          await destination.appendMessage(meta, m);
+          await destination.appendMessage(srcMeta, m);
           report.messages += 1;
         }
       }

--- a/packages/core/src/chat/session.spec.ts
+++ b/packages/core/src/chat/session.spec.ts
@@ -42,10 +42,12 @@ const flush = async () => {
 // Wait for a specific notice to be sent. `/init` does real fs writes before sending the
 // notice, so the notice is the completion signal — polling for it is deterministic where a
 // fixed microtask flush races the fs IO under full-suite load. Throws if it never arrives.
+// 5ms ticks give a ~2s budget: some paths (/skills via ownedSkillsMsg) await a slow
+// dynamic import (skillSource, ~400ms cold) first — same rationale as waitForType below.
 const waitForNotice = async (transport: any, text: string) => {
-  for (let i = 0; i < 200; i++) {
+  for (let i = 0; i < 400; i++) {
     if (transport.send.mock.calls.some((c: any[]) => c[0]?.type === "notice" && c[0]?.text === text)) return;
-    await new Promise((r) => setTimeout(r, 0));
+    await new Promise((r) => setTimeout(r, 5));
   }
   throw new Error(`notice "${text}" was never sent`);
 };
@@ -367,7 +369,7 @@ describe("chat/session — slash commands", () => {
 
     fromUI({ type: "slashCommand", command: "resume" });
     await flush();
-    expect(transport.send).toHaveBeenCalledWith({ type: "sessions", list: [], activeId: undefined, cloud: "none" });
+    expect(transport.send).toHaveBeenCalledWith({ type: "sessions", list: [], activeId: undefined, running: [], cloud: "none" });
     expect(transport.send).toHaveBeenCalledWith({ type: "notice", text: "Resume: open a session from History." });
   });
 
@@ -401,13 +403,17 @@ describe("chat/session — slash commands", () => {
     const { fromUI, transport } = harness({ ownedSkills: ["clean-code"] });
 
     fromUI({ type: "slashCommand", command: "skills" });
-    await flush();
+    // ownedSkillsMsg awaits a dynamic import (skillSource, for catalog meta) before it
+    // replies, so a fixed flush races it; the trailing "Skills refreshed." notice is the
+    // completion signal (it is sent after the ownedSkills frame on the same await chain).
+    await waitForNotice(transport, "Skills refreshed.");
     expect(transport.send).toHaveBeenCalledWith({
       type: "ownedSkills",
       names: ["clean-code"],
       mints: {},
       disposedMints: {},
       workflowMints: [],
+      meta: {},
     });
   });
 

--- a/packages/core/src/core/dasSource.spec.ts
+++ b/packages/core/src/core/dasSource.spec.ts
@@ -19,7 +19,7 @@ describe("core/dasSource", () => {
     vi.unstubAllGlobals();
   });
 
-  it("falls back to the public-devnet default when no RPC is configured (issue #23)", async () => {
+  it("falls back to the public-mainnet default when no RPC is configured (issue #23)", async () => {
     process.env[SKILLS] = "SkiLLCoLLecTion1111111111111111111111111111";
     let calledUrl = "";
     vi.stubGlobal("fetch", vi.fn().mockImplementation(async (url: string) => {
@@ -27,10 +27,10 @@ describe("core/dasSource", () => {
       return { json: async () => ({ result: { items: [] } }) };
     }));
     await expect(dasSource.listSkills()).resolves.toEqual([]);
-    expect(calledUrl).toContain("devnet"); // resolveRpcUrl() supplied the default
+    expect(calledUrl).toContain("mainnet"); // resolveRpcUrl() supplied the default
   });
 
-  // (No "no collection mint" test: seed.ts ships default devnet collection ids,
+  // (No "no collection mint" test: seed.ts ships default mainnet collection ids,
   // so a collection is always configured unless explicitly overridden.)
 
   it("builds a getAssetsByGroup(collection) request and parses items into Skill[]", async () => {

--- a/packages/core/src/core/seed.spec.ts
+++ b/packages/core/src/core/seed.spec.ts
@@ -42,7 +42,7 @@ describe("core/seed", () => {
     });
 
     it("matches the gateway to the RPC's network", () => {
-      // a mainnet RPC must map to the mainnet gateway even though the static NETWORK is devnet
+      // a devnet RPC must map to the devnet gateway even though the static NETWORK is mainnet
       expect(getGatewayUrl(networkFromRpcUrl("https://api.mainnet-beta.solana.com"))).toBe(
         ENDPOINTS.mainnet.gateway
       );
@@ -52,8 +52,8 @@ describe("core/seed", () => {
     });
 
     it("falls back to the static network for an unrecognized host", () => {
-      // no network token in the host -> static switch (devnet in this build)
-      expect(networkFromRpcUrl("https://my-private-node.example.com/rpc")).toBe("devnet");
+      // no network token in the host -> static switch (mainnet in this build)
+      expect(networkFromRpcUrl("https://my-private-node.example.com/rpc")).toBe("mainnet");
     });
   });
 });

--- a/packages/core/src/core/skillSource.spec.ts
+++ b/packages/core/src/core/skillSource.spec.ts
@@ -74,7 +74,7 @@ describe("core/skillSource — dasSource", () => {
     await expect(dasSource.listSkills()).rejects.toThrow(/DAS getAssetsByGroup failed/);
   });
 
-  it("falls back to the public-devnet default when no RPC is configured (issue #23)", async () => {
+  it("falls back to the public-mainnet default when no RPC is configured (issue #23)", async () => {
     delete process.env.DAS_RPC_URL;
     delete process.env.SOLANA_RPC_URL;
     let calledUrl = "";
@@ -84,10 +84,10 @@ describe("core/skillSource — dasSource", () => {
     }));
     // no throw — resolveRpcUrl() supplies the default (a Helius key would win if set)
     await expect(dasSource.listSkills()).resolves.toEqual([]);
-    expect(calledUrl).toContain("devnet"); // the public-devnet default
+    expect(calledUrl).toContain("mainnet"); // the public-mainnet default
   });
 
-  // (No "no collection mints" test: seed.ts now ships default devnet collection
+  // (No "no collection mints" test: seed.ts now ships default mainnet collection
   // ids, so a collection is always configured unless explicitly overridden.)
 });
 

--- a/packages/core/src/skill-market/index.spec.ts
+++ b/packages/core/src/skill-market/index.spec.ts
@@ -129,7 +129,9 @@ describe("skill-market", () => {
     vi.mocked(searchSkills).mockResolvedValue([]);
     const result = await handleToolCall(mockConn, signer, "defaultCreator", "search_skills", {});
     expect(result.content[0].text).toContain("No matching skills found");
-    expect(searchSkills).toHaveBeenCalledWith(mockConn, { filters: { keyword: undefined, category: undefined, type: undefined } });
+    // objectContaining: the handler also passes an optional `source` (set only when no
+    // Helius key is configured, e.g. in CI), which is incidental to this assertion about filters.
+    expect(searchSkills).toHaveBeenCalledWith(mockConn, expect.objectContaining({ filters: { keyword: undefined, category: undefined, type: undefined } }));
   });
 
   it("search_skills formats results", async () => {


### PR DESCRIPTION
While adding a CI test gate (follow-up PR), the core suite turned out to have 6 pre-existing failures on main. I triaged each with git evidence: five were stale tests, and one was a real bug they were masking.

## The real bug: re-key drops stored session meta

`migrateSessions` copied each session using the `listMine()` row's meta. Since "Sort sessions by last activity, not creation time" (5dd96f0), that row's `ts` is a DERIVED last-activity value, not the stored creation ts. So every re-key (wallet switch, guest unlock) stamped the last-activity ts into the destination pages, overwriting the session's real stored creation ts and dropping `model`/`effort`. That violates the module's own contract ("Meta ... is written verbatim into each destination page, so identity and ordering survive the copy").

Fix: write the loaded session's own stored meta (`load()` returns the truth from the newest readable page) instead of the `listMine` row. The migrate idempotency, resume, and guest-unlock tests all still pass.

## The 5 stale tests (deliberate code changes, specs missed)

- `dasSource` / `skillSource` / `seed`: `NETWORK` was flipped devnet -> mainnet in 57259b0 for the shipped mainnet deployment; the specs still asserted devnet. Updated to mainnet.
- `session` `/resume`: the sessions frame gained a `running` field (f85a6df); expectation updated.
- `session` `/skills`: `ownedSkills` gained a `meta` field and an unconditional cold import (ae5bf53); the test now waits on the completion notice and expects `meta`.

Full core suite after this: 317/317. No behavior change beyond the migrate fix; the rest is test-only.

Follow-up PR adds the CI gate so this cannot drift silently again.
