### PR TITLE
webview: responsive desktop layout in one codebase, plus an off screen overlay fix

### DIFF
--- a/surfaces/webview/src/App.tsx
+++ b/surfaces/webview/src/App.tsx
@@ -11,7 +11,7 @@ import { TabBar } from "./shell/TabBar";
 import { WelcomeTutorial } from "./unlock/WelcomeTutorial";
 import { StarterTemplates } from "./unlock/StarterTemplates";
 import { Alert } from "./Alert";
-import { useVisualViewportVars, useKeyboardChrome } from "./layoutEffects";
+import { useVisualViewportVars, useKeyboardChrome, useIsDesktop } from "./layoutEffects";
 import { useEffect, useRef, useState, type PointerEvent } from "react";
 import { syncAgentService, notifyApproval, clearApprovalNotice, ensureBackgroundConsent, notifyTurnComplete } from "./platform/agentService";
 import { haptics } from "./haptics";
@@ -261,7 +261,10 @@ function TabShell() {
     : Math.max(0, Math.min(1, drawerDrag / drawerWidth));
 
   // Drawer push: the whole surface slides right (no shrink/rounding — reads as a panel).
-  const surfaceTx = drawerProgress * drawerWidth;
+  // On desktop the drawer OVERLAYS instead (index.css raises it above the surface):
+  // pushing a full-width desktop surface would shove the content area off the window.
+  const desktop = useIsDesktop();
+  const surfaceTx = desktop ? 0 : drawerProgress * drawerWidth;
   // Pager: the 400%-wide track sits at -idx*25%, plus the live drag offset.
   const tabPosition = Math.max(0, Math.min(LAST, idx - pageDrag / vw));
   const goToTab = (i: number) => { setIdx(i); changeDrawer(false); };

--- a/surfaces/webview/src/index.css
+++ b/surfaces/webview/src/index.css
@@ -151,6 +151,24 @@ body {
   overscroll-behavior: none;
 }
 
+/* Responsive: the surface is a phone-first, full-bleed layout (pager is width:400%,
+   cards sized for ~a phone column). On the Android shell and narrow windows that is
+   exactly right, so nothing changes below the phone breakpoint. In the tablet /
+   half-screen band (560px to 1023px) a full-bleed phone layout smears edge to edge; cap
+   #app to a centered phone-width column with a subtle frame so it reads as
+   intentional. From 1024px up the app switches to a real desktop layout (left nav
+   rail + wide content, see the desktop block near the shell rules), so the cap
+   must NOT apply there. */
+@media (min-width: 560px) and (max-width: 1023.98px) {
+  body { background: #05070a; }
+  #app {
+    max-width: 460px;
+    margin-inline: auto;
+    border-inline: 1px solid var(--an-line);
+    box-shadow: 0 0 90px rgba(0, 0, 0, 0.6);
+  }
+}
+
 .unlock-sheet { animation: unlock-sheet-in var(--dur-screen) var(--ease-emphasized-decelerate); }
 .unlock-pop { animation: unlock-pop var(--dur-celebrate) var(--ease-emphasized-decelerate); }
 .unlock-gate-reveal { animation: unlock-gate-reveal 520ms var(--ease-emphasized-decelerate) var(--unlock-delay) both; }
@@ -2076,4 +2094,85 @@ html[data-keyboard="open"] .an-shell-panels::after { display: none; }
 }
 @media (prefers-reduced-motion: reduce) {
   .cmp-wrap, .cmp-label, .unlock-sheet, .unlock-pop, .unlock-gate-reveal, .unlock-badge-open, .unlock-denied-in, .unlock-flicker, .unlock-reward { animation-duration: 0.01ms; animation-delay: 0ms; }
+}
+
+/* ── Desktop (≥1024px) ──────────────────────────────────────────────────────
+   Same components, desktop layout: one codebase, media queries only. The
+   floating bottom NAV_DOCK becomes a persistent LEFT rail (TabBar.tsx flips its
+   sliding indicator to translateY and publishes --tabbar-height as 0 up here, so
+   every "clear the bottom dock" inset naturally collapses); the pager fills the
+   remaining width. Long-form content gets a readable centered column; card lists
+   flow into multi-column grids instead of smearing a phone column edge to edge.
+   Nothing in this block runs below 1024px; phone/tablet stay byte-identical. */
+@media (min-width: 1024px) {
+  /* shell = [ nav rail | active screen ] */
+  .an-app-surface { flex-direction: row; }
+  .an-tabbar-shell {
+    position: static;
+    order: -1;            /* DOM keeps panels-then-nav; the rail renders left */
+    width: 168px;
+    flex: none;
+    align-self: stretch;
+    border-right: 1px solid var(--an-line);
+    background: var(--an-bg-0);
+  }
+  /* Typing must not hide the rail; the keyboard-chrome rule is a phone concern. */
+  html[data-keyboard="open"] .an-tabbar-shell { display: block; }
+  html[data-keyboard="open"] .an-shell-panels::after { display: none; }
+
+  /* NAV_DOCK → vertical rail: same bar, brackets, glyphs and engine-tinted
+     indicator; segments stack and the indicator slides on Y (TabBar.tsx). */
+  .an-navdock-shell { padding: 18px 14px 0; }
+  .an-navdock { width: 100%; }
+  .an-navdock-bar { flex-direction: column; height: auto; }
+  .an-navdock-ind { width: 100%; height: 25%; }
+  .an-navseg {
+    flex: none;
+    height: 62px;
+    border-left: none;
+    border-top: 1px solid color-mix(in srgb, var(--an-fg) 12%, transparent);
+  }
+  .an-navseg:first-child { border-top: none; }
+
+  /* No floating dock ⇒ no bottom glass to fade into. */
+  .an-shell-panels::after { display: none; }
+
+  /* Chat drawer: overlay from the left instead of pushing the surface (App.tsx keeps
+     the surface still on desktop). Same panel, just stacked above with an edge. */
+  .an-drawer-base {
+    z-index: 30;
+    border-right: 1px solid var(--an-line);
+    box-shadow: 24px 0 60px rgba(0, 0, 0, 0.55);
+    animation: an-drawer-overlay-in var(--dur-screen) var(--ease-emphasized-decelerate);
+  }
+
+  /* Chat: the log already centers on max-w-2xl; the floating controls
+     (marquee / approval dock / composer) follow the same readable column. */
+  .an-chat-float > * { width: 100%; max-width: 42rem; margin-inline: auto; }
+
+  /* Market / Skills / Rank screens: a wide but bounded content column. */
+  .an-screen { width: 100%; max-width: 1120px; margin-inline: auto; }
+
+  /* Skill-card tiles: keep tile size sane and let the count grow with width. */
+  .an-cardgrid { grid-template-columns: repeat(auto-fill, minmax(168px, 1fr)); }
+
+  /* Rank: a comfortable centered column; the agent-card list becomes a 2-up grid
+     (space-y margins are a phone-stack concern — the grid gap replaces them). The
+     trading cards are drawn for a ~350px phone column: their fixed aspect-ratio
+     would balloon a wide card's height, so height follows content instead. */
+  .an-rankcol { max-width: 880px; margin-inline: auto; }
+  .an-agentgrid {
+    display: grid;
+    grid-template-columns: repeat(auto-fill, minmax(400px, 1fr));
+    gap: 10px;
+  }
+  .an-agentgrid > * { margin-top: 0 !important; }
+  .an-ac { aspect-ratio: auto; }
+  .an-ac-ava { min-height: 96px; }
+}
+
+/* Desktop drawer overlay entrance (used only inside the ≥1024px block above). */
+@keyframes an-drawer-overlay-in {
+  from { transform: translateX(-24px); opacity: 0; }
+  to   { transform: translateX(0); opacity: 1; }
 }

--- a/surfaces/webview/src/index.css
+++ b/surfaces/webview/src/index.css
@@ -1061,6 +1061,7 @@ body {
   letter-spacing: 1.5px;
 }
 .an-navdock-status .dim { color: #6e6e72; }
+.an-navdock-status .an-navdock-kana { display: none; } /* desktop rail only, see the >=1024px block */
 .an-navdock-status .sig { color: #5e5e62; }
 .an-navdock-status .sig b { color: #cfcfcf; }
 .an-navdock-status .sig i { color: #2c2c2f; font-style: normal; }
@@ -2134,6 +2135,19 @@ html[data-keyboard="open"] .an-shell-panels::after { display: none; }
      bottom edge instead of hanging open mid-rail; the indicator is one fixed
      56px segment (25% of a full-height bar would balloon). */
   .an-navdock-shell { display: flex; flex-direction: column; padding: 14px 10px 0; }
+
+  /* The rail's NAV_DOCK line gets its kana sub, same title + kana idiom as the
+     screen headers (MY SKILLS / マイスキル). Second line, so the status row
+     stacks instead of spreading. */
+  .an-navdock-status { flex-direction: column; align-items: flex-start; gap: 2px; }
+  .an-navdock-status .an-navdock-kana {
+    display: block;
+    font-family: "Noto Sans JP", ui-sans-serif, sans-serif;
+    font-weight: 400;
+    font-size: 8px;
+    letter-spacing: 1px;
+    color: #5a5a5d;
+  }
   .an-navdock { display: flex; flex-direction: column; flex: 1; min-height: 0; width: 100%; }
   .an-navdock-bar { flex-direction: column; height: auto; flex: 1; }
   .an-navdock-ind { width: 100%; height: 56px; }
@@ -2164,14 +2178,19 @@ html[data-keyboard="open"] .an-shell-panels::after { display: none; }
      (marquee / approval dock / composer) follow the same readable column. */
   .an-chat-float > * { width: 100%; max-width: 42rem; margin-inline: auto; }
 
-  /* Market / Skills / Rank screens: a wide but bounded content column. */
-  .an-screen { width: 100%; max-width: 1120px; margin-inline: auto; }
+  /* Market / Skills / Rank screens: a wide but bounded content column. The screens
+     paint Tailwind zinc-950 (#09090b), one shade off the app ground (--an-bg-0,
+     #0a0b0d). Full-bleed on phone that never shows; here the capped column exposes
+     both blacks side by side as a seam, so the screen takes the ground token. */
+  .an-screen { width: 100%; max-width: 1120px; margin-inline: auto; background: var(--an-bg-0); }
 
-  /* Rank reads best as a narrower column (the trading cards are ~phone-width
-     artwork), so the whole screen — header included — shares one 880px axis.
-     The header's phone padding (14px) is trued up to the body's 12px so the
-     "AGENT RANK" title and the card edges sit on the same line. */
-  .an-screen-rank { max-width: 880px; }
+  /* Rank reads best as one narrow column (the trading cards are ~phone-width
+     artwork): 584px = the 560px card plus the px-3 gutters, so the header,
+     hero, search bar, and list cards all share a single axis (see the rank
+     rules further down). The header's phone padding (14px) is trued up to the
+     body's 12px so the "AGENT RANK" title and the card edges sit on the same
+     line. */
+  .an-screen-rank { max-width: 584px; }
   .an-screen-rank > header { padding-inline: 12px; }
 
   /* Skill-card tiles: keep tile size sane and let the count grow with width. */
@@ -2182,15 +2201,15 @@ html[data-keyboard="open"] .an-shell-panels::after { display: none; }
      gaps). Solid backstop over the button + inset, fading out across the pt-8 zone. */
   .an-cta-float { background: linear-gradient(to top, var(--an-bg-0) 70px, transparent); }
 
-  /* Rank: the agent-card list becomes a 2-up grid (space-y margins are a
-     phone-stack concern — the grid gap replaces them). The trading cards are
-     drawn for a ~350px phone column: their fixed aspect-ratio would balloon a
-     wide card's height, so height follows content instead. The pinned "YOU"
-     hero keeps trading-card proportions rather than stretching its stars gauge
-     across the whole column. */
-  .an-ac.is-self { max-width: 560px; }
-  /* Same treatment for the profile detail's portrait ID card: capped so its
-     stat leaders and stars gauge keep card proportions on a wide screen. */
+  /* Rank reads as a single centered leaderboard column: the screen cap above
+     (584px = a 560px card + the px-3 gutters) makes the header, the pinned
+     "YOU" hero, the search bar, and every list card the exact same width on
+     one axis, whatever the agent count. The cards are drawn for ~a phone
+     column, so 560px keeps their proportions without any per-card capping;
+     their fixed aspect-ratio would still balloon the height, so height
+     follows content instead. */
+  /* The profile detail's portrait ID card: capped so its stat leaders and
+     stars gauge keep card proportions on a wide screen. */
   .an-id { max-width: 600px; }
   .an-agentgrid {
     display: grid;

--- a/surfaces/webview/src/index.css
+++ b/surfaces/webview/src/index.css
@@ -2136,6 +2136,9 @@ html[data-keyboard="open"] .an-shell-panels::after { display: none; }
     border-top: 1px solid color-mix(in srgb, var(--an-fg) 12%, transparent);
   }
   .an-navseg:first-child { border-top: none; }
+  /* Close the stack: the last segment gets the same separator underneath, so
+     MARKET does not bleed into the empty rail below it. */
+  .an-navseg:last-child { border-bottom: 1px solid color-mix(in srgb, var(--an-fg) 12%, transparent); }
 
   /* No floating dock ⇒ no bottom glass to fade into. */
   .an-shell-panels::after { display: none; }

--- a/surfaces/webview/src/index.css
+++ b/surfaces/webview/src/index.css
@@ -2110,7 +2110,7 @@ html[data-keyboard="open"] .an-shell-panels::after { display: none; }
   .an-tabbar-shell {
     position: static;
     order: -1;            /* DOM keeps panels-then-nav; the rail renders left */
-    width: 168px;
+    width: 116px;
     flex: none;
     align-self: stretch;
     border-right: 1px solid var(--an-line);
@@ -2125,13 +2125,13 @@ html[data-keyboard="open"] .an-shell-panels::after { display: none; }
      bracket frame stretches to the rail's full height so the box closes at the
      bottom edge instead of hanging open mid-rail; the indicator is one fixed
      62px segment (25% of a full-height bar would balloon). */
-  .an-navdock-shell { display: flex; flex-direction: column; padding: 18px 14px 0; }
+  .an-navdock-shell { display: flex; flex-direction: column; padding: 14px 10px 0; }
   .an-navdock { display: flex; flex-direction: column; flex: 1; min-height: 0; width: 100%; }
   .an-navdock-bar { flex-direction: column; height: auto; flex: 1; }
-  .an-navdock-ind { width: 100%; height: 62px; }
+  .an-navdock-ind { width: 100%; height: 56px; }
   .an-navseg {
     flex: none;
-    height: 62px;
+    height: 56px;
     border-left: none;
     border-top: 1px solid color-mix(in srgb, var(--an-fg) 12%, transparent);
   }

--- a/surfaces/webview/src/index.css
+++ b/surfaces/webview/src/index.css
@@ -160,6 +160,7 @@ body {
    rail + wide content, see the desktop block near the shell rules), so the cap
    must NOT apply there. */
 @media (min-width: 560px) and (max-width: 1023.98px) {
+  /* A hair darker than --an-bg-0 so the centered framed column reads as lifted. */
   body { background: #05070a; }
   #app {
     max-width: 460px;
@@ -1190,6 +1191,13 @@ body {
   padding-bottom: calc(var(--tabbar-height, 0px) + max(0.75rem, env(safe-area-inset-bottom)));
 }
 
+/* Pinned CTA over a detail scroll (Buy / Remove / Re-equip): the content fades out
+   under a translucent wash; on phone the floating dock covers the strip below the
+   button, so the wash can stay light. Desktop solidifies it (see the ≥1024px block). */
+.an-cta-float {
+  background: linear-gradient(to top, color-mix(in srgb, var(--an-bg-0) 60%, transparent), transparent);
+}
+
 /* Floating chat controls: the layer around the composer stays transparent so messages
    move behind it. The controls themselves are opaque surfaces. */
 .an-chat-float {
@@ -2124,7 +2132,7 @@ html[data-keyboard="open"] .an-shell-panels::after { display: none; }
      indicator; segments stack and the indicator slides on Y (TabBar.tsx). The
      bracket frame stretches to the rail's full height so the box closes at the
      bottom edge instead of hanging open mid-rail; the indicator is one fixed
-     62px segment (25% of a full-height bar would balloon). */
+     56px segment (25% of a full-height bar would balloon). */
   .an-navdock-shell { display: flex; flex-direction: column; padding: 14px 10px 0; }
   .an-navdock { display: flex; flex-direction: column; flex: 1; min-height: 0; width: 100%; }
   .an-navdock-bar { flex-direction: column; height: auto; flex: 1; }
@@ -2168,6 +2176,11 @@ html[data-keyboard="open"] .an-shell-panels::after { display: none; }
 
   /* Skill-card tiles: keep tile size sane and let the count grow with width. */
   .an-cardgrid { grid-template-columns: repeat(auto-fill, minmax(168px, 1fr)); }
+
+  /* Pinned detail CTA: no floating dock hides the strip under the button here, so
+     the scrolled text bled through the translucent wash (and the button's bracket
+     gaps). Solid backstop over the button + inset, fading out across the pt-8 zone. */
+  .an-cta-float { background: linear-gradient(to top, var(--an-bg-0) 70px, transparent); }
 
   /* Rank: the agent-card list becomes a 2-up grid (space-y margins are a
      phone-stack concern — the grid gap replaces them). The trading cards are

--- a/surfaces/webview/src/index.css
+++ b/surfaces/webview/src/index.css
@@ -151,6 +151,19 @@ body {
   overscroll-behavior: none;
 }
 
+/* Pointer affordance: the surface is phone-first (tap feedback is active:
+   states, hover never fires), so nothing declares a cursor and a mouse reads
+   the whole app as inert text. With a real pointer present, clickables get
+   the hand. Touch devices never match this media block. */
+@media (hover: hover) and (pointer: fine) {
+  button:not(:disabled),
+  a,
+  summary,
+  [role="button"] {
+    cursor: pointer;
+  }
+}
+
 /* Responsive: the surface is a phone-first, full-bleed layout (pager is width:400%,
    cards sized for ~a phone column). On the Android shell and narrow windows that is
    exactly right, so nothing changes below the phone breakpoint. In the tablet /

--- a/surfaces/webview/src/index.css
+++ b/surfaces/webview/src/index.css
@@ -2224,6 +2224,13 @@ html[data-keyboard="open"] .an-shell-panels::after { display: none; }
   /* The profile detail's portrait ID card: capped so its stat leaders and
      stars gauge keep card proportions on a wide screen. */
   .an-id { max-width: 600px; }
+
+  /* Blog: the 90/10 peek carousel is a touch idiom (its wheel, drag, and
+     keyboard handlers stay for phone-sized windows). A tall desktop column
+     has room, so posts stack vertically and read like a feed; the dormant
+     horizontal handlers become no-ops against a column layout. */
+  .an-blogrow { flex-direction: column; overflow-x: visible; scroll-snap-type: none; }
+  .an-blogrow > * { flex: none; }
   .an-agentgrid {
     display: grid;
     grid-template-columns: repeat(auto-fill, minmax(400px, 1fr));

--- a/surfaces/webview/src/index.css
+++ b/surfaces/webview/src/index.css
@@ -2121,11 +2121,14 @@ html[data-keyboard="open"] .an-shell-panels::after { display: none; }
   html[data-keyboard="open"] .an-shell-panels::after { display: none; }
 
   /* NAV_DOCK → vertical rail: same bar, brackets, glyphs and engine-tinted
-     indicator; segments stack and the indicator slides on Y (TabBar.tsx). */
-  .an-navdock-shell { padding: 18px 14px 0; }
-  .an-navdock { width: 100%; }
-  .an-navdock-bar { flex-direction: column; height: auto; }
-  .an-navdock-ind { width: 100%; height: 25%; }
+     indicator; segments stack and the indicator slides on Y (TabBar.tsx). The
+     bracket frame stretches to the rail's full height so the box closes at the
+     bottom edge instead of hanging open mid-rail; the indicator is one fixed
+     62px segment (25% of a full-height bar would balloon). */
+  .an-navdock-shell { display: flex; flex-direction: column; padding: 18px 14px 0; }
+  .an-navdock { display: flex; flex-direction: column; flex: 1; min-height: 0; width: 100%; }
+  .an-navdock-bar { flex-direction: column; height: auto; flex: 1; }
+  .an-navdock-ind { width: 100%; height: 62px; }
   .an-navseg {
     flex: none;
     height: 62px;
@@ -2153,14 +2156,26 @@ html[data-keyboard="open"] .an-shell-panels::after { display: none; }
   /* Market / Skills / Rank screens: a wide but bounded content column. */
   .an-screen { width: 100%; max-width: 1120px; margin-inline: auto; }
 
+  /* Rank reads best as a narrower column (the trading cards are ~phone-width
+     artwork), so the whole screen — header included — shares one 880px axis.
+     The header's phone padding (14px) is trued up to the body's 12px so the
+     "AGENT RANK" title and the card edges sit on the same line. */
+  .an-screen-rank { max-width: 880px; }
+  .an-screen-rank > header { padding-inline: 12px; }
+
   /* Skill-card tiles: keep tile size sane and let the count grow with width. */
   .an-cardgrid { grid-template-columns: repeat(auto-fill, minmax(168px, 1fr)); }
 
-  /* Rank: a comfortable centered column; the agent-card list becomes a 2-up grid
-     (space-y margins are a phone-stack concern — the grid gap replaces them). The
-     trading cards are drawn for a ~350px phone column: their fixed aspect-ratio
-     would balloon a wide card's height, so height follows content instead. */
-  .an-rankcol { max-width: 880px; margin-inline: auto; }
+  /* Rank: the agent-card list becomes a 2-up grid (space-y margins are a
+     phone-stack concern — the grid gap replaces them). The trading cards are
+     drawn for a ~350px phone column: their fixed aspect-ratio would balloon a
+     wide card's height, so height follows content instead. The pinned "YOU"
+     hero keeps trading-card proportions rather than stretching its stars gauge
+     across the whole column. */
+  .an-ac.is-self { max-width: 560px; }
+  /* Same treatment for the profile detail's portrait ID card: capped so its
+     stat leaders and stars gauge keep card proportions on a wide screen. */
+  .an-id { max-width: 600px; }
   .an-agentgrid {
     display: grid;
     grid-template-columns: repeat(auto-fill, minmax(400px, 1fr));

--- a/surfaces/webview/src/index.css
+++ b/surfaces/webview/src/index.css
@@ -2231,6 +2231,10 @@ html[data-keyboard="open"] .an-shell-panels::after { display: none; }
      horizontal handlers become no-ops against a column layout. */
   .an-blogrow { flex-direction: column; overflow-x: visible; scroll-snap-type: none; }
   .an-blogrow > * { flex: none; }
+
+  /* Verified work: same touch-carousel idiom, but these are compact folder
+     cards, so on desktop the row wraps instead of stacking. */
+  .an-workrow { flex-wrap: wrap; overflow-x: visible; scroll-snap-type: none; }
   .an-agentgrid {
     display: grid;
     grid-template-columns: repeat(auto-fill, minmax(400px, 1fr));

--- a/surfaces/webview/src/layoutEffects.ts
+++ b/surfaces/webview/src/layoutEffects.ts
@@ -83,6 +83,21 @@ export function useKeyboardChrome() {
   }, []);
 }
 
+// Desktop breakpoint. MUST match the @media (min-width: 1024px) block in index.css.
+// There the bottom NAV_DOCK renders as a vertical LEFT rail and the chat drawer overlays
+// instead of pushing; components use this to flip the few behaviors CSS can't express
+// (indicator axis, published dock height, surface push distance).
+export function useIsDesktop() {
+  const [desktop, setDesktop] = useState(() => typeof window !== "undefined" && window.matchMedia("(min-width: 1024px)").matches);
+  useEffect(() => {
+    const mq = window.matchMedia("(min-width: 1024px)");
+    const sync = () => setDesktop(mq.matches);
+    mq.addEventListener("change", sync);
+    return () => mq.removeEventListener("change", sync);
+  }, []);
+  return desktop;
+}
+
 export function useElementHeightVariable(ref: { current: HTMLElement | null }, variableName: string) {
   useEffect(() => {
     const root = document.documentElement;

--- a/surfaces/webview/src/market/AgentDirectory.tsx
+++ b/surfaces/webview/src/market/AgentDirectory.tsx
@@ -179,7 +179,7 @@ export function AgentDirectory() {
   const loading = state.agentsLoading || !everLoaded || state.agents.length === 0;
 
   return (
-    <div className="pt-1">
+    <div className="an-rankcol pt-1">
       {/* Sticky "me" + wallet search: both pinned so the self card and the filter stay reachable
           while the ranked list scrolls under them. */}
       <div className="sticky top-0 z-10 pt-1" style={{ background: "var(--an-bg-0)" }}>
@@ -228,7 +228,7 @@ export function AgentDirectory() {
           {query.trim() ? "No agent matches that wallet" : "No other agents yet"}
         </div>
       ) : (
-        <div className="space-y-2.5">
+        <div className="an-agentgrid space-y-2.5">
           {others.map((agent) => (
             <AgentCard key={agent.wallet} agent={agent} onOpen={openProfile} />
           ))}

--- a/surfaces/webview/src/market/AgentDirectory.tsx
+++ b/surfaces/webview/src/market/AgentDirectory.tsx
@@ -179,7 +179,7 @@ export function AgentDirectory() {
   const loading = state.agentsLoading || !everLoaded || state.agents.length === 0;
 
   return (
-    <div className="an-rankcol pt-1">
+    <div className="pt-1">
       {/* Sticky "me" + wallet search: both pinned so the self card and the filter stay reachable
           while the ranked list scrolls under them. */}
       <div className="sticky top-0 z-10 pt-1" style={{ background: "var(--an-bg-0)" }}>

--- a/surfaces/webview/src/market/AgentProfileView.tsx
+++ b/surfaces/webview/src/market/AgentProfileView.tsx
@@ -1068,10 +1068,7 @@ export function AgentProfileView({ profile, onBack, onOpenSkill }: Props) {
 
       {/* Buy all footer (agent tab, viewing another agent's skills) */}
       {showBuyAll && tab === "agent" && (
-        <div
-          className="pointer-events-none absolute inset-x-0 bottom-0 z-20 px-3 pt-10 an-tabbar-inset"
-          style={{ background: "linear-gradient(to top, color-mix(in srgb, var(--an-bg-0) 60%, transparent), transparent)" }}
-        >
+        <div className="an-cta-float pointer-events-none absolute inset-x-0 bottom-0 z-20 px-3 pt-10 an-tabbar-inset">
           <LockedGate reason="buy" onUnlocked={handleBuyAll} className="pointer-events-auto">
             <button onClick={handleBuyAll} disabled={buyingAll} className="an-btn an-btn-orange">
               {buyingAll

--- a/surfaces/webview/src/market/AgentProfileView.tsx
+++ b/surfaces/webview/src/market/AgentProfileView.tsx
@@ -884,7 +884,7 @@ export function AgentProfileView({ profile, onBack, onOpenSkill }: Props) {
               {verifiedRepos.length > 0 && (
                 <div>
                   <p className="mb-2 text-[11px] uppercase tracking-wide" style={{ color: "var(--an-fg-mute)" }}>Verified work</p>
-                  <div className="flex snap-x gap-3 overflow-x-auto pb-1 [-webkit-overflow-scrolling:touch]">
+                  <div className="an-workrow flex snap-x gap-3 overflow-x-auto pb-1 [-webkit-overflow-scrolling:touch]">
                     {sortedRepos.map((r) => (
                       <WorkCard key={`${r.owner}/${r.name}`} repo={r} skillById={skillById} onOpenSkill={onOpenSkill} onAllSkills={setRepoSkills} />
                     ))}

--- a/surfaces/webview/src/market/AgentProfileView.tsx
+++ b/surfaces/webview/src/market/AgentProfileView.tsx
@@ -896,7 +896,7 @@ export function AgentProfileView({ profile, onBack, onOpenSkill }: Props) {
               {allSkills.length > 0 && (
                 <div>
                   <p className="mb-2 text-[11px] uppercase tracking-wide" style={{ color: "var(--an-fg-mute)" }}>Skills</p>
-                  <div className="grid grid-cols-3 gap-3.5">
+                  <div className="an-cardgrid grid grid-cols-3 gap-3.5">
                     {allSkills.map((card) => (
                       <SkillSdCard
                         key={card.id}

--- a/surfaces/webview/src/market/AgentProfileView.tsx
+++ b/surfaces/webview/src/market/AgentProfileView.tsx
@@ -932,7 +932,7 @@ export function AgentProfileView({ profile, onBack, onOpenSkill }: Props) {
                     )}
                   </div>
                   <div
-                    className="flex snap-x snap-mandatory gap-2 overflow-x-auto pb-2 outline-none [-webkit-overflow-scrolling:touch]"
+                    className="an-blogrow flex snap-x snap-mandatory gap-2 overflow-x-auto pb-2 outline-none [-webkit-overflow-scrolling:touch]"
                     tabIndex={0}
                     aria-label="Blog posts"
                     onKeyDown={onBlogKeyDown}

--- a/surfaces/webview/src/market/CompleteCelebration.tsx
+++ b/surfaces/webview/src/market/CompleteCelebration.tsx
@@ -1,4 +1,5 @@
 import { useEffect } from "react";
+import { createPortal } from "react-dom";
 import { haptics } from "../haptics";
 import { CompleteOverlay } from "./CompleteOverlay";
 import { SkillReceiptOverlay } from "./SkillReceiptOverlay";
@@ -16,7 +17,14 @@ export function CompleteCelebration({ label, onDone, flicker = false, card }: { 
     return () => clearTimeout(t);
   }, []);
 
-  return card
-    ? <SkillReceiptOverlay card={card} onClick={onDone} />
-    : <CompleteOverlay label={label} onClick={onDone} flicker={flicker} />;
+  // Portal both success overlays to <body>: they are rendered from views inside
+  // the transformed swipe pager, where position:fixed resolves against the
+  // transformed ancestor instead of the viewport (the plaque otherwise lands
+  // off-screen). Hoisting the portal here keeps the two branches symmetric.
+  return createPortal(
+    card
+      ? <SkillReceiptOverlay card={card} onClick={onDone} />
+      : <CompleteOverlay label={label} onClick={onDone} flicker={flicker} />,
+    document.body,
+  );
 }

--- a/surfaces/webview/src/market/CompleteOverlay.tsx
+++ b/surfaces/webview/src/market/CompleteOverlay.tsx
@@ -1,3 +1,5 @@
+import { createPortal } from "react-dom";
+
 // Green LED dot-matrix "COMPLETE" plaque (design "OVERLAY // COMPLETE"). One plaque, only
 // the [CONTEXT] sub-label swaps per action. Presentational only: callers own the timing,
 // haptics, and dismissal. Styling lives in index.css (.cmp-*) so it mirrors the VS Code
@@ -16,13 +18,20 @@ export function CompleteOverlay({ label, onClick, flicker = false }: { label: st
       <div className="cmp-label">[{label}]</div>
     </div>
   );
-  return (
+  // Portal to <body>: this overlay is often rendered from views that live inside the
+  // swipe pager, whose ancestors carry a CSS transform (and will-change: transform).
+  // A transformed ancestor makes position:fixed resolve against THAT ancestor, not the
+  // viewport, so `fixed inset-0` lands off-screen (the 400%-wide, translated pager
+  // track). Portaling out to body restores true viewport centering everywhere, matching
+  // the createPortal pattern the profile sheet and FundModal already use.
+  return createPortal(
     <div
       className="fixed inset-0 z-50 flex items-center justify-center"
       style={{ background: "rgba(6,9,11,0.74)", backdropFilter: "blur(4px)", WebkitBackdropFilter: "blur(4px)" }}
       onClick={onClick}
     >
       {flicker ? <div className="unlock-flicker">{plaque}</div> : plaque}
-    </div>
+    </div>,
+    document.body,
   );
 }

--- a/surfaces/webview/src/market/CompleteOverlay.tsx
+++ b/surfaces/webview/src/market/CompleteOverlay.tsx
@@ -1,5 +1,3 @@
-import { createPortal } from "react-dom";
-
 // Green LED dot-matrix "COMPLETE" plaque (design "OVERLAY // COMPLETE"). One plaque, only
 // the [CONTEXT] sub-label swaps per action. Presentational only: callers own the timing,
 // haptics, and dismissal. Styling lives in index.css (.cmp-*) so it mirrors the VS Code
@@ -18,20 +16,15 @@ export function CompleteOverlay({ label, onClick, flicker = false }: { label: st
       <div className="cmp-label">[{label}]</div>
     </div>
   );
-  // Portal to <body>: this overlay is often rendered from views that live inside the
-  // swipe pager, whose ancestors carry a CSS transform (and will-change: transform).
-  // A transformed ancestor makes position:fixed resolve against THAT ancestor, not the
-  // viewport, so `fixed inset-0` lands off-screen (the 400%-wide, translated pager
-  // track). Portaling out to body restores true viewport centering everywhere, matching
-  // the createPortal pattern the profile sheet and FundModal already use.
-  return createPortal(
+  // Presentational only; the parent (CompleteCelebration) owns the portal to
+  // <body> so this and SkillReceiptOverlay escape the transformed pager together.
+  return (
     <div
       className="fixed inset-0 z-50 flex items-center justify-center"
       style={{ background: "rgba(6,9,11,0.74)", backdropFilter: "blur(4px)", WebkitBackdropFilter: "blur(4px)" }}
       onClick={onClick}
     >
       {flicker ? <div className="unlock-flicker">{plaque}</div> : plaque}
-    </div>,
-    document.body,
+    </div>
   );
 }

--- a/surfaces/webview/src/market/MarketScreen.tsx
+++ b/surfaces/webview/src/market/MarketScreen.tsx
@@ -127,7 +127,7 @@ export function MarketScreen({ tab, onBack, onGoMarket }: { tab: ShellTab; onBac
   // Skill detail (reachable from any tab)
   if (state.marketDetail) {
     return (
-      <div className="flex flex-col h-full bg-zinc-950">
+      <div className="an-screen flex flex-col h-full bg-zinc-950">
         <SkillDetailView
           detail={state.marketDetail}
           owned={state.marketOwned.includes(state.marketDetail.card.name)}
@@ -147,7 +147,7 @@ export function MarketScreen({ tab, onBack, onGoMarket }: { tab: ShellTab; onBac
   // (or the user backs out). Mirrors the skill-detail pendingMint skeleton above.
   if (state.agentProfileLoading) {
     return (
-      <div className="flex flex-col h-full bg-zinc-950">
+      <div className="an-screen flex flex-col h-full bg-zinc-950">
         <AgentProfileSkeleton onBack={() => clearAgentProfile()} />
       </div>
     );
@@ -156,7 +156,7 @@ export function MarketScreen({ tab, onBack, onGoMarket }: { tab: ShellTab; onBac
   // Agent profile (self on Profile tab, or a tapped agent on Market tab)
   if (state.agentProfile) {
     return (
-      <div className="flex flex-col h-full bg-zinc-950">
+      <div className="an-screen flex flex-col h-full bg-zinc-950">
         <AgentProfileView
           profile={state.agentProfile}
           onBack={() => clearAgentProfile()}
@@ -170,7 +170,7 @@ export function MarketScreen({ tab, onBack, onGoMarket }: { tab: ShellTab; onBac
   // or workflow tab), same as the VSCode builder.
   if (view === "publish") {
     return (
-      <div className="flex flex-col h-full bg-zinc-950">
+      <div className="an-screen flex flex-col h-full bg-zinc-950">
         <PublishForm initialKind={state.marketTab} onBack={() => setView("browse")} />
       </div>
     );
@@ -205,7 +205,7 @@ export function MarketScreen({ tab, onBack, onGoMarket }: { tab: ShellTab; onBac
   const balanceSol = state.marketBalance != null ? (state.marketBalance / 1_000_000_000).toFixed(3) : null;
 
   return (
-    <div className="flex flex-col h-full bg-zinc-950">
+    <div className="an-screen flex flex-col h-full bg-zinc-950">
       {/* Header (no back-to-chat button — the bottom tab bar owns top-level nav) */}
       <header
         className="flex items-start gap-2.5 border-b px-3.5 shrink-0"
@@ -375,7 +375,7 @@ export function MarketScreen({ tab, onBack, onGoMarket }: { tab: ShellTab; onBac
               </div>
             </div>
           ) : (
-            <div className="grid grid-cols-3 gap-3.5 pt-3">
+            <div className="an-cardgrid grid grid-cols-3 gap-3.5 pt-3">
               {ownedCards.map((card) => (
                 <SkillSdCard
                   key={card.id}
@@ -401,7 +401,7 @@ export function MarketScreen({ tab, onBack, onGoMarket }: { tab: ShellTab; onBac
                 No {state.marketTab}s found.{!state.rpcStatus?.hasKey && " Add a Helius key for better results."}
               </div>
             ) : (
-              <div className="grid grid-cols-3 gap-3.5 pt-1">
+              <div className="an-cardgrid grid grid-cols-3 gap-3.5 pt-1">
                 {state.marketResults
                   .filter((card) => !hideOwned || !state.marketOwned.includes(card.name))
                   .map((card) => {

--- a/surfaces/webview/src/market/MarketScreen.tsx
+++ b/surfaces/webview/src/market/MarketScreen.tsx
@@ -205,7 +205,7 @@ export function MarketScreen({ tab, onBack, onGoMarket }: { tab: ShellTab; onBac
   const balanceSol = state.marketBalance != null ? (state.marketBalance / 1_000_000_000).toFixed(3) : null;
 
   return (
-    <div className="an-screen flex flex-col h-full bg-zinc-950">
+    <div className={`an-screen ${isAgents ? "an-screen-rank" : ""} flex flex-col h-full bg-zinc-950`}>
       {/* Header (no back-to-chat button — the bottom tab bar owns top-level nav) */}
       <header
         className="flex items-start gap-2.5 border-b px-3.5 shrink-0"

--- a/surfaces/webview/src/market/SkillDetailView.tsx
+++ b/surfaces/webview/src/market/SkillDetailView.tsx
@@ -1,4 +1,4 @@
-import { useEffect, useRef, useState, type ReactNode, type CSSProperties } from "react";
+import { useEffect, useRef, useState } from "react";
 import { useStore } from "../state/store";
 import { haptics } from "../haptics";
 import type { SkillCard, SkillDetail } from "../transport/protocol";
@@ -12,32 +12,6 @@ function shortAddr(w?: string) {
   return w ? `${w.slice(0, 4)}…${w.slice(-4)}` : "";
 }
 
-// Accent-green 12px corner ticks that frame the hero card as an owned-object plaque (matching
-// the OWNED button family). Purely decorative, so it stays out of the tab order.
-function Corners() {
-  const g = "var(--an-term-green)";
-  const base = "pointer-events-none absolute h-3 w-3";
-  return (
-    <>
-      <span className={base} style={{ top: -1, left: -1, borderTop: `2px solid ${g}`, borderLeft: `2px solid ${g}` }} />
-      <span className={base} style={{ top: -1, right: -1, borderTop: `2px solid ${g}`, borderRight: `2px solid ${g}` }} />
-      <span className={base} style={{ bottom: -1, left: -1, borderBottom: `2px solid ${g}`, borderLeft: `2px solid ${g}` }} />
-      <span className={base} style={{ bottom: -1, right: -1, borderBottom: `2px solid ${g}`, borderRight: `2px solid ${g}` }} />
-    </>
-  );
-}
-
-// A `> LABEL` terminal section header + its body. Labels are uppercased in green, matching the
-// card art's engraving and the rest of the terminal surfaces.
-function Section({ label, children }: { label: string; children: ReactNode }) {
-  return (
-    <div className="mx-4 mt-5">
-      <div className="an-term-mono mb-2 text-[10px] uppercase" style={{ letterSpacing: "0.14em", color: "var(--an-term-green)" }}>&gt; {label}</div>
-      {children}
-    </div>
-  );
-}
-
 interface Props {
   detail: SkillDetail;
   owned: boolean;
@@ -45,13 +19,6 @@ interface Props {
   onOpenSkill?: (card: SkillCard) => void;
 }
 
-// Card-hero detail view (design "Skill Detail - Card Hero", direction 1): the minted 1:1 card
-// PNG is the hero, so the old icon + title + description head is dropped (the wordmark is baked
-// into the art; a visually-hidden h1 keeps the live name for a11y). Below the card: the action
-// bar (Buy / Owned + Unequip), a meta line, then the live/accessible body the art cannot do -
-// full untruncated > ABOUT, live hashtag chips, > SKILL TEXT, and > COMMENTS. Items with no
-// image degrade to the sigil-icon + Chakra Petch title head. Skill-item comments are ON-CHAIN
-// token gated: owners get the composer; non-owners get the collect-to-comment gate.
 export function SkillDetailView({ detail, owned, onBack, onOpenSkill }: Props) {
   const { state, send } = useStore();
   const [buying, setBuying] = useState(false);
@@ -71,7 +38,6 @@ export function SkillDetailView({ detail, owned, onBack, onOpenSkill }: Props) {
   const isWorkflow = requiredCards.length > 0;
   const ownedRequiredCount = requiredCards.filter((r) => state.marketOwned.includes(r.name)).length;
   const allRequiredOwned = ownedRequiredCount === requiredCards.length;
-  const noteCount = Array.isArray(notes) ? notes.length : 0;
 
   function handleBuy() {
     haptics.strong();
@@ -107,135 +73,106 @@ export function SkillDetailView({ detail, owned, onBack, onOpenSkill }: Props) {
     setResumeComment(false);
   }, [owned, resumeComment]);
 
-  const img = mediaUrl(card.image);
-  const solidGreen: CSSProperties = { background: "var(--an-term-green)", color: "var(--an-on-green)" };
-
   return (
-    <div className="relative flex h-full flex-col" style={{ background: "var(--an-bg-0)" }}>
+    <div className="relative flex flex-col h-full">
       {commentDone && <CompleteCelebration label="COMMENT POSTED" onDone={() => setCommentDone(false)} />}
-      {/* live name for screen readers / find-in-page (the visible title lives in the card art) */}
-      <h1 className="sr-only">{card.name}</h1>
+      <header className="flex items-center gap-2 border-b border-zinc-800 px-2.5 shrink-0" style={{ paddingTop: "max(0.5rem, env(safe-area-inset-top))", paddingBottom: "0.55rem" }}>
+        <button onClick={() => { haptics.tick(); onBack(); }} className="an-iconbtn shrink-0" aria-label="Back"><svg width="18" height="18" viewBox="0 0 24 24" fill="none" stroke="currentColor" strokeWidth="2" strokeLinecap="round" strokeLinejoin="round"><path d="m15 18-6-6 6-6" /></svg></button>
+        {isWorkflow && (
+          <span className="shrink-0 rounded px-1 py-0.5 text-[9px] font-bold tracking-wide bg-amber-500/20 text-amber-300">WORKFLOW</span>
+        )}
+        <span className="truncate font-medium text-sm">{card.name}</span>
+        {owned && (
+          <span className="ml-auto shrink-0 rounded px-1.5 py-0.5 text-[10px] font-semibold bg-green-900/60 text-green-400">
+            owned
+          </span>
+        )}
+        {disposed && (
+          <span className="ml-auto shrink-0 rounded px-1.5 py-0.5 text-[10px] font-semibold bg-zinc-800 text-zinc-500">
+            un-equipped
+          </span>
+        )}
+      </header>
 
-      <div
-        className="flex-1 overflow-y-auto an-tabbar-inset"
-        style={{ paddingTop: "max(0.6rem, env(safe-area-inset-top))", paddingBottom: "calc(max(0.75rem, env(safe-area-inset-bottom)) + 12px)" }}
-      >
-        {/* back */}
-        <div className="px-4">
-          <button onClick={() => { haptics.tick(); onBack(); }} className="an-term-mono text-[11px] uppercase tracking-[0.08em] active:opacity-70" style={{ color: "var(--an-term-fg-6)" }}>
-            &lt; Back_to_market
-          </button>
-        </div>
-
-        {/* HERO: the 1:1 card art as a bracket-corner plaque, or the sigil-icon fallback head */}
-        {img ? (
-          <div className="relative mx-4 mt-3">
-            <div className="relative" style={{ border: "1px solid var(--an-term-line-2)", background: "#080b09" }}>
-              <img
-                src={img}
-                alt={`${card.name} skill card`}
-                referrerPolicy="no-referrer"
-                className="block w-full"
-                style={{ aspectRatio: "1 / 1", objectFit: "cover", imageRendering: "pixelated" }}
-              />
-              <Corners />
+      <div className="flex-1 overflow-y-auto p-3 space-y-4" style={{ paddingBottom: "calc(var(--tabbar-height, 0px) + max(0.75rem, env(safe-area-inset-bottom)) + 76px)" }}>
+        <div className="flex items-start gap-3">
+          {mediaUrl(card.image) ? (
+            <img src={mediaUrl(card.image)} alt="" referrerPolicy="no-referrer" className="h-14 w-14 rounded-xl object-cover shrink-0" />
+          ) : (
+            <div className="h-14 w-14 rounded-xl bg-zinc-800 shrink-0 flex items-center justify-center text-zinc-400"><SkillIcon className="h-7 w-7" /></div>
+          )}
+          <div className="min-w-0">
+            <p className="text-sm text-zinc-300">{card.description}</p>
+            <div className="mt-1 flex flex-wrap gap-1.5 text-[11px]">
+              {card.category && <span className="bg-zinc-800 text-zinc-400 px-1.5 py-0.5 rounded">{card.category}</span>}
+              {card.hashtags?.map((h) => (
+                <span key={h} className="bg-zinc-800/60 text-zinc-500 px-1.5 py-0.5 rounded">#{h}</span>
+              ))}
+              {card.supply != null && <span className="text-zinc-600">↑{card.supply} holders</span>}
+              {card.stars ? <span className="text-amber-400">★{card.stars}</span> : null}
+              {/* inventory only: a small jump to the item's public marketplace page */}
+              {owned && card.id && (
+                <a
+                  href={`https://magiceden.io/item-details/${card.id}`}
+                  target="_blank"
+                  rel="noreferrer"
+                  onClick={(e) => e.stopPropagation()}
+                  className="border border-zinc-700 text-zinc-400 px-1.5 py-0.5 rounded active:opacity-80"
+                >
+                  MAGIC EDEN
+                </a>
+              )}
             </div>
           </div>
-        ) : (
-          <div className="mx-4 mt-3.5 flex items-center gap-3">
-            <div className="relative grid h-14 w-14 shrink-0 place-items-center" style={{ border: "1px solid var(--an-term-green-line-2)", background: "var(--an-term-green-bg)", color: "var(--an-term-green)" }}>
-              <SkillIcon className="h-7 w-7" />
-              <span className="pointer-events-none absolute h-2 w-2" style={{ top: -1, left: -1, borderTop: "2px solid var(--an-term-green)", borderLeft: "2px solid var(--an-term-green)" }} />
-              <span className="pointer-events-none absolute h-2 w-2" style={{ bottom: -1, right: -1, borderBottom: "2px solid var(--an-term-green)", borderRight: "2px solid var(--an-term-green)" }} />
-            </div>
-            <div className="flex min-w-0 flex-col gap-0.5">
-              <span className="an-term-mono text-[9px] uppercase" style={{ letterSpacing: "0.18em", color: "var(--an-term-fg-7)" }}>{isWorkflow ? "Workflow" : "Skill"}</span>
-              <span className="truncate text-[19px] font-semibold" style={{ fontFamily: "var(--an-font-tech)", color: "var(--an-term-fg)" }}>{card.name}</span>
+        </div>
+
+        {skillText && (
+          <div className="rounded-lg bg-zinc-900 border border-zinc-800 p-3">
+            <p className="text-[11px] text-zinc-500 mb-1 uppercase tracking-wide">SKILL.md</p>
+            <pre className="text-xs text-zinc-300 whitespace-pre-wrap font-mono overflow-x-auto">{skillText}</pre>
+          </div>
+        )}
+
+        {Array.isArray(detail.repos) && detail.repos.length > 0 && (
+          <div className="space-y-2">
+            <p className="text-[11px] text-zinc-500 uppercase tracking-wide">
+              Used by · <span className="text-amber-400">★{card.stars ?? detail.repos.reduce((s, r) => s + (r.stars || 0), 0)}</span>
+            </p>
+            <div className="space-y-1.5">
+              {detail.repos.map((r) => (
+                <a key={r.url} href={r.url} target="_blank" rel="noreferrer"
+                  className="flex items-center gap-2 rounded-lg bg-zinc-900 border border-zinc-800 p-2.5 text-sm active:opacity-80">
+                  <span className="min-w-0 flex-1 truncate text-zinc-300">{r.owner}/{r.name}</span>
+                  <span className="shrink-0 text-[11px] text-amber-400">★{r.stars}</span>
+                </a>
+              ))}
             </div>
           </div>
         )}
 
-        {/* ACTION BAR — right under the card so Buy / Owned sit above the fold */}
-        <div className="mx-4 mt-3">
-          {owned && !disposed ? (
-            <div className="flex items-center gap-2">
-              <span className="flex h-11 flex-1 items-center justify-center an-term-mono text-[12px] font-bold uppercase" style={{ letterSpacing: "0.12em", border: "1px solid var(--an-term-green-line)", color: "var(--an-term-green)", background: "var(--an-term-green-bg)" }}>Owned</span>
-              <button onClick={() => { haptics.tap(); send({ type: "disposeSkill", skillId: card.id }); }} className="flex h-11 flex-1 items-center justify-center an-term-mono text-[12px] font-bold uppercase active:opacity-80" style={{ letterSpacing: "0.12em", border: "1px solid var(--an-term-line-3)", color: "var(--an-fg-dim)" }}>Unequip</button>
-            </div>
-          ) : disposed ? (
-            <button onClick={() => { haptics.tap(); send({ type: "reEquipSkill", skillId: card.id }); }} className="flex h-11 w-full items-center justify-center an-term-mono text-[12px] font-bold uppercase active:opacity-90" style={{ letterSpacing: "0.12em", ...solidGreen }}>Re-equip</button>
-          ) : (
-            <LockedGate reason="buy" onUnlocked={handleBuy}>
-              <button
-                onClick={handleBuy}
-                disabled={buying || (isWorkflow && !allRequiredOwned)}
-                className="flex h-11 w-full items-center justify-center an-term-mono text-[12px] font-bold uppercase active:opacity-90 disabled:opacity-40"
-                style={{ letterSpacing: "0.12em", ...solidGreen }}
-              >
-                {buying
-                  ? "Buying..."
-                  : isWorkflow && !allRequiredOwned
-                    ? `Collect ${requiredCards.length - ownedRequiredCount} more skill${requiredCards.length - ownedRequiredCount === 1 ? "" : "s"}`
-                    : priceSol ? `Buy · ${priceSol} SOL` : "Buy · Free"}
-              </button>
-            </LockedGate>
-          )}
-        </div>
-
-        {/* meta line: holders / price on the left, Magic Eden (owned only) on the right */}
-        <div className="mx-4 mt-2.5 flex items-center justify-between an-term-mono text-[10px]" style={{ letterSpacing: "0.08em" }}>
-          <span style={{ color: "var(--an-term-fg-7)" }}>
-            {card.supply != null ? `${card.supply}x owned` : ""}
-            {card.supply != null && priceSol ? " · " : ""}
-            {priceSol ? `${priceSol} SOL` : card.supply == null ? "Free" : ""}
-          </span>
-          {owned && card.id && (
-            <a href={`https://magiceden.io/item-details/${card.id}`} target="_blank" rel="noreferrer" onClick={(e) => e.stopPropagation()} className="active:opacity-70" style={{ color: "var(--an-term-fg-6)" }}>
-              Magic Eden ↗
-            </a>
-          )}
-        </div>
-
-        {/* > ABOUT — the full, untruncated, selectable description + live hashtag chips */}
-        <Section label="About">
-          <p className="whitespace-pre-wrap break-words text-[12.5px] leading-relaxed" style={{ color: "var(--an-fg-dim)" }}>{card.description}</p>
-          {(card.category || card.hashtags?.length) && (
-            <div className="mt-3 flex flex-wrap gap-1.5">
-              {card.category && (
-                <span className="an-term-mono px-2 py-1 text-[10px] uppercase" style={{ letterSpacing: "0.06em", border: "1px solid var(--an-term-green-line)", color: "var(--an-term-green)", background: "var(--an-term-green-bg)" }}>{card.category}</span>
-              )}
-              {card.hashtags?.map((h) => (
-                <span key={h} className="an-term-mono px-2 py-1 text-[10px]" style={{ border: "1px solid var(--an-term-line-2)", color: "var(--an-fg-mute)" }}>#{h}</span>
-              ))}
-            </div>
-          )}
-        </Section>
-
-        {/* Required skills (workflow) — collect the parts before the workflow can be bought */}
         {isWorkflow && (() => {
           const unowned = requiredCards.filter((r) => !state.marketOwned.includes(r.name));
           const totalLamports = unowned.reduce((sum, r) => sum + (r.price ? Number(r.price) : 0), 0);
           const totalSol = totalLamports > 0 ? (totalLamports / 1_000_000_000).toFixed(3) : null;
           return (
-            <div className="mx-4 mt-5">
-              <div className="mb-2 flex items-center justify-between gap-2">
-                <div className="an-term-mono text-[10px] uppercase" style={{ letterSpacing: "0.14em", color: "var(--an-term-green)" }}>
-                  &gt; Required_skills <span style={{ color: allRequiredOwned ? "var(--an-term-green)" : "var(--an-amber)" }}>{ownedRequiredCount}/{requiredCards.length}</span>
-                </div>
+            <div className="space-y-2">
+              <div className="flex items-center justify-between">
+                <p className="text-[11px] text-zinc-500 uppercase tracking-wide">
+                  Required skills · <span className={allRequiredOwned ? "text-green-400" : "text-amber-300"}>{ownedRequiredCount}/{requiredCards.length} collected</span>
+                </p>
                 {unowned.length > 0 && (
                   <LockedGate reason="buy" onUnlocked={() => { haptics.strong(); send({ type: "buyRequiredSkills", items: unowned.map((r) => ({ skillId: r.id, creatorWallet: r.creator })) }); }}>
                     <button
                       type="button"
                       onClick={() => { haptics.strong(); send({ type: "buyRequiredSkills", items: unowned.map((r) => ({ skillId: r.id, creatorWallet: r.creator })) }); }}
-                      className="an-term-mono px-2.5 py-1 text-[10px] font-bold uppercase active:opacity-80"
-                      style={{ letterSpacing: "0.06em", ...solidGreen }}
+                      className="rounded-lg bg-amber-400 px-2.5 py-1 text-[11px] font-semibold text-zinc-900 active:bg-amber-300"
                     >
-                      Collect {unowned.length}{totalSol ? ` · ${totalSol}` : ""}
+                      Collect all {unowned.length}{totalSol ? ` · ${totalSol} SOL` : ""}
                     </button>
                   </LockedGate>
                 )}
               </div>
-              <div className="space-y-1.5">
+              <div className="space-y-2">
                 {requiredCards.map((req) => {
                   const reqOwned = state.marketOwned.includes(req.name);
                   return (
@@ -243,24 +180,24 @@ export function SkillDetailView({ detail, owned, onBack, onOpenSkill }: Props) {
                       key={req.id}
                       type="button"
                       onClick={() => onOpenSkill?.(req)}
-                      className="flex w-full items-center gap-2.5 p-2.5 text-left active:opacity-80"
-                      style={{ border: reqOwned ? "1px solid var(--an-term-line-2)" : "1px dashed var(--an-term-green-line)", background: reqOwned ? "var(--an-bg-1)" : "var(--an-term-green-bg)" }}
+                      className={`flex w-full items-center gap-2.5 rounded-lg border p-2.5 text-left active:opacity-80 ${reqOwned ? "bg-zinc-900 border-zinc-800" : "bg-zinc-900/40 border-dashed border-amber-500/40"}`}
                     >
+                      {/* collection checkbox: filled green check when owned, empty slot when missing */}
                       {reqOwned ? (
-                        <span className="grid h-5 w-5 shrink-0 place-items-center text-[11px] font-bold" style={solidGreen}>✓</span>
+                        <span className="shrink-0 grid h-5 w-5 place-items-center rounded-md bg-green-500/90 text-zinc-950 text-xs font-bold">✓</span>
                       ) : (
-                        <span className="h-5 w-5 shrink-0" style={{ border: "1px dashed var(--an-term-green-line)" }} />
+                        <span className="shrink-0 h-5 w-5 rounded-md border-2 border-dashed border-amber-500/50" />
                       )}
                       <div className="min-w-0 flex-1">
-                        <p className="an-term-mono text-[12px]" style={{ color: "var(--an-term-fg)" }}>{req.name}</p>
-                        <p className="mt-0.5 line-clamp-2 text-[11px]" style={{ color: "var(--an-fg-mute)" }}>{req.description}</p>
+                        <p className={`text-xs font-medium ${reqOwned ? "text-zinc-200" : "text-zinc-300"}`}>{req.name}</p>
+                        <p className="mt-0.5 line-clamp-2 text-[11px] text-zinc-500">{req.description}</p>
                       </div>
                       {reqOwned ? (
-                        <span className="an-term-mono shrink-0 text-[10px] font-bold" style={{ color: "var(--an-term-green)" }}>owned</span>
+                        <span className="shrink-0 text-[10px] font-semibold text-green-400">owned</span>
                       ) : req.price ? (
-                        <span className="an-term-mono shrink-0 text-[11px]" style={{ color: "var(--an-fg-dim)" }}>{(Number(req.price) / 1_000_000_000).toFixed(3)}</span>
+                        <span className="shrink-0 text-[11px] font-medium text-amber-300">{(Number(req.price) / 1_000_000_000).toFixed(3)} SOL</span>
                       ) : (
-                        <span className="an-term-mono shrink-0 text-[11px]" style={{ color: "var(--an-fg-mute)" }}>free</span>
+                        <span className="shrink-0 text-[11px] text-zinc-500">free</span>
                       )}
                     </button>
                   );
@@ -270,75 +207,94 @@ export function SkillDetailView({ detail, owned, onBack, onOpenSkill }: Props) {
           );
         })()}
 
-        {/* > USED BY — repos that reference this skill, with their star grade */}
-        {Array.isArray(detail.repos) && detail.repos.length > 0 && (
-          <Section label="Used_by">
-            <div className="space-y-1.5">
-              {detail.repos.map((r) => (
-                <a key={r.url} href={r.url} target="_blank" rel="noreferrer" className="flex items-center gap-2 p-2.5 active:opacity-80" style={{ border: "1px solid var(--an-term-line)", background: "var(--an-bg-1)" }}>
-                  <span className="an-term-mono min-w-0 flex-1 truncate text-[12px]" style={{ color: "var(--an-fg-dim)" }}>{r.owner}/{r.name}</span>
-                  <span className="an-term-mono shrink-0 text-[11px]" style={{ color: "var(--an-amber)" }}>★{r.stars}</span>
-                </a>
-              ))}
-            </div>
-          </Section>
-        )}
-
-        {/* > SKILL TEXT — the raw SKILL.md */}
-        {skillText && (
-          <Section label="Skill_text">
-            <pre className="an-term-mono overflow-x-auto whitespace-pre-wrap break-words text-[11px] leading-relaxed" style={{ border: "1px solid var(--an-term-line)", background: "#080b09", padding: "12px", color: "var(--an-fg-dim)" }}>{skillText}</pre>
-          </Section>
-        )}
-
-        {/* > COMMENTS — on-chain token-gated: owners post, non-owners see the collect gate */}
-        <Section label={`Comments (${noteCount})`}>
-          {noteCount > 0 && (
-            <div className="mb-3 flex flex-col">
-              {(notes as any[]).map((n: any, i) => (
-                <div key={i} className="border-t py-3 first:border-t-0" style={{ borderColor: "var(--an-term-line)" }}>
-                  <div className="mb-2 flex items-center gap-2.5">
-                    <div className="h-[22px] w-[22px] shrink-0 overflow-hidden" style={{ border: "1px solid var(--an-term-line-2)" }} aria-hidden="true" dangerouslySetInnerHTML={{ __html: walletAvatarSvg(n.author ?? "") }} />
-                    <span className="an-term-mono text-[11px]" style={{ color: "var(--an-term-fg)" }}>{shortAddr(n.author)}</span>
-                  </div>
-                  <p className="an-term-mono whitespace-pre-wrap break-words text-[12px] leading-relaxed" style={{ color: "var(--an-fg-dim)" }}>{n.text}</p>
+        {Array.isArray(notes) && notes.length > 0 && (
+          <div className="space-y-2">
+            <p className="text-[11px] text-zinc-500 uppercase tracking-wide">Comments</p>
+            {(notes as any[]).map((n: any, i) => (
+              <div key={i} className="rounded-xl bg-zinc-900 border border-zinc-800 p-3.5 text-sm text-zinc-300">
+                <div className="mb-2 flex items-center gap-2.5">
+                  <div className="h-8 w-8 shrink-0 overflow-hidden rounded-full border border-zinc-800 bg-zinc-800" aria-hidden="true" dangerouslySetInnerHTML={{ __html: walletAvatarSvg(n.author ?? "") }} />
+                  <span className="font-mono text-xs text-zinc-400">{shortAddr(n.author)}</span>
                 </div>
-              ))}
-            </div>
-          )}
-          {owned ? (
-            <div className="space-y-2.5">
-              <textarea
-                ref={noteInput}
-                className="an-term-field resize-none leading-relaxed"
-                rows={4}
-                placeholder="Write a comment..."
-                value={noteText}
-                onChange={(e) => setNoteText(e.target.value)}
-              />
-              <input
-                className="an-term-field"
-                placeholder="GitHub link (optional)"
-                value={noteGitLink}
-                onChange={(e) => setNoteGitLink(e.target.value)}
-              />
-              <div className="flex justify-end">
-                <button onClick={handleNote} disabled={!noteText.trim()} className="an-btn an-btn-green w-auto px-6">Post</button>
+                <p className="whitespace-pre-wrap break-words leading-relaxed">{n.text}</p>
               </div>
-            </div>
-          ) : !state.walletAddress ? (
-            <LockedGate reason="comment" onUnlocked={() => { setResumeComment(true); send({ type: "ownedSkills" }); send({ type: "getSkillDetail", mint: card.id }); }}>
-              <div className="an-term-mono px-3 py-2.5 text-[10px] uppercase" style={{ letterSpacing: "0.06em", border: "1px solid var(--an-term-line)", color: "var(--an-term-fg-7)" }}>
-                <span style={{ color: "var(--an-term-green)" }}>&gt;</span>CONNECT_WALLET_ <span style={{ color: "var(--an-term-fg)" }}>Connect a wallet to comment.</span>
-              </div>
-            </LockedGate>
-          ) : (
-            <div className="an-term-mono px-3 py-2.5 text-[10px] uppercase" style={{ letterSpacing: "0.06em", border: "1px solid var(--an-term-green-line-2)", color: "var(--an-term-fg-7)" }}>
-              <span style={{ color: "var(--an-term-green)" }}>&gt;</span>HOLDERS_ONLY_ <span style={{ color: "var(--an-term-fg)" }}>Collect this skill to comment.</span>
-            </div>
-          )}
-        </Section>
+            ))}
+          </div>
+        )}
+
+        {owned && (
+          <div className="space-y-2.5">
+            <p className="text-[11px] text-zinc-500 uppercase tracking-wide">Leave a comment</p>
+            <textarea
+              ref={noteInput}
+              className="w-full rounded-xl bg-zinc-900 border border-zinc-800 p-3.5 text-base text-zinc-200 leading-relaxed resize-none focus:outline-none focus:border-green-500/50"
+              rows={4}
+              placeholder="Share your experience…"
+              value={noteText}
+              onChange={(e) => setNoteText(e.target.value)}
+            />
+            <input
+              className="w-full rounded-xl bg-zinc-900 border border-zinc-800 px-3.5 py-3 text-base text-zinc-300 placeholder-zinc-600 focus:outline-none focus:border-blue-500/50"
+              placeholder="GitHub link (optional)"
+              value={noteGitLink}
+              onChange={(e) => setNoteGitLink(e.target.value)}
+            />
+            <button
+              onClick={handleNote}
+              disabled={!noteText.trim()}
+              className="w-full rounded-xl py-3.5 text-base font-semibold bg-zinc-800 text-zinc-200 disabled:opacity-40 active:bg-zinc-700"
+            >
+              Post
+            </button>
+          </div>
+        )}
+        {!owned && !state.walletAddress && (
+          <LockedGate reason="comment" onUnlocked={() => { setResumeComment(true); send({ type: "ownedSkills" }); send({ type: "getSkillDetail", mint: card.id }); }}>
+            <button className="w-full rounded-xl border border-zinc-800 bg-zinc-900 px-3.5 py-3 text-left text-sm text-zinc-400">
+              Connect a wallet to comment
+            </button>
+          </LockedGate>
+        )}
+        {!owned && !!state.walletAddress && (
+          <p className="rounded-xl border border-zinc-800 bg-zinc-900 px-3.5 py-3 text-sm text-zinc-500">Collect this skill before commenting.</p>
+        )}
       </div>
+
+      {owned && (
+        <div className="an-cta-float pointer-events-none absolute inset-x-0 bottom-0 z-20 px-3 pt-8 an-tabbar-inset">
+          {/* pointer-events-auto: the fade wrapper is pointer-events-none (so it can't block
+              the list scroll), which otherwise swallows the tap too; see the Buy gate below. */}
+          <button onClick={() => { haptics.tap(); send({ type: "disposeSkill", skillId: card.id }); }} className="an-btn an-btn-danger pointer-events-auto">
+            Remove Skill
+          </button>
+        </div>
+      )}
+
+      {!owned && disposed && (
+        <div className="an-cta-float pointer-events-none absolute inset-x-0 bottom-0 z-20 px-3 pt-8 an-tabbar-inset">
+          <button onClick={() => { haptics.tap(); send({ type: "reEquipSkill", skillId: card.id }); }} className="an-btn an-btn-green pointer-events-auto">
+            Re-equip Skill
+          </button>
+        </div>
+      )}
+
+      {!owned && !disposed && (
+        <div className="an-cta-float pointer-events-none absolute inset-x-0 bottom-0 z-20 px-3 pt-8 an-tabbar-inset">
+          <LockedGate reason="buy" onUnlocked={handleBuy} className="pointer-events-auto">
+            <button
+              onClick={handleBuy}
+              disabled={buying || (isWorkflow && !allRequiredOwned)}
+              className="an-btn an-btn-orange"
+            >
+              {buying
+                ? "Buying…"
+                : isWorkflow && !allRequiredOwned
+                  ? `Collect ${requiredCards.length - ownedRequiredCount} more skill${requiredCards.length - ownedRequiredCount === 1 ? "" : "s"} to buy`
+                  : priceSol ? `Buy for ${priceSol} SOL` : "Buy (free)"}
+            </button>
+          </LockedGate>
+        </div>
+      )}
     </div>
   );
 }

--- a/surfaces/webview/src/shell/TabBar.tsx
+++ b/surfaces/webview/src/shell/TabBar.tsx
@@ -1,5 +1,5 @@
 import { useRef } from "react";
-import { useElementHeightVariable } from "../layoutEffects";
+import { useElementHeightVariable, useIsDesktop } from "../layoutEffects";
 import { useStore } from "../state/store";
 import { useUnlock } from "../unlock/UnlockProvider";
 
@@ -72,8 +72,12 @@ const TABS: { key: TabKey; label: string; Glyph: () => JSX.Element }[] = [
 // it follows a live page swipe) and animates on tap (transition off only while dragging).
 export function TabBar({ position, instant, onChange }: { position: number; instant: boolean; onChange: (i: number) => void }) {
   // Publish the dock's height so the chat composer can sit just above it (0 when hidden).
+  // On desktop the rail is full-height on the LEFT, so it publishes 0 (a null ref writes 0px);
+  // nothing at the bottom to clear.
+  const desktop = useIsDesktop();
   const navRef = useRef<HTMLElement>(null);
-  useElementHeightVariable(navRef, "--tabbar-height");
+  const noneRef = useRef<HTMLElement>(null);
+  useElementHeightVariable(desktop ? noneRef : navRef, "--tabbar-height");
   const { state } = useStore();
   const { unlocked } = useUnlock();
   const accent = state.cli === "claude" ? "var(--claude)" : "var(--an-green)";
@@ -90,7 +94,7 @@ export function TabBar({ position, instant, onChange }: { position: number; inst
             className="an-navdock-ind"
             style={{
               background: accent,
-              transform: `translateX(calc(${position} * 100%))`,
+              transform: desktop ? `translateY(calc(${position} * 100%))` : `translateX(calc(${position} * 100%))`,
               transition: instant ? "none" : undefined,
             }}
           />

--- a/surfaces/webview/src/shell/TabBar.tsx
+++ b/surfaces/webview/src/shell/TabBar.tsx
@@ -87,6 +87,9 @@ export function TabBar({ position, instant, onChange }: { position: number; inst
       <div className="an-navdock">
         <div className="an-navdock-status">
           <span className="dim">&gt; NAV_DOCK</span>
+          {/* Kana sub in the screen-header idiom (title + kana). Phone hides it:
+              the dock's one status row has no room for a second line there. */}
+          <span className="an-navdock-kana" aria-hidden="true">ナビドック</span>
         </div>
         <div className="an-navdock-bar">
           {/* sliding active fill — engine-tinted, glides between segments */}


### PR DESCRIPTION

## What

At `>= 1024px` the SPA lays itself out for the width: the bottom NAV_DOCK becomes a compact full height left rail, skills and market card lists go multi column, and the rank column widens. Below 1024px nothing changes, and that is proven with pixels below, not claimed.

One codebase. The whole layout is a single `@media (min-width: 1024px)` block in `index.css` plus one `useIsDesktop()` hook. No screen grew a desktop fork or a second component, so there is nothing extra to maintain.

Details the wide layout called for, all inside the same block:

- One ground color: the screens paint zinc-950 (#09090b), one shade off the app ground (#0a0b0d). Invisible on a full bleed phone; the capped desktop column put the two blacks side by side as a faint seam, so the screen takes the ground token.
- Rank reads as a single centered leaderboard column (584px = card width plus gutters): the header, the pinned YOU hero, the search bar, and every list card share one axis at any agent count.
- The rail's NAV_DOCK line gains its kana sub (the title plus kana idiom every screen header already uses); the profile blog carousel becomes a vertical feed and the verified work row wraps, both touch idioms that stay untouched on phone.
- Clickables get the hand cursor for mouse users (a hover: hover and pointer: fine block, so touch devices never match).

## Why

`localhost` and the VS Code webview render this SPA in wide viewports today, where it floats as a phone column in empty space. This makes those surfaces read as designed for the machine they run on while the phone build stays byte identical.

| Chat | Skills | Market | Rank |
| --- | --- | --- | --- |
| ![chat](https://github.com/RemilioNubilio/AgentNet/releases/download/pr-evidence/ui-desktop-chat.png) | ![skills](https://github.com/RemilioNubilio/AgentNet/releases/download/pr-evidence/ui-desktop-skills.png) | ![market](https://github.com/RemilioNubilio/AgentNet/releases/download/pr-evidence/ui-desktop-market.png) | ![rank](https://github.com/RemilioNubilio/AgentNet/releases/download/pr-evidence/ui-desktop-rank.png) |

1440x900. The rail keeps the NAV_DOCK design language: corner tick brackets, engine tinted indicator (now sliding on Y), blinking dot, lock badge, 56px segments in a 116px rail.

Phone, 390x844, unchanged:

<img src="https://github.com/RemilioNubilio/AgentNet/releases/download/pr-evidence/ui-phone-chat.png" width="300">

## Also fixed: the completion overlay could land off screen

`CompleteOverlay` used `position: fixed` from inside the swipe pager, whose ancestors carry a CSS transform. A transformed ancestor makes `fixed` resolve against that ancestor instead of the viewport, so the success plaque rendered somewhere on the 400% wide pager track. Both success overlays (plaque and buy receipt) now portal to `document.body` from `CompleteCelebration`, the same portal pattern `FundModal` already uses. This bug affected every surface, phone included.

Two small cleanups rode along: the CTA float gradient that was inlined four times across `SkillDetailView` and `AgentProfileView` is now one `.an-cta-float` class (desktop gives it a solid backstop so scrolled SKILL.md text does not bleed under the button), and a dead `.an-rankcol` class reference was removed.

## Proof

- Phone untouched: 390x844 render of main vs this branch, 0 of 329,160 pixels differ.
- `pnpm --filter agentnet-webview build` green; `tsc --noEmit` introduces no new errors.
- Rail interactions checked at 1440x900: tab clicks, indicator glide, lock badge, composer bottom alignment (the dock publishes 0 height on desktop so nothing reserves phantom bottom space).

Not verified here, said plainly:

- Everything above was tested in Chrome against the localhost surface. The VS Code panel serves the same SPA and hits the same breakpoint, but I did not re-test inside an actual VS Code webview.
- The phone proof is a headless 390x844 pixel diff, not a physical device pass of the Android APK. Same code path, but not the same runtime.

## The five rules against this diff

1. No meaningless wrappers: the only new function is `useIsDesktop()`, which owns a matchMedia subscription and rerenders on breakpoint change. Real behavior, no passthrough.
2. Scan and reuse first: the rail is the existing `TabBar` component restyled, not a second nav; the CTA change deletes four duplicated inline gradients in favor of one class.
3. No single use type variables: none added.
4. No non-essential parameters: `TabBar` props are unchanged; `useIsDesktop` takes none.
5. Responsibilities stay separated: layout lives in CSS, behavior in components. The one crossover is `useIsDesktop` choosing where the dock height variable is published, which is exactly the contract the composer already consumed.
