### PR TITLE
webview: threaded replies under skill comments

### DIFF
--- a/surfaces/webview/src/market/AgentProfileView.tsx
+++ b/surfaces/webview/src/market/AgentProfileView.tsx
@@ -199,8 +199,9 @@ function VerifiedRepoRow({ repo }: { repo: VRepo }) {
 }
 
 // A GitHub link rendered as an embed card (Repo/PR/File/Commit + label + meta). Shared by
-// the WORK cards and the blog/comment bodies. `className` controls outer spacing.
-function GithubCard({ url, className = "mt-2" }: { url: string; className?: string }) {
+// the WORK cards, the blog/comment bodies, and the skill comment rows (exported like
+// CommentThreadList). `className` controls outer spacing.
+export function GithubCard({ url, className = "mt-2" }: { url: string; className?: string }) {
   const info = parseGithubLink(url);
   if (!info) {
     const safe = safeExternalUrl(url);

--- a/surfaces/webview/src/market/AgentProfileView.tsx
+++ b/surfaces/webview/src/market/AgentProfileView.tsx
@@ -373,7 +373,7 @@ function WorkCard({
   );
 }
 
-interface NoteFields {
+export interface NoteFields {
   text: string;
   title?: string;
   gitLink?: string;
@@ -384,7 +384,7 @@ interface NoteFields {
 // box (holders). Keeps its own draft; the parent owns postAgentNote + success. Empty posts
 // are blocked (need a title OR body); a title-only post is allowed. Image accepts an https
 // link or an on-chain ref (resolved via the gateway on render).
-function NoteComposer({
+export function NoteComposer({
   placeholder,
   submitLabel,
   posting,
@@ -550,7 +550,7 @@ type CommentReply = CommentThread["replies"][number];
 // Threaded comment list (GH #101): top-level comments, each with its replies collapsed to one
 // indented level; Reply opens an inline composer. Shared by the agent-profile comment wall and
 // a blog post's own comment thread (comment:blog:<postId>), so both render identically.
-function CommentThreadList({ threads, canPost, posting, replyTo, setReplyTo, onReply }: {
+export function CommentThreadList({ threads, canPost, posting, replyTo, setReplyTo, onReply }: {
   threads: CommentThread[];
   canPost: boolean;
   posting: boolean;

--- a/surfaces/webview/src/market/SkillDetailView.tsx
+++ b/surfaces/webview/src/market/SkillDetailView.tsx
@@ -6,7 +6,7 @@ import { SkillIcon } from "../icons";
 import { mediaUrl } from "./mediaUrl";
 import { walletAvatarSvg } from "./walletAvatar";
 import { CompleteCelebration } from "./CompleteCelebration";
-import { CommentThreadList, NoteComposer, type NoteFields } from "./AgentProfileView";
+import { CommentThreadList, GithubCard, NoteComposer, type NoteFields } from "./AgentProfileView";
 import { LockedGate } from "../unlock/UnlockProvider";
 
 function shortAddr(w?: string) {
@@ -344,7 +344,7 @@ export function SkillDetailView({ detail, owned, onBack, onOpenSkill }: Props) {
 // connected wallet may answer. The thread loads lazily per comment; the host
 // pushes the refreshed thread after a reply lands, which also closes the
 // composer. Renderer and composer are the blog reader's own.
-function SkillCommentRow({ note }: { note: { id?: string; author?: string; text: string } }) {
+function SkillCommentRow({ note }: { note: { id?: string; author?: string; text: string; gitLink?: string } }) {
   const { state, send } = useStore();
   const canReply = !!state.walletAddress;
   const [replyOpen, setReplyOpen] = useState(false);
@@ -368,6 +368,7 @@ function SkillCommentRow({ note }: { note: { id?: string; author?: string; text:
         <span className="an-term-mono text-[11px]" style={{ color: "var(--an-term-fg)" }}>{shortAddr(note.author)}</span>
       </div>
       <p className="an-term-mono whitespace-pre-wrap break-words text-[12px] leading-relaxed" style={{ color: "var(--an-fg-dim)" }}>{note.text}</p>
+      {note.gitLink && <GithubCard url={note.gitLink} />}
       {note.id && (
         <button
           type="button"

--- a/surfaces/webview/src/market/SkillDetailView.tsx
+++ b/surfaces/webview/src/market/SkillDetailView.tsx
@@ -6,6 +6,7 @@ import { SkillIcon } from "../icons";
 import { mediaUrl } from "./mediaUrl";
 import { walletAvatarSvg } from "./walletAvatar";
 import { CompleteCelebration } from "./CompleteCelebration";
+import { CommentThreadList, NoteComposer, type NoteFields } from "./AgentProfileView";
 import { LockedGate } from "../unlock/UnlockProvider";
 
 function shortAddr(w?: string) {
@@ -296,13 +297,7 @@ export function SkillDetailView({ detail, owned, onBack, onOpenSkill }: Props) {
           {noteCount > 0 && (
             <div className="mb-3 flex flex-col">
               {(notes as any[]).map((n: any, i) => (
-                <div key={i} className="border-t py-3 first:border-t-0" style={{ borderColor: "var(--an-term-line)" }}>
-                  <div className="mb-2 flex items-center gap-2.5">
-                    <div className="h-[22px] w-[22px] shrink-0 overflow-hidden" style={{ border: "1px solid var(--an-term-line-2)" }} aria-hidden="true" dangerouslySetInnerHTML={{ __html: walletAvatarSvg(n.author ?? "") }} />
-                    <span className="an-term-mono text-[11px]" style={{ color: "var(--an-term-fg)" }}>{shortAddr(n.author)}</span>
-                  </div>
-                  <p className="an-term-mono whitespace-pre-wrap break-words text-[12px] leading-relaxed" style={{ color: "var(--an-fg-dim)" }}>{n.text}</p>
-                </div>
+                <SkillCommentRow key={n.id ?? i} note={n} />
               ))}
             </div>
           )}
@@ -339,6 +334,64 @@ export function SkillDetailView({ detail, owned, onBack, onOpenSkill }: Props) {
           )}
         </Section>
       </div>
+    </div>
+  );
+}
+
+// One comment row plus its OPEN reply thread. The comment itself stays holder
+// gated above (it shapes the skill's standing), but replies ride the same
+// comment:blog:<noteId> tables the blog reader uses (issue #183 model), so any
+// connected wallet may answer. The thread loads lazily per comment; the host
+// pushes the refreshed thread after a reply lands, which also closes the
+// composer. Renderer and composer are the blog reader's own.
+function SkillCommentRow({ note }: { note: { id?: string; author?: string; text: string } }) {
+  const { state, send } = useStore();
+  const canReply = !!state.walletAddress;
+  const [replyOpen, setReplyOpen] = useState(false);
+  const [posting, setPosting] = useState(false);
+  const [replyTo, setReplyTo] = useState<string | null>(null);
+  const threads = note.id ? state.blogComments[note.id] : undefined;
+  useEffect(() => {
+    if (note.id) send({ type: "getBlogComments", postId: note.id, agentWallet: note.author ?? "" });
+  }, [note.id, note.author, send]);
+  useEffect(() => { setPosting(false); setReplyOpen(false); setReplyTo(null); }, [threads]);
+  function submitReply(f: NoteFields, parentId?: string) {
+    const text = f.text.trim();
+    if (!text || !canReply || !note.id) return;
+    setPosting(true);
+    send({ type: "postBlogComment", postId: note.id, agentWallet: note.author ?? "", text, gitLink: f.gitLink, parentId });
+  }
+  return (
+    <div className="border-t py-3 first:border-t-0" style={{ borderColor: "var(--an-term-line)" }}>
+      <div className="mb-2 flex items-center gap-2.5">
+        <div className="h-[22px] w-[22px] shrink-0 overflow-hidden" style={{ border: "1px solid var(--an-term-line-2)" }} aria-hidden="true" dangerouslySetInnerHTML={{ __html: walletAvatarSvg(note.author ?? "") }} />
+        <span className="an-term-mono text-[11px]" style={{ color: "var(--an-term-fg)" }}>{shortAddr(note.author)}</span>
+      </div>
+      <p className="an-term-mono whitespace-pre-wrap break-words text-[12px] leading-relaxed" style={{ color: "var(--an-fg-dim)" }}>{note.text}</p>
+      {note.id && (
+        <button
+          type="button"
+          onClick={() => setReplyOpen((v) => !v)}
+          className="an-term-mono mt-2 text-[10px] font-bold uppercase active:opacity-70"
+          style={{ letterSpacing: "0.08em", color: "var(--an-term-fg-7)" }}
+        >
+          [Reply{threads?.length ? ` (${threads.length})` : ""}]
+        </button>
+      )}
+      {(threads?.length || replyOpen) ? (
+        <div className="mt-2 space-y-2 pl-8">
+          {!!threads?.length && (
+            <CommentThreadList threads={threads} canPost={canReply} posting={posting} replyTo={replyTo} setReplyTo={setReplyTo} onReply={submitReply} />
+          )}
+          {replyOpen && (canReply ? (
+            <NoteComposer placeholder="Write a reply..." submitLabel="Reply" posting={posting} autoFocus onSubmit={(f) => submitReply(f)} />
+          ) : (
+            <div className="an-term-mono px-3 py-2.5 text-[10px] uppercase" style={{ letterSpacing: "0.06em", border: "1px solid var(--an-term-line)", color: "var(--an-term-fg-7)" }}>
+              <span style={{ color: "var(--an-term-green)" }}>&gt;</span>CONNECT_WALLET_ <span style={{ color: "var(--an-term-fg)" }}>Connect a wallet to reply.</span>
+            </div>
+          ))}
+        </div>
+      ) : null}
     </div>
   );
 }

--- a/surfaces/webview/src/state/store.tsx
+++ b/surfaces/webview/src/state/store.tsx
@@ -641,7 +641,11 @@ function reducer(state: State, ev: Action): State {
     case "agentNoteResult":
       return { ...state, toast: ev.ok ? "Note posted." : `Note failed: ${ev.error ?? "unknown"}` };
     case "notes":
-      return state;
+      // issue #34: refreshed comments pushed after a successful postNote. Write them into
+      // the open detail (matched by mint) so the fresh comment appears without reopening.
+      return state.marketDetail && state.marketDetail.card.id === ev.skillId
+        ? { ...state, marketDetail: { ...state.marketDetail, notes: ev.notes as SkillDetail["notes"] } }
+        : state;
     case "blogComments":
       return { ...state, blogComments: { ...state.blogComments, [ev.postId]: ev.threads } };
     case "blogCommentResult":


### PR DESCRIPTION

## What

Replies to skill comments already exist on chain but had no UI. `postBlogComment` keys an open reply table by any note id (the issue #183 model: open to any connected wallet, first replier creates the table), and both hosts already serve `getBlogComments` and `postBlogComment`. The skill detail rendered comments as a flat list, so a reply written through that system was invisible in the app.

Each comment now lazily loads its `comment:blog:<noteId>` thread and renders it with the same `CommentThreadList` and `NoteComposer` the blog post reader uses, exported from `AgentProfileView` instead of duplicated. A REPLY affordance with the live count sits under each comment; tap away or post and the composer clears when the host pushes the refreshed thread.

<img src="https://github.com/RemilioNubilio/AgentNet/releases/download/pr-evidence/ui-skill-threads.png" width="300">

That screenshot is real mainnet data: the reply under the comment was written through `postBlogComment` before this change existed, and no surface could show it.

Rebased on the community tab restyle (e9ecbe0): because the thread renderer and composer are the restyled originals, the skill threads picked up the new terminal style (square avatars, mono wallets, [Reply]) with zero changes to this branch. That is the reuse paying off.

## Two follow up commits (review findings on this PR's own loop)

- A freshly posted comment was invisible until the view reopened: the host emits a notes refresh after postNote (the legacy VS Code webview live updates from it), but the React store dropped the event. The reducer now writes the refreshed notes into the open skill detail.
- The composer collects an optional GitHub link, then the comment rows silently discarded it. Top level comments now render it with the existing GithubCard.

## Gating stays exactly as designed

Top level skill comments remain holder gated (they shape the skill's standing). Replies are open to any connected wallet, the same deliberate split the blog reader ships with. No core or host changes at all; the diff is two webview files.

## Verified

- Read path against mainnet: an existing on chain reply renders under its comment with the count.
- `pnpm --filter agentnet-webview build` green; `tsc --noEmit` introduces no new errors.
- Posting from this UI is now verified end to end on mainnet too: a reply written in the skill page composer landed on chain (tx 2Ff4jS8gLKsZbP7gfXv7nr1L..., first reply on a comment, so it exercised the create table path as well) and rendered back threaded with the count.

## The five rules against this diff

1. No meaningless wrappers: the one new component, `SkillCommentThread`, owns real state (lazy thread load, reply composer, pending flag). No passthroughs.
2. Scan and reuse first: `CommentThreadList`, `NoteComposer`, and `NoteFields` are the blog reader's own, exported instead of copied; the transport ops already existed.
3. No single use type variables: none added.
4. No non-essential parameters: `SkillCommentThread` takes only the note it renders.
5. Responsibilities stay separated: the store keeps owning thread state per postId; the component only asks and renders. The gating split (holder gated comments, open replies) is untouched.
