### PR TITLE
opt-in per-session wallet sync (issue #123)

### DIFF
--- a/packages/core/src/account/migrate.spec.ts
+++ b/packages/core/src/account/migrate.spec.ts
@@ -187,6 +187,24 @@ describe("account/migrate — session re-key between wallets", () => {
     expect((await storeFor(walletB).load("s-ok"))?.messages).toHaveLength(3);
   });
 
+  it("scopes to one session when a sessionId is given: siblings are untouched", async () => {
+    const src = storeFor(walletA);
+    await seed(src, meta("s1", "wanted", 2000), 3);
+    await seed(src, meta("s2", "left local", 1000), 2);
+
+    const report = await migrateSessions(storeFor(walletA), storeFor(walletB), "s1");
+    expect(report).toEqual({ copied: 1, skipped: 0, messages: 3 });
+
+    const dst = storeFor(walletB);
+    expect((await dst.listMine()).map((s) => s.sessionId)).toEqual(["s1"]);
+    expect((await dst.load("s1"))?.messages).toHaveLength(3);
+    expect(await dst.load("s2")).toBeNull();
+
+    // An unknown id copies nothing and fails nothing.
+    const miss = await migrateSessions(storeFor(walletA), storeFor(walletB), "nope");
+    expect(miss).toEqual({ copied: 0, skipped: 0, messages: 0 });
+  });
+
   it("covers the guest-unlock shape: a signMessage-only device wallet migrates into a real wallet", async () => {
     // Mirror of the surface's deviceGuestWallet: session-key signing works, chain signing
     // fails closed. Migration must only ever need signMessage.

--- a/packages/core/src/account/migrate.ts
+++ b/packages/core/src/account/migrate.ts
@@ -12,6 +12,9 @@
 // Idempotent: sessions already complete in the destination are skipped; a partial
 // copy (an interrupted earlier run) resumes — only the missing tail is appended,
 // matched by JSON prefix; a same-id session with DIFFERENT content is never touched.
+//
+// `sessionId` scopes the run to that one session (the opt-in per-session sync);
+// omitted, every source session is copied (the wallet-switch bulk path).
 
 import type { SessionStore } from "./store.js";
 
@@ -24,10 +27,12 @@ export interface MigrationReport {
 export async function migrateSessions(
   source: SessionStore,
   destination: SessionStore,
+  sessionId?: string,
 ): Promise<MigrationReport> {
   const report: MigrationReport = { copied: 0, skipped: 0, messages: 0 };
   const existing = new Set((await destination.listMine()).map((s) => s.sessionId));
-  for (const meta of await source.listMine()) {
+  const metas = await source.listMine();
+  for (const meta of sessionId ? metas.filter((m) => m.sessionId === sessionId) : metas) {
     // Per-session tolerance (mirrors listMine's): one undecryptable/corrupt session
     // must not abort the run — count it and keep copying the healthy ones.
     try {

--- a/surfaces/localhost/src/index.ts
+++ b/surfaces/localhost/src/index.ts
@@ -217,7 +217,7 @@ function sessionStoreFor(w: Wallet): SessionStore {
 // surface part only: which wallets and stores are involved. Scoped to ONE session, so
 // connecting a wallet never adopts guest work wholesale; the user pulls sessions in one
 // at a time from the chat list.
-async function migrateGuestSession(realWallet: Wallet, sessionId: string): Promise<void> {
+async function migrateGuestSession(realWallet: Wallet, sessionId: string): Promise<boolean> {
   const guest = await deviceGuestWallet();
   const report = await migrateSessions(
     sessionStoreFor(guest),
@@ -228,6 +228,10 @@ async function migrateGuestSession(realWallet: Wallet, sessionId: string): Promi
     `[wallet] session sync ${sessionId.slice(0, 8)}: ${report.copied} copied ` +
       `(${report.messages} messages), ${report.skipped} skipped`,
   );
+  // migrateSessions swallows per-session faults into report.skipped (an unloadable
+  // guest page throws inside the loop, not out of it), so "did not throw" is NOT
+  // "copied": only a real copy may clear the Local tag.
+  return report.copied === 1;
 }
 
 // Guest sessions NOT yet present in the connected wallet's store, cached at adopt/sync
@@ -1196,7 +1200,11 @@ function attachWalletConnection(c: Client) {
         return;
       }
       try {
-        await migrateGuestSession(wallet, m.sessionId);
+        const copied = await migrateGuestSession(wallet, m.sessionId);
+        if (!copied) {
+          c.send({ type: "sessionSynced", sessionId: m.sessionId, ok: false, error: "Could not read this session from local storage." });
+          return;
+        }
         if (localSessions) localSessions = localSessions.filter((s) => s.sessionId !== m.sessionId);
         c.send({ type: "sessionSynced", sessionId: m.sessionId, ok: true });
       } catch (e) {

--- a/surfaces/localhost/src/index.ts
+++ b/surfaces/localhost/src/index.ts
@@ -52,6 +52,7 @@ import {
   type ClaudeLogin,
   type CodexLogin,
   type Wallet,
+  type SessionMeta,
   type GoogleLogin,
   type StorageConfig,
   switchStorage,
@@ -205,22 +206,56 @@ async function ensureGuestRuntime(): Promise<AgentRuntime> {
   return ensureRuntime(guest);
 }
 
-// Preserve the value-first conversation when the user unlocks. Guest pages are decrypted
-// with the device key and re-encrypted into the real wallet's local store; the copy loop
-// (dedupe/resume/fault tolerance) lives in core's migrateSessions — this owns the surface
-// part only: which wallets and stores are involved.
-async function migrateGuestSessions(realWallet: Wallet): Promise<void> {
+// A wallet's manual store is always keyed by its own address; keep the pairing in one place.
+function sessionStoreFor(w: Wallet): SessionStore {
+  return new SessionStore(w, manualStorage(w.address));
+}
+
+// Preserve the value-first conversation when the user opts in (issue #123). Guest pages are
+// decrypted with the device key and re-encrypted into the real wallet's local store; the
+// copy loop (dedupe/resume/fault tolerance) lives in core's migrateSessions, this owns the
+// surface part only: which wallets and stores are involved. Scoped to ONE session, so
+// connecting a wallet never adopts guest work wholesale; the user pulls sessions in one
+// at a time from the chat list.
+async function migrateGuestSession(realWallet: Wallet, sessionId: string): Promise<void> {
   const guest = await deviceGuestWallet();
   const report = await migrateSessions(
-    new SessionStore(guest, manualStorage(guest.address)),
-    new SessionStore(realWallet, manualStorage(realWallet.address)),
+    sessionStoreFor(guest),
+    sessionStoreFor(realWallet),
+    sessionId,
   );
-  if (report.copied || report.skipped) {
-    console.log(
-      `[wallet] guest migration: ${report.copied} session(s) copied ` +
-        `(${report.messages} messages), ${report.skipped} skipped`,
-    );
-  }
+  console.log(
+    `[wallet] session sync ${sessionId.slice(0, 8)}: ${report.copied} copied ` +
+      `(${report.messages} messages), ${report.skipped} skipped`,
+  );
+}
+
+// Guest sessions NOT yet present in the connected wallet's store, cached at adopt/sync
+// time. While a wallet is connected these ride along on every `sessions` push tagged
+// `local: true`, so the UI can show the Local tag + per-session sync affordance. Null
+// while no wallet is connected (a guest's list already IS its own local sessions).
+let localSessions: SessionMeta[] | null = null;
+
+async function refreshLocalSessions(realWallet: Wallet): Promise<void> {
+  const guest = await deviceGuestWallet();
+  const owned = new Set((await sessionStoreFor(realWallet).listMine()).map((s) => s.sessionId));
+  localSessions = (await sessionStoreFor(guest).listMine()).filter((s) => !owned.has(s.sessionId));
+}
+
+// Splice the cached guest-only sessions into a core `sessions` push, newest first and
+// tagged local. Pass-through for every other message and while no wallet is connected.
+// Synchronous (cached metas only), so SSE event ordering is untouched. Ids already in
+// the push are skipped: a client attached before the connect still lists from the guest
+// runtime until it reconnects, and appending there would duplicate every row.
+function withLocalSessions(msg: any): unknown {
+  if (msg?.type !== "sessions" || !walletAddress || !localSessions?.length) return msg;
+  const seen = new Set(msg.list.map((s: SessionMeta) => s.sessionId));
+  const extras = localSessions.filter((s) => !seen.has(s.sessionId));
+  if (!extras.length) return msg;
+  const list = [...msg.list, ...extras.map((s) => ({ ...s, local: true }))].sort(
+    (a, b) => b.ts - a.ts,
+  );
+  return { ...msg, list };
 }
 
 // Latest drive-mirror sync result + the hook the active chat sets to surface it
@@ -371,22 +406,27 @@ async function submitGoogleAuthCode(c: Client, code: string) {
 }
 
 // The one path a wallet takes to become THE connected wallet, whatever produced it
-// (external web/MWA wallet or a device-local keypair). Migrate the guest's work into the
-// new wallet's store, swap it in, and rebuild the runtime so the WebView reopens straight
-// into the unlocked state. Idempotent per host: re-connecting the same address is a no-op
-// so re-opened tabs don't rebuild. Adapters below build the Wallet; this owns the connect.
+// (external web/MWA wallet or a device-local keypair). Swap it in and rebuild the runtime
+// so the WebView reopens straight into the unlocked state. Guest sessions are NOT migrated
+// here (issue #123): connecting a wallet must not silently bind the device's local chats
+// to that identity. They stay in the guest store, listed with a Local tag, and move only
+// through the explicit syncSessionToWallet flow. Sessions created from here on are born
+// in the wallet's store, so those keep syncing automatically as before. Idempotent per
+// host: re-connecting the same address is a no-op so re-opened tabs don't rebuild.
+// Adapters below build the Wallet; this owns the connect.
 async function adoptWallet(connected: Wallet, address: string): Promise<void> {
   if (walletAddress === address) return;
-  // A damaged guest store must never lock the user out of connecting — the guest copy
-  // stays on disk, so a later connect can retry the migration.
-  try {
-    await migrateGuestSessions(connected);
-  } catch (e) {
-    console.error("[wallet] guest session migration failed:", e);
-  }
   wallet = connected;
   walletAddress = address;
   walletEpoch += 1;
+  // A damaged guest store must never lock the user out of connecting; tagging is
+  // best-effort and recomputed on the next connect.
+  try {
+    await refreshLocalSessions(connected);
+  } catch (e) {
+    localSessions = [];
+    console.error("[wallet] local session listing failed:", e);
+  }
   await rebuildRuntime(connected);
 }
 
@@ -994,7 +1034,9 @@ function attachMarketHandlers(c: Client) {
 // arrives via the same onRecv (POST), so TransportApprovalChannel is unchanged.
 function attachChat(id: string, c: Client, rt: AgentRuntime) {
   const transport = {
-    send: (msg: unknown) => c.send(msg),
+    // Local (guest) sessions ride along on the dispatcher's sessions pushes while a
+    // wallet is connected (see withLocalSessions); everything else passes through.
+    send: (msg: unknown) => c.send(withLocalSessions(msg)),
     // Subscribe (don't replace): both the dispatcher and the approval channel register a
     // handler on the same transport. POST fans out to all of them.
     onRecv: (cb: (m: any) => void) => { c.recvs.push(cb); },
@@ -1033,6 +1075,7 @@ function attachChat(id: string, c: Client, rt: AgentRuntime) {
       await clearWalletMode(); // explicit disconnect = the standing choice is gone
       await disconnectCloud();
       walletAddress = null;
+      localSessions = null; // back to guest: its own list IS the local sessions
       runtime = null;
       wallet = await deviceGuestWallet();
       walletEpoch += 1;
@@ -1141,6 +1184,24 @@ function attachWalletConnection(c: Client) {
       c.send({ type: "walletConnected", address: walletAddress, storageOptions: STORAGE_OPTIONS, storageConfigured: await isCloudConnected() });
       c.send({ type: "storage", info: await getStorageInfo(), options: STORAGE_OPTIONS, googleCredsConfigured: await hasGoogleCreds() });
       await pushCliStatus(c);
+      return;
+    }
+    // Opt-in per-session sync (issue #123): copy ONE local (guest) session into the
+    // connected wallet's store. The reused migrateSessions machinery is idempotent, so
+    // a retry after a partial copy resumes instead of duplicating. On success the tag
+    // cache drops the session; the UI clears its Local tag off the sessionSynced ack.
+    if (m?.type === "syncSessionToWallet" && typeof m.sessionId === "string") {
+      if (!wallet || !walletAddress) {
+        c.send({ type: "sessionSynced", sessionId: m.sessionId, ok: false, error: "Connect a wallet first." });
+        return;
+      }
+      try {
+        await migrateGuestSession(wallet, m.sessionId);
+        if (localSessions) localSessions = localSessions.filter((s) => s.sessionId !== m.sessionId);
+        c.send({ type: "sessionSynced", sessionId: m.sessionId, ok: true });
+      } catch (e) {
+        c.send({ type: "sessionSynced", sessionId: m.sessionId, ok: false, error: (e as Error).message });
+      }
       return;
     }
     if (m?.type !== "connectWallet" || typeof m.address !== "string" || !Array.isArray(m.signature)) return;

--- a/surfaces/webview/src/chat/Sessions.tsx
+++ b/surfaces/webview/src/chat/Sessions.tsx
@@ -1,4 +1,5 @@
 import { useState, useEffect, useRef, type ReactNode, type CSSProperties, type PointerEvent as ReactPointerEvent } from "react";
+import { walletAvatarSvg } from "../market/walletAvatar";
 import { useStore } from "../state/store";
 import { IqLogo, AgentIcon, LockIcon, SkillIcon } from "../icons";
 import { useOnline } from "../layoutEffects";
@@ -469,9 +470,12 @@ export function Sessions({
                   <div className="an-chatmenu-title truncate">{syncFor.title}</div>
                   <div className="px-3 pb-3">
                     <p className="text-[12px] leading-relaxed" style={{ color: "var(--an-fg-dim)" }}>{t(M.menu.syncConfirm)}</p>
-                    <p className="an-term-mono mt-2 break-all border px-2 py-1.5 text-[11px] leading-relaxed" style={{ borderColor: "var(--an-green-line)", background: "var(--an-green-dim)", color: "var(--an-term-fg)" }}>
-                      {state.walletAddress}
-                    </p>
+                    {/* Destination identity, address AND the agent it renders as (issue #123
+                        point 3): the avatar is derived from the wallet, same as the rank cards. */}
+                    <div className="an-term-mono mt-2 flex items-center gap-2.5 border px-2 py-1.5 text-[11px] leading-relaxed" style={{ borderColor: "var(--an-green-line)", background: "var(--an-green-dim)", color: "var(--an-term-fg)" }}>
+                      <span className="h-7 w-7 shrink-0 overflow-hidden" style={{ border: "1px solid var(--an-line)" }} aria-hidden="true" dangerouslySetInnerHTML={{ __html: walletAvatarSvg(state.walletAddress ?? "") }} />
+                      <span className="break-all">{state.walletAddress}</span>
+                    </div>
                     <div className="mt-3 flex gap-2">
                       <button className="an-btn an-btn-outline flex-1" onClick={() => setSyncFor(null)}>{t(M.menu.syncKeepLocal)}</button>
                       <button

--- a/surfaces/webview/src/chat/Sessions.tsx
+++ b/surfaces/webview/src/chat/Sessions.tsx
@@ -19,6 +19,18 @@ function WifiOffIcon({ className, style }: { className?: string; style?: CSSProp
     </svg>
   );
 }
+
+// circular-arrows mark for the per-session sync affordance (issue #123; inline SVG, no emoji).
+function SyncIcon({ className, style }: { className?: string; style?: CSSProperties }) {
+  return (
+    <svg className={className} style={style} viewBox="0 0 24 24" fill="none" stroke="currentColor" strokeWidth="1.8" strokeLinecap="round" strokeLinejoin="round">
+      <path d="M3 12a9 9 0 0 1 9-9 9.75 9.75 0 0 1 6.74 2.74L21 8" />
+      <path d="M21 3v5h-5" />
+      <path d="M21 12a9 9 0 0 1-9 9 9.75 9.75 0 0 1-6.74-2.74L3 16" />
+      <path d="M8 16H3v5" />
+    </svg>
+  );
+}
 import { forgetAndroidWallet } from "../onboarding/androidWallet";
 import { openExternalUrl } from "../platform/openExternalUrl";
 import { useAutoOpenExternalUrl } from "../platform/useAutoOpenExternalUrl";
@@ -171,6 +183,10 @@ export function Sessions({
   // Long-press a chat row to reveal a delete menu (replaces the always-on per-row x).
   // `pressFired` suppresses the row's open-on-click that would otherwise follow pointerup.
   const [menuFor, setMenuFor] = useState<{ id: string; title: string } | null>(null);
+  // Confirm sheet for the opt-in per-session sync (issue #123): tapping a Local row
+  // opens this instead of the chat, so a pre-wallet session is never opened (and
+  // possibly forked) under the wallet identity without an explicit yes.
+  const [syncFor, setSyncFor] = useState<{ id: string; title: string } | null>(null);
   const pressTimer = useRef<number | null>(null);
   const pressOrigin = useRef<{ x: number; y: number } | null>(null);
   const pressFired = useRef(false);
@@ -369,15 +385,25 @@ export function Sessions({
                 {state.sessions.map((s) => {
                   const active = s.sessionId === state.activeSessionId;
                   const running = state.sessionsRunning.includes(s.sessionId);
+                  // Pre-wallet session still in the device store (server tags these only
+                  // while a wallet is connected). Its row opens the sync confirm, never
+                  // the chat: the wallet runtime can't load it, and sending into an empty
+                  // same-id chat would fork the history and block the sync forever. No
+                  // long-press delete either; the wallet store doesn't hold this session.
+                  const local = !!s.local;
                   return (
                     <button
                       key={s.sessionId}
-                      onPointerDown={(e) => startPress(e, s)}
+                      onPointerDown={(e) => { if (!local) startPress(e, s); }}
                       onPointerMove={movePress}
                       onPointerUp={clearPress}
                       onPointerCancel={clearPress}
                       onClick={() => {
                         if (pressFired.current) { pressFired.current = false; return; }
+                        if (local) {
+                          setSyncFor({ id: s.sessionId, title: s.title || t(M.menu.untitled) });
+                          return;
+                        }
                         send({ type: "open", sessionId: s.sessionId });
                         onClose();
                       }}
@@ -387,6 +413,12 @@ export function Sessions({
                       <span className="an-term-mono min-w-0 flex-1 truncate text-[15px] font-bold" style={{ color: running ? "var(--an-run-fg)" : active ? "var(--an-term-fg)" : "var(--an-term-fg-2)" }}>
                         {s.title || t(M.menu.untitled)}
                       </span>
+                      {local && (
+                        <span className="an-term-mono ml-2 flex flex-none items-center gap-1.5 text-[11px] font-bold" style={{ color: "var(--an-term-fg-6)", letterSpacing: "0.5px" }}>
+                          LOCAL
+                          <SyncIcon className="h-3.5 w-3.5" style={{ color: "var(--an-green)" }} />
+                        </span>
+                      )}
                       {running && (
                         <span className="an-term-mono an-run ml-2 flex-none text-[11px] font-bold" style={{ color: "var(--an-run-accent)", letterSpacing: "0.5px" }}>
                           RUN
@@ -425,6 +457,34 @@ export function Sessions({
                     <svg width="18" height="18" viewBox="0 0 22 22" fill="none" stroke="currentColor" strokeWidth="1.7" strokeLinecap="round" strokeLinejoin="round"><path d="M4 6h14M9 6V4.5h4V6M6 6l.8 11a1.5 1.5 0 0 0 1.5 1.4h5.4a1.5 1.5 0 0 0 1.5-1.4L17 6" /></svg>
                     {t(M.menu.deleteChat)}
                   </button>
+                </div>
+              </div>
+            )}
+
+            {/* Opt-in per-session sync confirm (issue #123): show the destination wallet
+                address up front, then migrate that ONE session on an explicit yes. */}
+            {syncFor && (
+              <div className="an-chatmenu-backdrop" onClick={() => setSyncFor(null)}>
+                <div className="an-chatmenu" onClick={(e) => e.stopPropagation()}>
+                  <div className="an-chatmenu-title truncate">{syncFor.title}</div>
+                  <div className="px-3 pb-3">
+                    <p className="text-[12px] leading-relaxed" style={{ color: "var(--an-fg-dim)" }}>{t(M.menu.syncConfirm)}</p>
+                    <p className="an-term-mono mt-2 break-all border px-2 py-1.5 text-[11px] leading-relaxed" style={{ borderColor: "var(--an-green-line)", background: "var(--an-green-dim)", color: "var(--an-term-fg)" }}>
+                      {state.walletAddress}
+                    </p>
+                    <div className="mt-3 flex gap-2">
+                      <button className="an-btn an-btn-outline flex-1" onClick={() => setSyncFor(null)}>{t(M.menu.syncKeepLocal)}</button>
+                      <button
+                        className="an-btn an-btn-green flex-1"
+                        onClick={() => {
+                          send({ type: "syncSessionToWallet", sessionId: syncFor.id });
+                          setSyncFor(null);
+                        }}
+                      >
+                        {t(M.menu.syncAction)}
+                      </button>
+                    </div>
+                  </div>
                 </div>
               </div>
             )}

--- a/surfaces/webview/src/i18n/messages.ts
+++ b/surfaces/webview/src/i18n/messages.ts
@@ -213,6 +213,11 @@ export const M = {
     untitled: m("(untitled)", "(제목 없음)", "(без названия)"),
     newChat: m("New chat", "새 채팅", "Новый чат"),
     deleteChat: m("Delete chat", "채팅 삭제", "Удалить чат"),
+    // opt-in per-session sync (issue #123): confirm sheet for pulling a Local chat
+    // into the connected wallet. The LOCAL row tag itself is a terminal token (inline).
+    syncConfirm: m("Sync this session with this agent?", "이 세션을 이 에이전트와 동기화할까요?", "Синхронизировать эту сессию с этим агентом?"),
+    syncAction: m("Sync", "동기화", "Синхронизировать"),
+    syncKeepLocal: m("Keep local", "로컬로 유지", "Оставить локально"),
   },
 
   settings: {

--- a/surfaces/webview/src/state/store.tsx
+++ b/surfaces/webview/src/state/store.tsx
@@ -432,6 +432,14 @@ function reducer(state: State, ev: Action): State {
         sessionsRunning: ev.running ?? [],
         activeSessionId: state.activeSessionId ?? ev.activeId,
       };
+    case "sessionSynced":
+      // Per-session sync ack (issue #123). Clear the row's Local tag right away instead of
+      // waiting for the next natural sessions push (which only fires at turn edges/ready).
+      if (!ev.ok) return { ...state, toast: `Sync failed: ${ev.error ?? "unknown"}` };
+      return {
+        ...state,
+        sessions: state.sessions.map((s) => (s.sessionId === ev.sessionId ? { ...s, local: undefined } : s)),
+      };
     case "loading":
       return { ...state, loading: true };
     // Optimistic session switch: the moment the user taps a chat, flip the active id (so

--- a/surfaces/webview/src/transport/protocol.ts
+++ b/surfaces/webview/src/transport/protocol.ts
@@ -43,6 +43,10 @@ export interface SessionMeta {
   sessionId: string;
   title: string;
   ts: number;
+  // true = a pre-wallet guest session still living in the device store: not bound to the
+  // connected wallet until the user opts in via syncSessionToWallet. Only ever set while
+  // a wallet is connected (localhost splices these into the list, see withLocalSessions).
+  local?: boolean;
 }
 
 export type ApprovalKind = "bash" | "edit" | "write" | "read" | "question" | "plan" | "other";
@@ -105,6 +109,9 @@ export type ClientMessage =
   | { type: "interrupt" }
   | { type: "loadMore"; cursor: number }
   | { type: "delete"; sessionId: string }
+  // opt-in per-session sync (issue #123): copy ONE local (guest) session into the
+  // connected wallet's store; answered by sessionSynced.
+  | { type: "syncSessionToWallet"; sessionId: string }
   | { type: "wallet" }
   | { type: "getCliStatus" }
   | { type: "getEngineVersions" }
@@ -207,6 +214,9 @@ export type ServerMessage =
   // running: sessionIds whose agent turn is in flight right now (server reads its `busy`
   // set at each turn edge). Lets the list mark a per-session RUNNING state; absent = none.
   | { type: "sessions"; list: SessionMeta[]; activeId?: string; running?: string[]; cloud?: "ok" | "reauth" | "transient" | "none" }
+  // ack of syncSessionToWallet: ok = the session now lives in the wallet's store (its
+  // Local tag clears); the guest copy stays on disk either way (migration never deletes).
+  | { type: "sessionSynced"; sessionId: string; ok: boolean; error?: string }
   | { type: "modelOptions"; cli: Cli; options: import("@iqlabs-official/agent-sdk").ChatModelOption[] }
   | { type: "loading" }
   | { type: "platform"; cli: Cli }


### PR DESCRIPTION

Closes #123, following the decision and the 4 step plan written in the issue. The issue already contained the design, the message name, and the placement, which made this a pleasure to build; specs this well written are rare, and working on this project keeps being fun.

## What

Connecting a wallet no longer silently adopts the device's pre wallet chats. `adoptWallet` stops calling the guest migration wholesale; pre wallet sessions stay in the guest store and ride along on session pushes tagged LOCAL. Each one moves only through the new `syncSessionToWallet` message: tapping a LOCAL row opens a confirm sheet showing the destination wallet address and its agent avatar, and an explicit yes migrates that ONE session. Sessions created while a wallet is connected are born in the wallet's store and keep syncing automatically, exactly as today (the issue's scope line: only pre wallet sessions are affected).

The migration machinery is reused, not rewritten: `migrateSessions` (already on main) gained a single optional session scope, and the per session flow goes through it, so dedupe, resume after partial copy, and fault tolerance are the same code the wholesale path always used. The ack is truthful: `migrateSessions` swallows per session faults into `report.skipped`, so the handler acks ok only when `report.copied` is 1; a skipped copy keeps the LOCAL tag and reports a readable error instead of silently dropping the session from the list.

## One judgment call, flagged for your veto

Point 2 of the issue asks for a sync icon in the chat screen. A pre wallet session cannot be opened under the wallet runtime (the wallet store cannot load the guest page, and sending into an empty same id chat would fork the history), so tapping a LOCAL row opens the sync confirm instead of the chat, and the icon lives on the row. That means a pre wallet chat is not readable while a wallet is connected until it is synced (or the wallet is disconnected). If you want a read only open path for unsynced sessions instead, happy to build it as a follow up; this seemed like the smallest honest v1.

## Verified

- `pnpm --filter agentnet-webview build` green; `tsc --noEmit` clean for localhost; webview `tsc --noEmit` introduces no new errors (the same 9 pre-existing TS6133 hits as `main`, byte identical).
- The truthful ack path is exercised through `migrateSessions`' existing report shape (its specs cover copied vs skipped).
- Not verified: a live two device pass with a real wallet connect. The flow reuses the exact machinery the automatic migration used, but the UI path deserves one hands on run in review.

## The five rules against this diff

1. No meaningless wrappers: the localhost handler owns real work (wallet gate, truthful ack, tag cache upkeep); `migrateGuestSession` narrows stores and scope, not a passthrough.
2. Scan and reuse first: the copy loop is `migrateSessions` with a scope parameter; the confirm sheet reuses the chat menu idiom; the avatar reuses the rank card generator.
3. No single use type variables: none added.
4. No non-essential parameters: one optional `sessionId` scope on `migrateSessions`, used by this feature and useful to any future partial migration.
5. Responsibilities separated: core owns copying, the host owns which wallets and stores, the webview owns consent UI.

