### PR TITLE
Running Sync: cross-device RUNNING markers (issue #129)

### DIFF
--- a/packages/core/src/account/runningMarkers.spec.ts
+++ b/packages/core/src/account/runningMarkers.spec.ts
@@ -1,0 +1,117 @@
+// Running Sync markers (issue #129): the two-writes-per-turn protocol, the
+// reader rule (running AND expiresAt + grace > now), turn-scoped ends, and the
+// deviceId-scoped startup sweep - all over an in-memory StorageAdapter.
+import { describe, it, expect, vi, beforeEach } from "vitest";
+import { RunningMarkers, RUNNING_TTL_MS, READER_GRACE_MS, type RunningMarker } from "./runningMarkers.js";
+import type { StorageAdapter } from "../runtime/contract.js";
+
+const THIS_DEVICE = "device-aaaa";
+let deviceId = THIS_DEVICE;
+vi.mock("../core/device.js", () => ({
+  getDeviceProfile: vi.fn(() => Promise.resolve({ id: deviceId, label: "test" })),
+}));
+
+function memStorage(): StorageAdapter & { blobs: Map<string, Uint8Array> } {
+  const blobs = new Map<string, Uint8Array>();
+  return {
+    blobs,
+    put: async (k, b) => void blobs.set(k, b),
+    get: async (k) => blobs.get(k) ?? null,
+    list: async () => [...blobs.keys()],
+    remove: async (k) => void blobs.delete(k),
+  };
+}
+
+const readMarker = (s: { blobs: Map<string, Uint8Array> }, sessionId: string): RunningMarker =>
+  JSON.parse(new TextDecoder().decode(s.blobs.get(`running__${sessionId}`)!));
+
+describe("account/runningMarkers", () => {
+  beforeEach(() => {
+    deviceId = THIS_DEVICE;
+  });
+
+  it("start writes a running marker with the default 20 minute expiry; end overwrites it with ended", async () => {
+    const storage = memStorage();
+    const markers = new RunningMarkers(storage);
+
+    const before = Date.now();
+    const turnId = await markers.start("sess-1");
+    const running = readMarker(storage, "sess-1");
+    expect(running.state).toBe("running");
+    expect(running.deviceId).toBe(THIS_DEVICE);
+    expect(running.expiresAt - running.startedAt).toBe(RUNNING_TTL_MS);
+    expect(running.startedAt).toBeGreaterThanOrEqual(before);
+
+    await markers.end("sess-1", turnId);
+    const ended = readMarker(storage, "sess-1");
+    expect(ended.state).toBe("ended");
+    expect(ended.turnId).toBe(turnId);
+    expect(ended.endedAt).toBeGreaterThanOrEqual(running.startedAt);
+  });
+
+  it("end with a stale turnId cannot close a newer turn's marker", async () => {
+    const storage = memStorage();
+    const markers = new RunningMarkers(storage);
+
+    const oldTurn = await markers.start("sess-1");
+    const newTurn = await markers.start("sess-1"); // newer turn owns the file now
+    await markers.end("sess-1", oldTurn); // delayed/retried end from the old turn
+    expect(readMarker(storage, "sess-1").state).toBe("running");
+    expect(readMarker(storage, "sess-1").turnId).toBe(newTurn);
+  });
+
+  it("liveRemote lists only other devices' running, unexpired markers", async () => {
+    const storage = memStorage();
+    const markers = new RunningMarkers(storage);
+
+    deviceId = "device-bbbb"; // another device writes...
+    await markers.start("remote-live");
+    const endedTurn = await markers.start("remote-ended");
+    await markers.end("remote-ended", endedTurn);
+    deviceId = THIS_DEVICE; // ...and this device reads
+    await markers.start("mine"); // own marker: covered by the local busy set
+
+    expect(await markers.liveRemote()).toEqual(["remote-live"]);
+  });
+
+  it("liveRemote treats an expired marker as ended regardless of its state", async () => {
+    const storage = memStorage();
+    const markers = new RunningMarkers(storage);
+    deviceId = "device-bbbb";
+    await markers.start("remote-stale");
+    deviceId = THIS_DEVICE;
+
+    const past = Date.now() + RUNNING_TTL_MS + READER_GRACE_MS + 1;
+    vi.spyOn(Date, "now").mockReturnValue(past);
+    try {
+      expect(await markers.liveRemote()).toEqual([]);
+    } finally {
+      vi.restoreAllMocks();
+    }
+  });
+
+  it("sweep force-closes this device's leftover running markers and drops its ended ones, leaving other devices' alone", async () => {
+    const storage = memStorage();
+    const markers = new RunningMarkers(storage);
+
+    await markers.start("crashed"); // running, never ended (simulated crash)
+    const done = await markers.start("finished");
+    await markers.end("finished", done);
+    deviceId = "device-bbbb";
+    await markers.start("theirs");
+    deviceId = THIS_DEVICE;
+
+    await markers.sweep();
+    expect(readMarker(storage, "crashed").state).toBe("ended");
+    expect(storage.blobs.has("running__finished")).toBe(false); // bounded marker set
+    expect(readMarker(storage, "theirs").state).toBe("running"); // not ours to touch
+  });
+
+  it("ignores a corrupt marker blob instead of failing the list", async () => {
+    const storage = memStorage();
+    const markers = new RunningMarkers(storage);
+    storage.blobs.set("running__bad", new TextEncoder().encode("not json"));
+    expect(await markers.liveRemote()).toEqual([]);
+    await expect(markers.sweep()).resolves.toBeUndefined();
+  });
+});

--- a/packages/core/src/account/runningMarkers.spec.ts
+++ b/packages/core/src/account/runningMarkers.spec.ts
@@ -22,8 +22,10 @@ function memStorage(): StorageAdapter & { blobs: Map<string, Uint8Array> } {
   };
 }
 
-const readMarker = (s: { blobs: Map<string, Uint8Array> }, sessionId: string): RunningMarker =>
-  JSON.parse(new TextDecoder().decode(s.blobs.get(`running__${sessionId}`)!));
+// Keys are per session PER DEVICE (running__{sessionId}__{deviceId}) so a
+// device can only ever shadow or sweep its own markers (see the module header).
+const readMarker = (s: { blobs: Map<string, Uint8Array> }, sessionId: string, device = THIS_DEVICE): RunningMarker =>
+  JSON.parse(new TextDecoder().decode(s.blobs.get(`running__${sessionId}__${device}`)!));
 
 describe("account/runningMarkers", () => {
   beforeEach(() => {
@@ -103,8 +105,8 @@ describe("account/runningMarkers", () => {
 
     await markers.sweep();
     expect(readMarker(storage, "crashed").state).toBe("ended");
-    expect(storage.blobs.has("running__finished")).toBe(false); // bounded marker set
-    expect(readMarker(storage, "theirs").state).toBe("running"); // not ours to touch
+    expect(storage.blobs.has(`running__finished__${THIS_DEVICE}`)).toBe(false); // bounded marker set
+    expect(readMarker(storage, "theirs", "device-bbbb").state).toBe("running"); // not ours to touch
   });
 
   it("ignores a corrupt marker blob instead of failing the list", async () => {

--- a/packages/core/src/account/runningMarkers.ts
+++ b/packages/core/src/account/runningMarkers.ts
@@ -6,9 +6,14 @@
 // marker can never spin forever: expiry is a read-side display decision.
 //
 // The issue's open questions, resolved conservatively for v1:
-// - Placement: ONE MARKER FILE PER SESSION ("running__{sessionId}") rather than a
-//   single account-wide map - two devices running turns at the same time never
-//   contend on one blob, and the key shape mirrors the memory__ / page keys.
+// - Placement: ONE MARKER FILE PER SESSION PER DEVICE
+//   ("running__{sessionId}__{deviceId}") rather than a single account-wide map
+//   or one shared per-session file. Each device only ever writes ITS OWN key,
+//   which is what makes the local-first mirror safe: the mirror's get() prefers
+//   the local tier, so a shared key would let this device's stale local copy
+//   shadow (and its sweep destroy) another device's live cloud marker. With
+//   per-device keys another device's marker never exists in our local tier, so
+//   reading it always hits the cloud, and the sweep can only touch our own.
 // - Expiry classes: the issue's defaults (20 min normal, 60 min deepResearch).
 //   No flow sets deepResearch yet; the class is kept here so a known long-running
 //   flow can opt in at turn start later without a format change.
@@ -45,7 +50,7 @@ export interface RunningMarker {
 }
 
 const PREFIX = "running__";
-const markerKey = (sessionId: string) => `${PREFIX}${sessionId}`;
+const markerKey = (sessionId: string, deviceId: string) => `${PREFIX}${sessionId}__${deviceId}`;
 
 // The reader rule: running AND not yet expired on OUR clock (+ grace). An
 // expired marker is ended regardless of its state - nobody has to delete it.
@@ -70,7 +75,7 @@ export class RunningMarkers {
   }
 
   private async write(m: RunningMarker): Promise<void> {
-    await this.storage.put(markerKey(m.sessionId), new TextEncoder().encode(JSON.stringify(m)));
+    await this.storage.put(markerKey(m.sessionId, m.deviceId), new TextEncoder().encode(JSON.stringify(m)));
   }
 
   // Turn start -> write the `running` marker (write 1 of 2). Returns the turnId
@@ -95,7 +100,8 @@ export class RunningMarkers {
   // Turn end (interrupt lands on the same path) -> overwrite with `ended`
   // (write 2 of 2). Only closes the matching turnId: a newer turn owns the file.
   async end(sessionId: string, turnId: string): Promise<void> {
-    const cur = await this.read(markerKey(sessionId), true);
+    const device = await getDeviceProfile();
+    const cur = await this.read(markerKey(sessionId, device.id), true);
     if (!cur || cur.turnId !== turnId) return;
     await this.write({ ...cur, state: "ended", endedAt: Date.now() });
   }

--- a/packages/core/src/account/runningMarkers.ts
+++ b/packages/core/src/account/runningMarkers.ts
@@ -1,0 +1,142 @@
+// Running Sync (issue #129): cross-device RUNNING state via fixed-TTL markers on
+// the SAME StorageAdapter that syncs sessions. A turn writes exactly two markers:
+// a `running` mark at turn start and an `ended` overwrite at turn end - no
+// renewals, no heartbeat, no cleanup job. Readers treat a marker as live only
+// while `state == "running" AND expiresAt (+ grace) > now`, so an abandoned
+// marker can never spin forever: expiry is a read-side display decision.
+//
+// The issue's open questions, resolved conservatively for v1:
+// - Placement: ONE MARKER FILE PER SESSION ("running__{sessionId}") rather than a
+//   single account-wide map - two devices running turns at the same time never
+//   contend on one blob, and the key shape mirrors the memory__ / page keys.
+// - Expiry classes: the issue's defaults (20 min normal, 60 min deepResearch).
+//   No flow sets deepResearch yet; the class is kept here so a known long-running
+//   flow can opt in at turn start later without a format change.
+// - CLI surface: read-only in v1 - no CLI wiring ships with this module.
+//
+// Markers are PLAINTEXT json, unlike session/memory blobs: they carry only ids
+// and timestamps (never chat content), and the sessionId is already exposed as
+// the plaintext storage key of every session page, so encrypting them would cost
+// every reader a wallet decrypt per marker per list sync for no added secrecy.
+// The device LABEL (hostname) is deliberately NOT stored - only the opaque id.
+
+import { randomUUID } from "node:crypto";
+import type { StorageAdapter } from "../runtime/contract.js";
+import { getDeviceProfile } from "../core/device.js";
+
+// Hardcoded expiry classes, chosen at turn start (see the issue: fixed windows
+// instead of lease renewal - a crashed device's marker dies by construction).
+export const RUNNING_TTL_MS = 20 * 60_000;
+export const DEEP_RESEARCH_TTL_MS = 60 * 60_000;
+// Clock-skew grace on the READER side: expiresAt is compared against the
+// reader's own clock; windows are tens of minutes while realistic skew is
+// seconds, so a fixed margin is all the clock agreement we ever require.
+export const READER_GRACE_MS = 60_000;
+
+export interface RunningMarker {
+  sessionId: string;
+  turnId: string; // fresh per turn; an `ended` write only closes its own turn
+  deviceId: string; // writer's device (core/device.ts id), for the startup sweep
+  state: "running" | "ended";
+  startedAt: number;
+  expiresAt: number;
+  endedAt?: number;
+  deepResearch?: boolean; // long-flow class (60 min); absent = default (20 min)
+}
+
+const PREFIX = "running__";
+const markerKey = (sessionId: string) => `${PREFIX}${sessionId}`;
+
+// The reader rule: running AND not yet expired on OUR clock (+ grace). An
+// expired marker is ended regardless of its state - nobody has to delete it.
+function isLive(m: RunningMarker, now: number): boolean {
+  return m.state === "running" && m.expiresAt + READER_GRACE_MS > now;
+}
+
+export class RunningMarkers {
+  constructor(private storage: StorageAdapter) {}
+
+  private async read(key: string, localOnly = false): Promise<RunningMarker | null> {
+    const blob = localOnly && this.storage.getLocal
+      ? await this.storage.getLocal(key)
+      : await this.storage.get(key);
+    if (!blob) return null;
+    try {
+      const m = JSON.parse(new TextDecoder().decode(blob)) as RunningMarker;
+      return m && (m.state === "running" || m.state === "ended") && typeof m.expiresAt === "number" ? m : null;
+    } catch {
+      return null; // unreadable marker = no marker; never break the session list
+    }
+  }
+
+  private async write(m: RunningMarker): Promise<void> {
+    await this.storage.put(markerKey(m.sessionId), new TextEncoder().encode(JSON.stringify(m)));
+  }
+
+  // Turn start -> write the `running` marker (write 1 of 2). Returns the turnId
+  // the matching end() must echo, so a delayed/retried end from a previous turn
+  // can never kill the badge of a newer turn on the same session.
+  async start(sessionId: string, deepResearch = false): Promise<string> {
+    const now = Date.now();
+    const turnId = randomUUID();
+    const device = await getDeviceProfile();
+    await this.write({
+      sessionId,
+      turnId,
+      deviceId: device.id,
+      state: "running",
+      startedAt: now,
+      expiresAt: now + (deepResearch ? DEEP_RESEARCH_TTL_MS : RUNNING_TTL_MS),
+      ...(deepResearch ? { deepResearch: true } : {}),
+    });
+    return turnId;
+  }
+
+  // Turn end (interrupt lands on the same path) -> overwrite with `ended`
+  // (write 2 of 2). Only closes the matching turnId: a newer turn owns the file.
+  async end(sessionId: string, turnId: string): Promise<void> {
+    const cur = await this.read(markerKey(sessionId), true);
+    if (!cur || cur.turnId !== turnId) return;
+    await this.write({ ...cur, state: "ended", endedAt: Date.now() });
+  }
+
+  // sessionIds with a LIVE marker written by ANOTHER device. This device's own
+  // in-flight turns are already covered by the dispatcher's in-process busy set
+  // (and its stale markers are its own ghosts, cleared by sweep), so same-device
+  // markers are excluded here.
+  async liveRemote(): Promise<string[]> {
+    const device = await getDeviceProfile();
+    const now = Date.now();
+    const keys = (await this.storage.list()).filter((k) => k.startsWith(PREFIX));
+    const out: string[] = [];
+    await Promise.all(
+      keys.map(async (k) => {
+        const m = await this.read(k);
+        if (m && m.deviceId !== device.id && isLive(m, now)) out.push(m.sessionId);
+      }),
+    );
+    return out;
+  }
+
+  // Startup sweep, scoped by deviceId: force-close `running` markers this device
+  // left behind (a crash never wrote their `ended` mark), so a restart clears its
+  // own ghosts immediately instead of waiting out the expiry window. Ended
+  // markers this device wrote are removed: their only job is beating the expiry
+  // on live readers, long past by the next boot, and dropping them keeps the
+  // per-sync marker read set bounded. LOCAL tier only - this device's markers
+  // were written through it, so booting never waits on the cloud (the mirror
+  // propagates the fixes best-effort like any other write).
+  async sweep(): Promise<void> {
+    const list = this.storage.listLocal ? this.storage.listLocal() : this.storage.list();
+    const keys = (await list).filter((k) => k.startsWith(PREFIX));
+    const device = await getDeviceProfile();
+    await Promise.all(
+      keys.map(async (k) => {
+        const m = await this.read(k, true);
+        if (!m || m.deviceId !== device.id) return;
+        if (m.state === "running") await this.write({ ...m, state: "ended", endedAt: Date.now() });
+        else await this.storage.remove(k);
+      }),
+    );
+  }
+}

--- a/packages/core/src/chat/session.spec.ts
+++ b/packages/core/src/chat/session.spec.ts
@@ -50,7 +50,7 @@ const waitForNotice = async (transport: any, text: string) => {
   throw new Error(`notice "${text}" was never sent`);
 };
 
-function harness(opts: { cwd?: string; ownedSkills?: string[]; googleCredsConfigured?: boolean; env?: Record<string, unknown> } = {}) {
+function harness(opts: { cwd?: string; ownedSkills?: string[]; googleCredsConfigured?: boolean; env?: Record<string, unknown>; rt?: Record<string, unknown> } = {}) {
   const handles: ReturnType<typeof fakeHandle>[] = [];
   const startSession = vi.fn(async (opts: any) => {
     const h = fakeHandle("sess-" + handles.length, opts.cli);
@@ -69,7 +69,7 @@ function harness(opts: { cwd?: string; ownedSkills?: string[]; googleCredsConfig
     ownedSkills: opts.ownedSkills ? async () => opts.ownedSkills : undefined,
     ...opts.env,
   };
-  const chat = createChatSession(startSessionRuntime(startSession), transport as any, env);
+  const chat = createChatSession({ ...startSessionRuntime(startSession), ...opts.rt }, transport as any, env);
   return { handles, startSession, fromUI, chat, transport };
 }
 
@@ -560,5 +560,60 @@ describe("chat/session — a handler that throws", () => {
     });
     // the message behind the failure is still handled — a throw must not abandon the queue
     expect(transport.send).toHaveBeenCalledWith({ type: "wallet", address: null });
+  });
+});
+
+// Running Sync (issue #129): the dispatcher writes the cross-device marker at its
+// existing turn edges (two writes per turn) and unions live markers from OTHER
+// devices into the sessions frame's running list.
+describe("chat/session - Running Sync markers (issue #129)", () => {
+  it("writes the running marker at turn start and the matching ended mark at turn end", async () => {
+    const runningStart = vi.fn(async () => "turn-1");
+    const runningEnd = vi.fn(async () => {});
+    const { fromUI, handles } = harness({ rt: { runningStart, runningEnd } });
+
+    fromUI({ type: "send", text: "hi" });
+    await flush();
+    expect(runningStart).toHaveBeenCalledWith("sess-0");
+    expect(runningEnd).not.toHaveBeenCalled();
+
+    handles[0].emitTurnEnd();
+    await flush();
+    expect(runningEnd).toHaveBeenCalledWith("sess-0", "turn-1");
+  });
+
+  it("an interrupted turn ends the marker too (interrupt fires the same turn-end path)", async () => {
+    const runningStart = vi.fn(async () => "turn-1");
+    const runningEnd = vi.fn(async () => {});
+    const { fromUI, handles } = harness({ rt: { runningStart, runningEnd } });
+
+    fromUI({ type: "send", text: "hi" });
+    await flush();
+    fromUI({ type: "interrupt" });
+    handles[0].emitTurnEnd(); // the engine acks the interrupt as a turn end
+    await flush();
+    expect(runningEnd).toHaveBeenCalledWith("sess-0", "turn-1");
+  });
+
+  it("merges live markers from other devices into the sessions frame's running list", async () => {
+    const runningRemote = vi.fn(async () => ["remote-sess"]);
+    const { fromUI, transport } = harness({ rt: { runningRemote } });
+
+    fromUI({ type: "ready" });
+    await flush();
+    const frames = transport.send.mock.calls.map((c: any[]) => c[0]).filter((m: any) => m?.type === "sessions");
+    expect(frames.length).toBeGreaterThan(0);
+    expect(frames[frames.length - 1].running).toContain("remote-sess");
+  });
+
+  it("a failing remote-marker read never breaks the session list", async () => {
+    const runningRemote = vi.fn(async () => { throw new Error("cloud down"); });
+    const { fromUI, transport } = harness({ rt: { runningRemote } });
+
+    fromUI({ type: "ready" });
+    await flush();
+    const frames = transport.send.mock.calls.map((c: any[]) => c[0]).filter((m: any) => m?.type === "sessions");
+    expect(frames.length).toBeGreaterThan(0);
+    expect(frames[frames.length - 1].running).toEqual([]);
   });
 });

--- a/packages/core/src/chat/session.ts
+++ b/packages/core/src/chat/session.ts
@@ -276,7 +276,13 @@ export function createChatSession(
     if (s.restage === h) s.restage = null;
     busy.delete(h);
     retire.delete(h);
+    // Running Sync: an app-controlled stop (clear, delete) ends the turn without
+    // ever reaching onTurnEnd, so close the cross-device marker here too or other
+    // devices would show RUNNING for the full expiry window. Best-effort like the
+    // normal turn-end write.
+    const mark = turnMarks.get(h);
     turnMarks.delete(h);
+    if (mark && rt.runningEnd) void mark.then((turnId) => (turnId ? rt.runningEnd!(h.sessionId, turnId) : undefined)).catch(() => {});
     h.stop();
   }
 

--- a/packages/core/src/chat/session.ts
+++ b/packages/core/src/chat/session.ts
@@ -253,6 +253,10 @@ export function createChatSession(
   // Parked handles to stop the moment their background turn ends (flagged on switch-away
   // from a busy session). Cleared if you switch back before that turn ends.
   const retire = new Set<SessionHandle>();
+  // Running Sync (issue #129): per-handle turnId of the cross-device RUNNING marker
+  // written at turn start (a promise - marker writes never block the send path);
+  // onTurnEnd awaits it to write the matching `ended` mark, and only that turn's.
+  const turnMarks = new Map<SessionHandle, Promise<string | null>>();
 
   function isVisibleHandle(forCli: "claude" | "codex", h: SessionHandle): boolean {
     return cli === forCli && slots[forCli].handle === h;
@@ -272,6 +276,7 @@ export function createChatSession(
     if (s.restage === h) s.restage = null;
     busy.delete(h);
     retire.delete(h);
+    turnMarks.delete(h);
     h.stop();
   }
 
@@ -308,6 +313,13 @@ export function createChatSession(
     });
     h.onTurnEnd(async () => {
       busy.delete(h);
+      // Running Sync (issue #129): close this turn's cross-device marker (interrupt
+      // lands here too, so an interrupted turn writes `ended` like a normal one).
+      // Best-effort and fire-and-forget - a cloud hiccup just leaves the marker to
+      // its fixed expiry, which readers already treat as ended.
+      const mark = turnMarks.get(h);
+      turnMarks.delete(h);
+      if (mark && rt.runningEnd) void mark.then((turnId) => (turnId ? rt.runningEnd!(h.sessionId, turnId) : undefined)).catch(() => {});
       if (isVisibleHandle(forCli, h)) transport.send({ type: "turnEnd" }); // stop the typing dots
       await pushSessions();
       // A backgrounded session that just finished its in-flight turn is retired here:
@@ -430,6 +442,11 @@ export function createChatSession(
     // approval-blocked) session alive on switch-away; an idle one is stopped instead.
     const h = s.handle!;
     busy.add(h);
+    // Running Sync (issue #129): publish this turn's cross-device RUNNING marker
+    // (fixed TTL; closed in wire()'s onTurnEnd). Fire-and-forget - the send must
+    // never wait on a cloud write; the turnId promise is kept so the end write
+    // closes exactly this turn's marker.
+    if (rt.runningStart) turnMarks.set(h, rt.runningStart(h.sessionId).catch(() => null));
     // Turn just started: re-push so surfaces flip this session to RUNNING now (the
     // matching clear already happens in wire()'s onTurnEnd). Fire-and-forget so the
     // send isn't delayed by the session-list read.
@@ -438,13 +455,20 @@ export function createChatSession(
   }
 
   async function pushSessions() {
-    const list = await rt.listSessions();
+    // Running Sync (issue #129): sessions with a LIVE marker from ANOTHER device ride
+    // the same `running` list, so a turn started elsewhere badges RUNNING here too.
+    // Read in parallel with the session list (both are one storage round-trip) and
+    // best-effort - a cloud hiccup must never break the local list.
+    const [list, remote] = await Promise.all([
+      rt.listSessions(),
+      rt.runningRemote ? rt.runningRemote().catch(() => [] as string[]) : [],
+    ]);
     const activeId = slot().handle?.sessionId ?? slot().pendingId;
     // Sessions with a turn in flight, keyed by sessionId, so every surface can paint a
     // per-session RUNNING marker. Read straight off `busy` (the source of truth): it
     // mutates only at turn start/end and this push fires at both edges, so it stays live
     // with no polling. Dedupe (a cross-cli session could appear once per slot).
-    const running = [...new Set([...busy].map((h) => h.sessionId).filter(Boolean))];
+    const running = [...new Set([...busy].map((h) => h.sessionId).filter(Boolean).concat(remote))];
     // cloud reflects THIS list's union (read after listSessions): "reauth"/"transient"
     // mean the cloud tier failed and `list` is silently local-only — the UI labels it
     // so missing remote sessions read as "sync is down", not "they don't exist".

--- a/packages/core/src/runtime/contract.ts
+++ b/packages/core/src/runtime/contract.ts
@@ -214,6 +214,17 @@ export interface AgentRuntime {
   // per-launch cloud storm. No-op (0 uploads) when the storage has no cloud tier or is
   // already in sync. See StorageAdapter.backfill.
   syncCloud(): Promise<{ uploaded: number; missing: number }>;
+
+  // Running Sync (issue #129): cross-device RUNNING markers on the same storage.
+  // Exactly two writes per turn: runningStart at turn start (returns the turnId
+  // runningEnd must echo; null when the session has no id yet - a fresh chat whose
+  // engine hasn't revealed one - so the next turn is the first marked one) and
+  // runningEnd at turn end. runningRemote lists sessionIds with a live marker
+  // from ANOTHER device, for the session list's cross-device RUNNING badge.
+  // Optional: a runtime without them leaves surfaces on local-only busy state.
+  runningStart?(sessionId: string): Promise<string | null>;
+  runningEnd?(sessionId: string, turnId: string): Promise<void>;
+  runningRemote?(): Promise<string[]>;
 }
 
 // paginated read result (newest-first; cursor walks toward older pages)

--- a/packages/core/src/runtime/index.ts
+++ b/packages/core/src/runtime/index.ts
@@ -8,6 +8,7 @@ import { randomUUID } from "node:crypto";
 import { Connection } from "@solana/web3.js";
 import { spawnCli } from "./spawn.js";
 import { SessionStore } from "../account/store.js";
+import { RunningMarkers } from "../account/runningMarkers.js";
 import { prepareResume } from "./inject/index.js";
 import { getDeviceProfile, buildDeviceNotice } from "../core/device.js";
 import { MemorySync, updateSkillsSection, updatePreviewSection } from "../memory/index.js";
@@ -98,6 +99,11 @@ async function buildPassiveSpawn(
   return { mcpServers: { [AGENTNET_MCP_SERVER]: server }, allowedTools: agentNetAllowedTools() };
 }
 
+// Running Sync (issue #129): the startup sweep runs once per app instance, not per
+// createRuntime - a storage reconnect rebuilds the runtime, and re-sweeping then
+// could force-close the marker of a turn still running under the previous runtime.
+let sweptThisBoot = false;
+
 // `approval` is the swappable decision source (webview buttons / auto / push). The
 // surface passes one in; omit it and tool use auto-allows (safe local default).
 export function createRuntime(
@@ -112,6 +118,15 @@ export function createRuntime(
   // Soul (issue #84 follow-up): the wallet's persona, injected into the CLI's GLOBAL
   // instruction file so our engines wear the same self foreign hosts get.
   const souls = new SoulStore(wallet, storage);
+  // Running Sync (issue #129): cross-device RUNNING markers on the same storage.
+  // The startup sweep force-closes markers this device's previous run left behind
+  // (a crash never wrote their ended mark). Fire-and-forget, local tier only -
+  // it must never delay or fail runtime creation.
+  const running = new RunningMarkers(storage);
+  if (!sweptThisBoot) {
+    sweptThisBoot = true;
+    void running.sweep().catch((e) => console.warn("[running-sync] sweep failed:", e));
+  }
 
   return {
     async startSession(opts): Promise<SessionHandle> {
@@ -351,6 +366,21 @@ export function createRuntime(
     // cloud tier. Surfaces call this ONLY after an explicit (re)connect.
     async syncCloud(): Promise<{ uploaded: number; missing: number }> {
       return (await storage.backfill?.()) ?? { uploaded: 0, missing: 0 };
+    },
+
+    // Running Sync (issue #129): the dispatcher calls these at its existing turn
+    // edges (busy add / onTurnEnd). A fresh chat has no sessionId until the engine
+    // reveals one - no marker for that first turn (null), the next turn is marked.
+    async runningStart(sessionId: string): Promise<string | null> {
+      return sessionId ? running.start(sessionId) : null;
+    },
+
+    async runningEnd(sessionId: string, turnId: string): Promise<void> {
+      await running.end(sessionId, turnId);
+    },
+
+    async runningRemote(): Promise<string[]> {
+      return running.liveRemote();
     },
   };
 }

--- a/surfaces/webview/src/state/store.tsx
+++ b/surfaces/webview/src/state/store.tsx
@@ -117,7 +117,8 @@ export interface State {
   sessionsCloud: "ok" | "reauth" | "transient" | "none";
   activeSessionId?: string;
   // sessionIds whose agent turn is in flight (server pushes this in every `sessions`
-  // frame off its `busy` set). Drives the per-row RUNNING marker; transient, not persisted.
+  // frame off its `busy` set plus live cross-device Running Sync markers, issue #129).
+  // Drives the per-row RUNNING marker; transient, not persisted.
   sessionsRunning: string[];
   approvals: ApprovalRequest[];
   storage: { info: unknown; options: unknown; googleCredsConfigured?: boolean } | null;

--- a/surfaces/webview/src/transport/protocol.ts
+++ b/surfaces/webview/src/transport/protocol.ts
@@ -205,7 +205,8 @@ export type ServerMessage =
   // failed and the list is silently local-only (label it; other devices' sessions are
   // not gone, sync is down). "none" = no cloud configured.
   // running: sessionIds whose agent turn is in flight right now (server reads its `busy`
-  // set at each turn edge). Lets the list mark a per-session RUNNING state; absent = none.
+  // set at each turn edge, unioned with live Running Sync markers from OTHER devices -
+  // issue #129). Lets the list mark a per-session RUNNING state; absent = none.
   | { type: "sessions"; list: SessionMeta[]; activeId?: string; running?: string[]; cloud?: "ok" | "reauth" | "transient" | "none" }
   | { type: "modelOptions"; cli: Cli; options: import("@iqlabs-official/agent-sdk").ChatModelOption[] }
   | { type: "loading" }


### PR DESCRIPTION

Implements #129 to the design written in the issue. Honestly, the spec was complete enough that most of this was typing it out; the fixed TTL idea is the kind of design I like working with, so this was a fun one to build.

## What

A turn writes exactly two markers through the SAME StorageAdapter that already syncs sessions: a `running` mark at turn start, an `ended` overwrite at turn end. No renewals, no heartbeat, no cleanup job, no servers, no tokens, nothing on chain. Readers treat a marker as live only while `state == running AND expiresAt (+ grace) > now`, so an abandoned marker dies by construction. Sessions with a live marker from ANOTHER device show a RUNNING badge in the sessions list; this device's own turns stay covered by the in-process busy set, exactly as today.

The issue's open questions, resolved conservatively (each is one line to change if you want it different):

- Placement: one marker file per session per device (`running__{sessionId}__{deviceId}`). Per device matters on the local-first mirror: reads prefer the local tier, so a shared per-session key would let a device's stale local copy shadow another device's live cloud marker, and the boot sweep would then destroy it. With per-device keys a device only ever writes its own key, another device's marker never exists in our local tier, and the sweep cannot touch foreign markers. Proven with a two device mirror simulation (stale local device sees the other device RUNNING; its sweep leaves the live marker untouched).
- Expiry classes: your defaults, 20 min normal and 60 min deepResearch. The long class is plumbed but nothing sets it yet, so a future long-run flow can opt in at turn start without a format change.
- CLI: read-only v1, no CLI wiring ships here.

Markers are plaintext JSON deliberately: they carry only ids and timestamps (never content), the sessionId is already the plaintext storage key of every session page, and the device LABEL is not stored, only the opaque id.

Edge cases covered: `/clear` and delete-mid-turn go through stopHandle, which never reaches onTurnEnd, so it closes the marker too (otherwise other devices would show RUNNING for the full window on a turn the app itself ended). A delayed end from an old turn cannot close a newer turn's marker (turn id echo). A corrupt marker blob reads as no marker and never breaks the list.

## Verified

- 6 new specs in `runningMarkers.spec.ts` (write shapes, reader rule, expiry-as-ended, turn-scoped ends, deviceId-scoped sweep, corrupt blob). Full core suite: 321 pass, and the branch's failure set is a strict subset of `main`'s environment-only failures (verified by running the suite on `main` first and diffing the failure names; `main` also has one suite-order flaky spec the branch does not hit).
- Webview build green; `tsc --noEmit` introduces no new errors (same 9 pre-existing TS6133 hits as `main`).
- Two device mirror simulation for the key-shape decision, as above.
- Not verified: a live two device pass against real cloud storage. The marker path is the same adapter the session mirror uses, but a real world pass deserves one run in review.

## The five rules against this diff

1. No meaningless wrappers: RunningMarkers owns real lifecycle logic (write shapes, reader rule, sweep); the runtime exposes it as two optional hooks.
2. Scan and reuse first: storage goes through the existing StorageAdapter and device identity through the existing device profile; no new persistence or identity anywhere.
3. No single use type variables: the one exported interface (RunningMarker) is read by store, runtime, and specs.
4. No non-essential parameters: `deepResearch` is the issue's own second expiry class; everything else is session and turn ids.
5. Responsibilities separated: core writes markers, the runtime wires the hooks, the webview only renders the badge.

