### PR TITLE
localhost: boot wallet reconnect must lose to an explicit disconnect (#204)

### DIFF
--- a/surfaces/localhost/src/index.ts
+++ b/surfaces/localhost/src/index.ts
@@ -1377,8 +1377,19 @@ http.listen(PORT, () => {
 // listen: a UI that attaches mid-reconnect sees guest until its next `ready`.
 void (async () => {
   if ((await loadWalletMode()) !== "local") return;
+  // Guarded against the user acting first (issue #204): this task races the UI.
+  // On a slow cold start (Android under proot especially) the user can hit
+  // Disconnect while the reconnect is still loading the keypair; an unguarded
+  // adopt then resurrects the wallet they just removed and re-persists "local",
+  // so the disconnect silently never takes effect. Any explicit wallet action
+  // bumps walletEpoch, so: bail if the epoch moved while we loaded, and skip
+  // the mode re-save if it moved after the adopt. The explicit action wins.
+  const epoch = walletEpoch;
   try {
-    await connectLocalWallet();
+    const loaded = await localWallet();
+    if (walletEpoch !== epoch) return; // user connected/disconnected first
+    await adoptWallet(loaded.wallet, loaded.address);
+    if (walletEpoch === epoch + 1) await saveWalletMode("local");
     console.log(`AgentNet wallet → local wallet reconnected (${walletAddress})`);
   } catch (e) {
     console.error("[wallet] local wallet reconnect failed:", e);


### PR DESCRIPTION
Fixes #204: the diagnosis, the off-device repro, and the numbers are in the issue comment; short version here.

The boot local-wallet reconnect is a fire and forget task racing the user. On a slow cold start (Android under proot especially) a Disconnect can land while the reconnect is still loading the keypair; the unguarded adopt then resurrects the wallet the user just removed and re-persists mode local, so the disconnect silently never takes effect and the switch to an external wallet is blocked. Intermittent by construction.

The fix: the boot task captures the existing walletEpoch up front, bails before adopting if any explicit wallet action moved the epoch while the keypair loaded, and skips the mode re-save if one landed after the adopt. The explicit action always wins.

Verified at the transport level against an isolated AGENTNET_HOME with a 2 second simulated cold start: unfixed, a racing disconnect loses 3 of 3 runs (wallet re-adopted, mode file rewritten); fixed, the disconnect sticks 3 of 3 and the mode file stays deleted; the plain boot reconnect (no racing disconnect) still reconnects normally. tsc clean.

Adjacent observation left out of this diff (separate design call, detailed in the issue comment): an absent mode file after disconnect is indistinguishable from never-chose, so old MWA Keystore credentials can still silently re-adopt an external wallet post disconnect; a persisted explicit none mode would close that if wanted.
