### PR TITLE
Specs for the re-prime contract, plus four view fixes from a close read of the feed (#210)

### DIFF
--- a/packages/core/src/chat/session.spec.ts
+++ b/packages/core/src/chat/session.spec.ts
@@ -623,3 +623,54 @@ describe("chat/session - Running Sync markers (issue #129)", () => {
     expect(frames[frames.length - 1].running).toEqual([]);
   });
 });
+
+describe("chat/session — feed anchor re-prime after a bumping blog comment (issue #210)", () => {
+  const waitForType = async (transport: any, type: string) => {
+    for (let i = 0; i < 400; i++) {
+      const hit = transport.send.mock.calls.find((c: any[]) => c[0]?.type === type);
+      if (hit) return hit[0];
+      await new Promise((r) => setTimeout(r, 5));
+    }
+    throw new Error(`"${type}" was never sent`);
+  };
+  const comment = (over: Record<string, unknown> = {}) => ({
+    type: "postBlogComment", postId: "note:w1:1:aa", agentWallet: "w1", text: "hi", feedBump: true, ...over,
+  });
+
+  it("a bumping reply fires one fresh getBlogFeed so the shared anchor cache is re-primed", async () => {
+    const getBlogFeed = vi.fn(async () => []);
+    const { fromUI, transport } = harness({ env: { getBlogFeed, postBlogComment: async () => ({ ok: true, threads: [] }) } });
+    fromUI(comment());
+    await waitForType(transport, "blogCommentResult");
+    for (let i = 0; i < 400 && !getBlogFeed.mock.calls.length; i++) await new Promise((r) => setTimeout(r, 5));
+    expect(getBlogFeed).toHaveBeenCalledWith(undefined, undefined, true);
+  });
+
+  it("a sage reply never re-primes: it did not bump, so the cache is not stale", async () => {
+    const getBlogFeed = vi.fn(async () => []);
+    const { fromUI, transport } = harness({ env: { getBlogFeed, postBlogComment: async () => ({ ok: true, threads: [] }) } });
+    fromUI(comment({ sage: true }));
+    await waitForType(transport, "blogCommentResult");
+    fromUI({ type: "wallet" });
+    await waitForType(transport, "wallet");
+    expect(getBlogFeed).not.toHaveBeenCalled();
+  });
+
+  it("a failed comment never re-primes", async () => {
+    const getBlogFeed = vi.fn(async () => []);
+    const { fromUI, transport } = harness({ env: { getBlogFeed, postBlogComment: async () => ({ ok: false, error: "rpc" }) } });
+    fromUI(comment());
+    await waitForType(transport, "blogCommentResult");
+    fromUI({ type: "wallet" });
+    await waitForType(transport, "wallet");
+    expect(getBlogFeed).not.toHaveBeenCalled();
+  });
+
+  it("getBlogFeed request threads fresh through to the env", async () => {
+    const getBlogFeed = vi.fn(async () => []);
+    const { fromUI, transport } = harness({ env: { getBlogFeed } });
+    fromUI({ type: "getBlogFeed", sort: "latest", fresh: true });
+    await waitForType(transport, "blogFeed");
+    expect(getBlogFeed).toHaveBeenCalledWith(undefined, "latest", true);
+  });
+});

--- a/packages/core/src/chat/ui/webview.ts
+++ b/packages/core/src/chat/ui/webview.ts
@@ -4084,6 +4084,7 @@ export function chatHtml(): string {
   let feedSort = 'active';          // ACTIVE = lastActivityTime, LATEST = createdAt
   let feedPosts = null;             // null = never loaded (skeletons), [] = settled empty
   let currentFeedPost = null;       // the post open in the reader
+  let feedLastSage = false;         // whether the comment in flight was sage (skips the fresh re-read)
   const feedBodies = {};            // postId -> authoritative body from the author's table
   const feedThreads = {};           // postId -> comment threads
   function openAgents() {
@@ -4304,6 +4305,7 @@ export function chatHtml(): string {
       return el;
     }
     function submitComment(f, parentId) {
+      feedLastSage = !!f.sage;
       vscode.postMessage({
         type: 'postBlogComment', postId: p.id, agentWallet: p.author, text: f.text,
         gitLink: f.gitLink, parentId: parentId, sage: !!f.sage, feedBump: !f.sage,
@@ -6102,7 +6104,10 @@ export function chatHtml(): string {
             pane._mainCompose._btn.disabled = false; pane._mainCompose._btn.textContent = pane._mainCompose._label;
           }
           feedReplyTo = null;
-          vscode.postMessage({ type: 'getBlogFeed', sort: feedSort, fresh: true });
+          // a sage reply never bumped, so the anchor cache is not stale: a cheap cached
+          // read repaints the list without the cold fresh fetch (the dispatcher already
+          // re-primes after a bumping reply, so fresh here only covers the repaint)
+          vscode.postMessage({ type: 'getBlogFeed', sort: feedSort, fresh: !feedLastSage });
         } else {
           const box = pane._activeCompose || pane._mainCompose;
           if (box) {

--- a/surfaces/cli/src/views/SkillMarket.tsx
+++ b/surfaces/cli/src/views/SkillMarket.tsx
@@ -1,4 +1,4 @@
-import React, { useEffect, useState } from "react";
+import React, { useEffect, useRef, useState } from "react";
 import { Box, Text, useInput, useStdout } from "ink";
 import type { SkillCard, SkillDetail, Note } from "@iqlabs-official/agent-sdk";
 import type { Reputation, AgentProfile } from "@iqlabs-official/agent-sdk";
@@ -123,7 +123,9 @@ function feedPostLines(post: Note, body: Note | null, threads: FeedThread[] | nu
   if (real.image) out.push(<Text key="img" dimColor>[image: {truncateEnd(real.image, Math.max(4, w - 9))}]</Text>);
   if (real.gitLink) out.push(<Text key="git" color={colors.ok}>{glyph.sparkle} {truncateEnd(real.gitLink, Math.max(4, w - 2))}</Text>);
   out.push(<Text key="sp1"> </Text>);
-  const count = threads ? threads.reduce((s, t) => s + 1 + t.replies.length, 0) : (post.feedReplies ?? 0);
+  // top-level thread count, the same number the webview reader shows; before the
+  // thread settles, feedReplies (anchor bump rows) stands in
+  const count = threads ? threads.length : (post.feedReplies ?? 0);
   out.push(
     <Text key="ch">
       <Text color={colors.ok}>{">"}</Text>
@@ -320,6 +322,9 @@ export function SkillMarket({
   // loading convention as results/agents); [] only ever means a settled empty feed.
   const [feedPosts, setFeedPosts] = useState<Note[] | null>(null);
   const [feedSort, setFeedSort] = useState<"active" | "latest">("active");
+  // fetch sequence: only the newest feed read may land, or a slow older fetch
+  // (a cold fresh read, a pre-toggle sort) would overwrite newer rows
+  const feedSeq = useRef(0);
   const [feedIdx, setFeedIdx] = useState(0);
   const [feedPost, setFeedPost] = useState<Note | null>(null);      // the opened post (mirror row)
   const [feedBody, setFeedBody] = useState<Note | null>(null);      // authoritative body once fetched
@@ -603,15 +608,19 @@ export function SkillMarket({
 
   // ── feed (issue #210): load / open / comment ──────────────────────────────
   async function loadFeed(sort: "active" | "latest" = feedSort, fresh = false) {
+    const seq = ++feedSeq.current;
     setLoading(true);
     setError(null); // the error branch must only ever show a failure of THIS fetch
     try {
-      setFeedPosts(await api.getBlogFeed(undefined, sort, fresh));
+      const rows = await api.getBlogFeed(undefined, sort, fresh);
+      if (seq !== feedSeq.current) return;
+      setFeedPosts(rows);
       setFeedIdx(0);
     } catch (e) {
+      if (seq !== feedSeq.current) return;
       setError(e instanceof Error ? e.message : String(e));
     } finally {
-      setLoading(false);
+      if (seq === feedSeq.current) setLoading(false);
     }
   }
 
@@ -647,7 +656,14 @@ export function SkillMarket({
       // a bumping reply must re-prime the gateway's feed anchor cache: one fresh read
       // cold-fetches the new mirror row (same as every other host), and reloading the
       // held list here means the bump ordering is already right when esc lands on it.
-      if (!sage) void api.getBlogFeed(undefined, feedSort, true).then(setFeedPosts).catch(() => {});
+      // The sequence token keeps this slow cold read from clobbering a list the user
+      // has re-sorted or refreshed in the meantime.
+      if (!sage) {
+        const seq = ++feedSeq.current;
+        void api.getBlogFeed(undefined, feedSort, true).then((rows) => {
+          if (seq === feedSeq.current) setFeedPosts(rows);
+        }).catch(() => {});
+      }
       setFlash("comment posted");
       setStage("feedPost");
     } else {
@@ -1229,7 +1245,7 @@ export function SkillMarket({
                 const i = fStart + wi;
                 const on = i === feedIdx;
                 const bumped = (p.feedLastActivity ?? 0) > (p.timestamp ?? 0);
-                const when = bumped ? `bumped ${agoShort(p.feedLastActivity)}` : `${agoShort(p.timestamp)} ago`;
+                const when = bumped ? `bumped ${agoShort(p.feedLastActivity)}` : agoShort(p.timestamp) ? `${agoShort(p.timestamp)} ago` : "";
                 const preview = (p.title || p.text || "").trim();
                 return (
                   <Box key={p.id} flexDirection="column">
@@ -1269,7 +1285,7 @@ export function SkillMarket({
       <Box flexDirection="column" paddingX={1} borderStyle="round" borderColor={colors.iqViolet}>
         <Box justifyContent="space-between">
           <Text bold color={colors.bone}><Text color={colors.ok}>{">"}</Text>POST</Text>
-          {flash ? <Text color={colors.ok}>{flash}</Text> : null}
+          {flash ? <Text color={flash.startsWith("comment failed") ? colors.err : colors.ok}>{flash}</Text> : null}
         </Box>
         <Box flexDirection="column" marginTop={1}>
           <ScrollView lines={lines} height={height} offset={feedScroll} />
@@ -1314,6 +1330,9 @@ export function SkillMarket({
           })}
         </Box>
         {busy ? <Box marginTop={1}><Text dimColor>posting…</Text></Box> : null}
+        {/* a failed post keeps the draft on screen; the error has to show HERE, not
+            only on the post view the user has not returned to yet */}
+        {!busy && flash?.startsWith("comment failed") ? <Box marginTop={1}><Text color={colors.err}>{flash}</Text></Box> : null}
         <Box marginTop={1}><Text dimColor>↑/↓/[tab] field · space toggles sage · ↵ next / post on sage · esc cancel</Text></Box>
       </Box>
     );

--- a/surfaces/localhost/src/index.ts
+++ b/surfaces/localhost/src/index.ts
@@ -1023,7 +1023,7 @@ function attachMarketHandlers(c: Client) {
       // newest first, one read of the feed anchor.
       case "getBlogFeed": {
         try {
-          c.send({ type: "blogFeed", posts: await mkt.getBlogFeed(m.limit, m.sort) });
+          c.send({ type: "blogFeed", posts: await mkt.getBlogFeed(m.limit, m.sort, m.fresh) });
         } catch {
           c.send({ type: "blogFeed", posts: [] });
         }


### PR DESCRIPTION
Specs for the re-prime contract, plus four small view fixes from a close read of 338f491 (#210).

Reading the feed work after it landed, I wrote tests for the one behavior every commenting host now relies on, and the read also turned up four small view-layer issues. Two commits, view and spec layer only, no data path or on-chain change.

## Commit 1: specs pin the re-prime contract

The dispatcher's fresh re-prime after a bumping blog comment shipped without coverage. Four specs in `session.spec.ts` pin it:

1. a bumping reply fires exactly one fresh `getBlogFeed`
2. a sage reply never fires it
3. a failed comment never fires it
4. a `getBlogFeed` request threads `fresh` through to the env

They pass against the dispatcher as shipped, so this commit changes no behavior; it just makes the contract regression-proof.

```
Test Files  49 passed (49)
     Tests  350 passed (350)
```

## Commit 2: four view fixes

**CLI: a failed comment showed no error.** `doPostFeedComment` failure calls `setFlash` and stays on the composer, but the composer render never displays `flash`; the user watches "posting…" vanish and sees nothing until esc lands back on the post view, where the failure renders in the success green. The composer now shows the failure inline in the error color with the draft kept for retry, and the post view header colors failures red.

BEFORE (composer after a failed post, nothing visible):

```
╭──────────────────────────────────────────────────────────────────────────────────────────────────╮
│ //REPLY_                                        A NON SAGE REPLY BUMPS THE POST · POSTS ON CHAIN │
│                                                                                                  │
│   text      hello world                                                                          │
│   gitLink   (optional)                                                                           │
│ ▸ sage      ✗ off · bumps the post                                                               │
│                                                                                                  │
│ ↑/↓/[tab] field · space toggles sage · ↵ next / post on sage · esc cancel                        │
╰──────────────────────────────────────────────────────────────────────────────────────────────────╯
```

AFTER:

```
╭──────────────────────────────────────────────────────────────────────────────────────────────────╮
│ //REPLY_                                        A NON SAGE REPLY BUMPS THE POST · POSTS ON CHAIN │
│                                                                                                  │
│   text      hello world                                                                          │
│   gitLink   (optional)                                                                           │
│ ▸ sage      ✗ off · bumps the post                                                               │
│                                                                                                  │
│ comment failed: rpc unavailable                                                                  │
│                                                                                                  │
│ ↑/↓/[tab] field · space toggles sage · ↵ next / post on sage · esc cancel                        │
╰──────────────────────────────────────────────────────────────────────────────────────────────────╯
```

**CLI: feed reads had no ordering guard.** `[s]` and `[r]` fire direct env promises with no sequence token, so a slow older fetch (a cold `fresh` read, a pre-toggle sort) can settle last and leave stale rows under the wrong ACTIVE | LATEST label; the post-comment background reload captures the sort at comment time and could overwrite a list the user had re-sorted meanwhile. A sequence token lets only the newest read paint. (The VS Code panel needs no token: session.ts's serial pump already orders its responses.)

**CLI: comment counts disagreed across surfaces.** The post view counted note plus nested replies; the webview reader counts top-level threads; before threads settle the row count is `feedReplies`, which counts anchor bump rows only. The CLI now shows the reader's number. A missing timestamp also no longer renders a bare " ago" on feed rows.

**Panel and hosts: two one-liners.** The panel's post-comment fresh re-read now skips the cold fetch for sage replies (nothing bumped, the cache is not stale), the same guard the CLI has; the dispatcher's re-prime still covers the bumping case. localhost's `getBlogFeed` case forwards the `fresh` flag it was dropping.

## Verified

- `packages/core` vitest 350/350 (49 files), including the four new specs
- tsc clean on core, cli, vscode, localhost; tsup builds green on cli, vscode, localhost
- Live run: drove the CLI in a 100x35 pty against mainnet with the real wallet, opened the feed, opened a post (the comment count visibly settles from the bump-row stand-in to the thread count), toggled ACTIVE | LATEST, backed out clean

![the CLI feed live against mainnet](https://github.com/RemilioNubilio/AgentNet/releases/download/pr-assets/live-feed.png)

## The five rules, against this diff

1. **No meaningless wrappers.** None added; the only new function-shaped thing is the sequence-token block inside the existing `loadFeed`.
2. **Reuse first.** Every fix edits the existing function in place; the composer error line reuses `colors.err` and the existing flash state, no new state beyond the one `useRef` token.
3. **No single-use type variables.** None added.
4. **No non-essential parameters.** None added; the token is a ref, not a parameter.
5. **Responsibilities stay separated.** Views keep rendering, core keeps fetching; the sage guard lives where each host already made its re-read decision. One thing worth saying out loud: the panel now has two fresh reads on a bumping comment (the dispatcher's re-prime and the UI's repaint read). I left the dispatcher's in place because IPC hosts without a repainting UI still need it; if you would rather the panel's repaint read ride the re-primed cache instead, that is a two-line follow-up.

Happy to adjust anything. The CLI feed is a joy to use, by the way.
