### PR TITLE
Quote refs: >>note: ids hydrate as inline quote cards on VS Code and CLI

### DIFF
--- a/packages/core/src/chat/ui/webview.ts
+++ b/packages/core/src/chat/ui/webview.ts
@@ -1561,6 +1561,22 @@ export function chatHtml(): string {
              letter-spacing:0.08em; text-transform:uppercase; color:var(--an-fg-mute);
              background:none; border:none; padding:0; cursor:pointer; }
   .fd-sage.on { color:var(--an-amber); }
+  /* on-chain quote card: ">>note:<wallet>:<ts>:<rand>" refs hydrated from chain */
+  .fd-qref { color:var(--an-green); opacity:.85; word-break:break-all; }
+  .fd-quote { border:1px solid var(--an-line); padding:10px 12px; margin-top:10px;
+              font-family:ui-monospace, SFMono-Regular, Menlo, monospace; }
+  .fd-quote.fdq-live { cursor:pointer; }
+  .fd-quote.fdq-live:hover { border-color:var(--an-green-line); }
+  .fd-quote.fdq-loading { color:var(--an-fg-mute); font-size:10px; letter-spacing:0.06em; text-transform:uppercase; }
+  .fd-quote.fdq-dead { color:var(--an-fg-mute); font-size:11px; word-break:break-all; }
+  .fdq-top { display:flex; align-items:baseline; gap:8px; margin-bottom:4px;
+             font-size:10px; color:var(--an-fg-mute); }
+  .fdq-when { margin-left:auto; font-size:9px; white-space:nowrap; }
+  .fdq-title { font-size:11px; font-weight:700; text-transform:uppercase;
+               letter-spacing:0.04em; line-height:1.4; margin:0; color:var(--an-fg); }
+  .fdq-snip { font-size:11px; line-height:1.5; margin-top:4px; color:var(--an-fg-mute);
+              white-space:pre-wrap; word-break:break-word;
+              display:-webkit-box; -webkit-line-clamp:2; -webkit-box-orient:vertical; overflow:hidden; }
   .fdp-gate { font-family:ui-monospace, SFMono-Regular, Menlo, monospace; font-size:10px; letter-spacing:0.06em;
               text-transform:uppercase; border:1px solid var(--an-line); padding:10px 12px; color:var(--an-fg-mute); }
   .fdp-gate .gt { color:var(--an-green); }
@@ -4086,6 +4102,80 @@ export function chatHtml(): string {
   let currentFeedPost = null;       // the post open in the reader
   const feedBodies = {};            // postId -> authoritative body from the author's table
   const feedThreads = {};           // postId -> comment threads
+  // ── quote refs: ">>note:<wallet>:<ts>:<rand>" in a post body or comment is an
+  // on-chain quote-tweet, hydrated through the EXISTING getBlogPost/blogPost pair
+  // (zero new message types): the ref itself carries the author (wallet segment)
+  // and the postId (the whole "note:..." string after the ">>").
+  // Grammar is a byte-identical copy of core's QUOTE_REF (notes/quoteRefs.ts) —
+  // this template is emitted browser JS and cannot import it; change BOTH or the
+  // surfaces resolve different refs. Nonce = lowercase base36, 4-6 chars; the
+  // trailing lookahead refuses a ref glued to alphanumeric text (no match beats
+  // fetching a corrupted id and rendering a false deadlink).
+  const QUOTE_REF_RE = /(>>note:[1-9A-HJ-NP-Za-km-z]{32,44}:[0-9]{10,16}:[a-z0-9]{4,6})(?![A-Za-z0-9])/;
+  const QUOTE_REFS_MAX = 4;   // unique refs hydrated per post view (body + comments)
+  const quoteCache = {};     // postId -> { post: Note|null } once resolved (null = deadlink)
+  const quoteInflight = {};  // postId -> true while its getBlogPost is out
+  let quoteCards = {};       // postId -> [placeholder card elements] awaiting the reply
+  let quoteSeen = {};        // postId -> true once carded in the current render pass
+  let quoteSlots = 0;        // unique refs carded in the current render pass
+  function quoteRefWallet(id) { return id.split(':')[1] || ''; }
+  function fillQuoteCard(el, id, post) {
+    el.textContent = '';
+    el.classList.remove('fdq-loading');
+    if (!post) {
+      // deadlink: keep the raw ref text, dim, with a note (still legible/copyable)
+      el.classList.add('fdq-dead');
+      el.textContent = '>>' + id + ' [not found]';
+      return;
+    }
+    const top = document.createElement('div'); top.className = 'fdq-top';
+    const who = document.createElement('span'); who.textContent = '>>' + agShort(post.author || quoteRefWallet(id));
+    top.appendChild(who);
+    const when = fmtNoteDate(post);
+    if (when) { const w = document.createElement('span'); w.className = 'fdq-when'; w.textContent = when; top.appendChild(w); }
+    el.appendChild(top);
+    const lines = String(post.text || '').split('\\n');
+    const firstLine = (lines[0] || '').trim();
+    const title = post.title || firstLine;
+    if (title) { const t = document.createElement('p'); t.className = 'fdq-title'; t.textContent = title; el.appendChild(t); }
+    const snip = (post.title ? String(post.text || '') : lines.slice(1).join('\\n')).trim();
+    if (snip) { const s = document.createElement('p'); s.className = 'fdq-snip'; s.textContent = snip; el.appendChild(s); }
+    el.classList.add('fdq-live');
+    el.addEventListener('click', () => openFeedPost(post));
+  }
+  // Render text that may contain quote refs: plain segments stay textContent
+  // (post text is attacker-controlled, never innerHTML), each ref becomes a
+  // compact inline marker, and per unique ref (capped) a quote card is appended
+  // directly under the paragraph.
+  function appendQuoteText(parent, text, cls) {
+    const p = document.createElement('p'); p.className = cls;
+    const parts = String(text).split(QUOTE_REF_RE); // capture group: refs land at odd indexes
+    const cards = [];
+    for (let i = 0; i < parts.length; i++) {
+      if (i % 2 === 0) { if (parts[i]) p.appendChild(document.createTextNode(parts[i])); continue; }
+      const id = parts[i].slice(2); // drop ">>" to get the postId ("note:...")
+      const mk = document.createElement('span'); mk.className = 'fd-qref';
+      mk.textContent = '>>quote:' + agShort(quoteRefWallet(id));
+      mk.title = parts[i];
+      p.appendChild(mk);
+      if (quoteSeen[id] || quoteSlots >= QUOTE_REFS_MAX) continue;
+      quoteSeen[id] = true; quoteSlots++;
+      const card = document.createElement('div'); card.className = 'fd-quote';
+      if (id in quoteCache) {
+        fillQuoteCard(card, id, quoteCache[id].post);
+      } else {
+        card.classList.add('fdq-loading'); card.textContent = '>>resolving quote…';
+        (quoteCards[id] = quoteCards[id] || []).push(card);
+        if (!quoteInflight[id]) {
+          quoteInflight[id] = true;
+          vscode.postMessage({ type: 'getBlogPost', author: quoteRefWallet(id), postId: id });
+        }
+      }
+      cards.push(card);
+    }
+    parent.appendChild(p);
+    cards.forEach((c) => parent.appendChild(c));
+  }
   function openAgents() {
     if (agentsTab === 'feed') openFeed(); else openRank();
   }
@@ -4242,6 +4332,8 @@ export function chatHtml(): string {
     const keep = pane._mainCompose ? { text: pane._mainCompose._ta.value, git: pane._mainCompose._git.value } : null;
     pane.innerHTML = '';
     pane._activeCompose = null;
+    // fresh quote-card registry for this render pass (the old elements were wiped)
+    quoteCards = {}; quoteSeen = {}; quoteSlots = 0;
     // >POST … BY xxxx cap row + the [<] POST [date] header bar (mobile chrome)
     const cap = document.createElement('div'); cap.className = 'fdp-cap';
     const capL = document.createElement('span'); capL.innerHTML = '<span style="opacity:.55">&gt;</span>POST';
@@ -4271,7 +4363,7 @@ export function chatHtml(): string {
     who.textContent = (p.author ? agShort(p.author) : '?') + (date ? ' [' + date + ']' : '');
     au.appendChild(lb); au.appendChild(who);
     pane.appendChild(au);
-    if (body.text) { const tx = document.createElement('p'); tx.className = 'fdp-body'; tx.textContent = body.text; pane.appendChild(tx); }
+    if (body.text) appendQuoteText(pane, body.text, 'fdp-body');
     if (body.gitLink) { const gl = gitLinkNode(body.gitLink, 'pr-note-git'); if (gl) pane.appendChild(gl); }
     // >COMMENTS — OPEN to any connected wallet (issue #183), same as mobile.
     const sec = document.createElement('div'); sec.className = 'fdp-cmts';
@@ -4293,7 +4385,7 @@ export function chatHtml(): string {
         const to = document.createElement('p'); to.className = 'fdc-to'; to.textContent = '↳ replying to ' + agShort(nn.parentAuthor);
         el.appendChild(to);
       }
-      if (nn.text) { const tx = document.createElement('p'); tx.className = 'fdc-text'; tx.textContent = nn.text; el.appendChild(tx); }
+      if (nn.text) appendQuoteText(el, nn.text, 'fdc-text');
       if (nn.gitLink) { const gl = gitLinkNode(nn.gitLink, 'pr-note-git'); if (gl) el.appendChild(gl); }
       if (canReply) {
         const rb = document.createElement('button'); rb.type = 'button'; rb.className = 'fdc-replybtn';
@@ -6081,9 +6173,26 @@ export function chatHtml(): string {
       // authoritative body from the author's own table; null = the mirror row was
       // not backed by a real post (impersonation or a deleted table) — keep the reader
       // on the mirror text rather than blanking it.
+      // Disambiguation: reader requests (openFeedPost) never mark quoteInflight,
+      // quote-ref requests always do, so wasQuote is exact even when both are out.
+      const wasQuote = !!quoteInflight[m.postId];
+      if (wasQuote) {
+        delete quoteInflight[m.postId];
+        // only a real post is cached: a transient null (gateway hiccup) must not
+        // pin a permanent deadlink — uncached, the next render pass retries the
+        // read; the cards below still show this pass's dead state honestly
+        if (m.post) quoteCache[m.postId] = { post: m.post };
+      }
       if (m.post) {
         feedBodies[m.postId] = m.post;
         if (currentFeedPost && currentFeedPost.id === m.postId) renderFeedPost();
+      }
+      if (wasQuote) {
+        // fill any cards still waiting; a renderFeedPost just above rebuilt its
+        // own cards straight from quoteCache, so only detached views remain here
+        const els = quoteCards[m.postId] || [];
+        delete quoteCards[m.postId];
+        els.forEach((el) => fillQuoteCard(el, m.postId, m.post || null));
       }
     }
     else if (m.type === 'blogComments') {

--- a/packages/core/src/index.ts
+++ b/packages/core/src/index.ts
@@ -44,8 +44,8 @@ export type { PublishSkillInput, BuySkillInput } from "./nft/skill.js";
 export type { SkillMintMetadata } from "./nft/token2022.js";
 export { resolveMinter, tryMinterPubkey, resetMinterCache } from "./nft/minter.js";
 // notes (reviews)
-export { postNote, readNotes, deleteNote, postAgentNote, readAgentNotes, readBlogFeed, readBlogPost, migrateBlogPosts, getSolBalance, canAffordSkill, TX_FEE_BUFFER_LAMPORTS } from "./notes/index.js";
-export type { PostNoteInput, ReadNotesOptions, PostAgentNoteInput, BlogMigrationResult } from "./notes/index.js";
+export { postNote, readNotes, deleteNote, postAgentNote, readAgentNotes, readBlogFeed, readBlogPost, migrateBlogPosts, getSolBalance, canAffordSkill, TX_FEE_BUFFER_LAMPORTS, extractQuoteRefs, parseNoteRef, QUOTE_REFS_MAX } from "./notes/index.js";
+export type { PostNoteInput, ReadNotesOptions, PostAgentNoteInput, BlogMigrationResult, QuoteRef } from "./notes/index.js";
 // RPC resolution (issue #23): a registered Helius key wins over env over the default
 export { resolveRpcUrl, saveHeliusKey, loadHeliusKey, hasDasRpc, heliusUrl, maskedHeliusKey, HELIUS_QUICKSTART_URL, saveGithubToken, loadGithubToken, maskedGithubToken } from "./core/rpc.js";
 export { getNetwork, NETWORK } from "./core/seed.js";

--- a/packages/core/src/notes/index.ts
+++ b/packages/core/src/notes/index.ts
@@ -1,6 +1,8 @@
 export { postNote, readNotes, deleteNote, postAgentNote, readAgentNotes, postBlogComment,
   readBlogFeed, readBlogPost, readBlogCommentThreads } from "./notes.js";
 export type { PostNoteInput, ReadNotesOptions, PostAgentNoteInput, PostBlogCommentInput } from "./notes.js";
+export { extractQuoteRefs, parseNoteRef, QUOTE_REFS_MAX } from "./quoteRefs.js";
+export type { QuoteRef } from "./quoteRefs.js";
 export { migrateBlogPosts } from "./migrate.js";
 export type { BlogMigrationResult } from "./migrate.js";
 export { heldSkillMints, invalidateHeldMints } from "./holdings.js";

--- a/packages/core/src/notes/quoteRefs.spec.ts
+++ b/packages/core/src/notes/quoteRefs.spec.ts
@@ -1,0 +1,61 @@
+import { describe, it, expect } from "vitest";
+import { extractQuoteRefs, parseNoteRef, QUOTE_REFS_MAX } from "./quoteRefs.js";
+
+const W = "C3EPAsjHq6DHLDzG2bXySFpUYmQ5AUqDXDfEiEsCekrH";
+const id = (n: string) => `note:${W}:1787813695000:${n}`;
+
+describe("notes/quoteRefs — the >>note: text convention", () => {
+  it("extracts a ref with its author, from anywhere in the text", () => {
+    const refs = extractQuoteRefs(`saw this earlier\n>>${id("9n4iry")}\nand it holds up`);
+    expect(refs).toEqual([{ ref: id("9n4iry"), author: W }]);
+  });
+
+  it("dedupes repeats and keeps first-appearance order", () => {
+    const refs = extractQuoteRefs(`>>${id("aaaaaa")} then >>${id("bbbbbb")} then >>${id("aaaaaa")}`);
+    expect(refs.map((r) => r.ref)).toEqual([id("aaaaaa"), id("bbbbbb")]);
+  });
+
+  it("caps at QUOTE_REFS_MAX so one note cannot fan out unbounded reads", () => {
+    const many = Array.from({ length: QUOTE_REFS_MAX + 3 }, (_, i) => `>>${id(`n${i}pad0`)}`).join(" ");
+    expect(extractQuoteRefs(many)).toHaveLength(QUOTE_REFS_MAX);
+  });
+
+  it("ignores things that only look like refs", () => {
+    for (const bad of [
+      ">>note:short:1787813695000:9n4iry", // wallet too short
+      ">>note:" + W + ":17878:9n4iry", // timestamp too short
+      ">>tx:" + W, // wrong scheme
+      "note:" + W + ":1787813695000:9n4iry", // no >> marker
+      ">>note:" + W + ":1787813695000:9N4IRY", // uppercase nonce: toString(36) never mints one
+      undefined,
+      "",
+    ]) {
+      expect(extractQuoteRefs(bad as string | undefined)).toEqual([]);
+    }
+  });
+
+  it("a ref glued to alphanumeric text is no match, never a corrupted id", () => {
+    // punctuation after the nonce is fine; letters or digits are ambiguous
+    expect(extractQuoteRefs(`see >>${id("9n4iry")}.`)).toEqual([{ ref: id("9n4iry"), author: W }]);
+    expect(extractQuoteRefs(`(>>${id("9n4iry")})`)).toEqual([{ ref: id("9n4iry"), author: W }]);
+    expect(extractQuoteRefs(`>>${id("9n4iry")}\nnext line`)).toEqual([{ ref: id("9n4iry"), author: W }]);
+    expect(extractQuoteRefs(`>>${id("9n4iry")}glued`)).toEqual([]);
+    expect(extractQuoteRefs(`>>${id("9n4iry")}9`)).toEqual([]);
+    expect(extractQuoteRefs(`>>${id("9n4iry")}X`)).toEqual([]);
+  });
+
+  it("accepts the real nonce range: 4 to 6 lowercase base36 chars", () => {
+    expect(extractQuoteRefs(`>>${id("ab12")}`)).toHaveLength(1);
+    expect(extractQuoteRefs(`>>${id("ab12cd")}`)).toHaveLength(1);
+    expect(extractQuoteRefs(`>>${id("ab12cd3")}`)).toEqual([]); // 7: longer than slice(2, 8) can mint
+    expect(extractQuoteRefs(`>>${id("ab1")}`)).toEqual([]); // too short
+  });
+
+  it("parseNoteRef accepts exactly one bare id and rejects surrounding junk", () => {
+    expect(parseNoteRef(id("9n4iry"))).toEqual({ ref: id("9n4iry"), author: W });
+    expect(parseNoteRef(id("9n4iry") + "!!")).toBeNull();
+    expect(parseNoteRef("x" + id("9n4iry"))).toBeNull();
+    expect(parseNoteRef("nope")).toBeNull();
+    expect(parseNoteRef(undefined)).toBeNull();
+  });
+});

--- a/packages/core/src/notes/quoteRefs.ts
+++ b/packages/core/src/notes/quoteRefs.ts
@@ -1,0 +1,49 @@
+// Quote refs (the feed's hyperlink): ">>note:<wallet>:<ms>:<nonce>" inside a note's
+// text points at another note. The ref IS the note id, so it already carries the
+// author wallet and the row key; a surface resolves it through the SAME spoof-proof
+// read every post open uses (readBlogPost: the author's own table is the truth, the
+// anchor is permissionless), and renders the result as an inline quote card. Pure
+// text convention: nothing new on chain, no contract or seed change, a miss is a
+// deadlink, not an error. Descends from blockchan's ">>txSignature" quotelinks,
+// which only resolve inside one loaded page; the note id makes the quote portable
+// across threads, boards, and surfaces.
+
+// One ref: ">>" + a note id as buildNote mints them:
+// note:<base58 wallet (32-44)>:<unix ms>:<nonce>. The nonce is
+// Math.random().toString(36).slice(2, 8): lowercase base36, six chars in practice
+// but shorter when the random tail is, so 4-6 (slice(2, 8) caps at 6). The trailing lookahead refuses a
+// ref glued to alphanumeric text: a corrupted id would fetch a nonexistent post
+// and render a deadlink for a ref that actually resolves, so no match is safer.
+// The VS Code panel template cannot import this (it is emitted browser JS), so
+// webview.ts carries a byte-identical copy: change BOTH or the surfaces diverge.
+const QUOTE_REF = />>(note:([1-9A-HJ-NP-Za-km-z]{32,44}):(\d{10,16}):([a-z0-9]{4,6}))(?![A-Za-z0-9])/g;
+
+export interface QuoteRef {
+  ref: string; // the full note id ("note:...:...:...")
+  author: string; // the wallet segment, ready for readBlogPost(author, ref)
+}
+
+// How many refs one note may hydrate. Quotes resolve lazily on view, but each one
+// is still a read; the cap keeps a pathological note from fanning out unbounded.
+export const QUOTE_REFS_MAX = 4;
+
+/** Every unique quote ref in a note's text, in order of first appearance, capped. */
+export function extractQuoteRefs(text: string | undefined): QuoteRef[] {
+  if (!text) return [];
+  const seen = new Set<string>();
+  const out: QuoteRef[] = [];
+  for (const m of text.matchAll(QUOTE_REF)) {
+    if (seen.has(m[1])) continue;
+    seen.add(m[1]);
+    out.push({ ref: m[1], author: m[2] });
+    if (out.length >= QUOTE_REFS_MAX) break;
+  }
+  return out;
+}
+
+/** Parse one bare note id (no ">>") into a QuoteRef, or null when it is not one. */
+export function parseNoteRef(id: string | undefined): QuoteRef | null {
+  if (!id) return null;
+  const refs = extractQuoteRefs(`>>${id}`);
+  return refs.length === 1 && refs[0].ref === id ? refs[0] : null;
+}

--- a/surfaces/cli/src/views/SkillMarket.tsx
+++ b/surfaces/cli/src/views/SkillMarket.tsx
@@ -1,8 +1,8 @@
-import React, { useEffect, useState } from "react";
+import React, { useEffect, useRef, useState } from "react";
 import { Box, Text, useInput, useStdout } from "ink";
 import type { SkillCard, SkillDetail, Note } from "@iqlabs-official/agent-sdk";
 import type { Reputation, AgentProfile } from "@iqlabs-official/agent-sdk";
-import { maskedHeliusKey, hasDasRpc, saveHeliusKey, getNetwork } from "@iqlabs-official/agent-sdk";
+import { maskedHeliusKey, hasDasRpc, saveHeliusKey, getNetwork, extractQuoteRefs, QUOTE_REFS_MAX } from "@iqlabs-official/agent-sdk";
 import { saveGithubToken, loadGithubToken, maskedGithubToken, registerVerifiedWork, parseGithubRepo } from "@iqlabs-official/agent-sdk";
 import { colors, glyph, tierColor, tierColors } from "../theme.js";
 import { displayWidth, truncateEnd, truncateStart, wrapBlock } from "../format.js";
@@ -105,7 +105,7 @@ function feedDate(ts: number | undefined): string { return ts ? new Date(ts).toL
 // The FEED post view's line array — ONE array entry per terminal row (the ScrollView
 // slice-math contract), so the body is pre-wrapped with wrapBlock. The mirror row
 // renders until the authoritative body (fetched from the author's table) lands.
-function feedPostLines(post: Note, body: Note | null, threads: FeedThread[] | null, cols: number): React.ReactNode[] {
+function feedPostLines(post: Note, body: Note | null, threads: FeedThread[] | null, cols: number, quotes: Record<string, Note | null> = {}): React.ReactNode[] {
   const w = Math.max(20, cols - 6);
   const real = body ?? post;
   const out: React.ReactNode[] = [];
@@ -122,6 +122,37 @@ function feedPostLines(post: Note, body: Note | null, threads: FeedThread[] | nu
   wrapBlock(real.text || "", w).forEach((l, i) => out.push(<Text key={`b${i}`}>{l}</Text>));
   if (real.image) out.push(<Text key="img" dimColor>[image: {truncateEnd(real.image, Math.max(4, w - 9))}]</Text>);
   if (real.gitLink) out.push(<Text key="git" color={colors.ok}>{glyph.sparkle} {truncateEnd(real.gitLink, Math.max(4, w - 2))}</Text>);
+  // >>note: quote cards, one per ref, hydrated from the quoted author's own table.
+  // Same one-array-entry-per-terminal-row contract as everything above.
+  const qrefs = extractQuoteRefs(real.text);
+  qrefs.forEach((q, qi) => {
+    const qw = Math.max(10, w - 4);
+    const qn = quotes[q.ref];
+    out.push(<Text key={`q${qi}s`}> </Text>);
+    if (qn === undefined) {
+      out.push(<Text key={`q${qi}`} dimColor>{"  "}▌ {">>"}{qi + 1} resolving quote…</Text>);
+    } else if (qn === null) {
+      out.push(<Text key={`q${qi}`} dimColor>{"  "}▌ {">>"}{qi + 1} {feedShort(q.author)} (not found)</Text>);
+    } else {
+      // an untitled note promotes its first line to the title row, and the
+      // snippet then starts from line 2 so the same words never print twice
+      const hasTitle = !!(qn.title ?? "").trim();
+      const qt = hasTitle ? (qn.title ?? "").trim() : ((qn.text ?? "").split("\n")[0] ?? "").trim();
+      const snipText = hasTitle ? (qn.text || "") : (qn.text ?? "").split("\n").slice(1).join("\n");
+      out.push(
+        <Text key={`q${qi}`}>
+          {"  "}<Text color={colors.iqViolet}>▌ </Text>
+          <Text dimColor>{">>"}{qi + 1} </Text>
+          <Text color={walletColor(qn.author)}>{walletFace(qn.author)} </Text>
+          <Text bold color={colors.bone}>{feedShort(qn.author)}</Text>
+          <Text dimColor>  {feedDate(qn.timestamp)}</Text>
+        </Text>,
+      );
+      if (qt) out.push(<Text key={`q${qi}t`}>{"  "}<Text color={colors.iqViolet}>▌ </Text><Text bold color={colors.iqCyan}>{truncateEnd(qt, qw)}</Text></Text>);
+      wrapBlock(snipText, qw).slice(0, 2).forEach((l, li) =>
+        out.push(<Text key={`q${qi}b${li}`}>{"  "}<Text color={colors.iqViolet}>▌ </Text><Text dimColor>{l}</Text></Text>));
+    }
+  });
   out.push(<Text key="sp1"> </Text>);
   const count = threads ? threads.reduce((s, t) => s + 1 + t.replies.length, 0) : (post.feedReplies ?? 0);
   out.push(
@@ -324,6 +355,13 @@ export function SkillMarket({
   const [feedPost, setFeedPost] = useState<Note | null>(null);      // the opened post (mirror row)
   const [feedBody, setFeedBody] = useState<Note | null>(null);      // authoritative body once fetched
   const [feedThreads, setFeedThreads] = useState<FeedThread[] | null>(null);
+  // >>note: quote refs in the open post, hydrated lazily through the same
+  // getBlogPost read the open itself uses. Missing key = resolving, null = deadlink.
+  const [feedQuotes, setFeedQuotes] = useState<Record<string, Note | null>>({});
+  // refs already being fetched for the open post; a Set (not state) so the
+  // mirror-row and authoritative-body passes cannot double-fetch the same ref
+  const feedQuotesPending = useRef<Set<string>>(new Set());
+  const feedQuoteEpoch = useRef(0); // bumped per open; late settles from an old open are dropped
   const [feedScroll, setFeedScroll] = useState(0);
   const [feedCmtText, setFeedCmtText] = useState("");
   const [feedCmtGit, setFeedCmtGit] = useState("");
@@ -623,9 +661,31 @@ export function SkillMarket({
     setFeedBody(null);
     setFeedThreads(null);
     setFeedScroll(0);
+    setFeedQuotes({});
+    feedQuotesPending.current = new Set();
+    // epoch fence: a quote-hop opens a new post while the old post's quote fetches
+    // are still in flight; without the fence a late settle from the OLD open would
+    // write into the NEW post's map (worst case stamping null over a good card)
+    const epoch = ++feedQuoteEpoch.current;
     setStage("feedPost");
-    void api.getBlogPost(p.author, p.id).then(setFeedBody).catch(() => {});
-    void api.getBlogComments(p.id).then(setFeedThreads).catch(() => setFeedThreads([]));
+    hydrateQuotes(p.text, epoch);
+    void api.getBlogPost(p.author, p.id).then((b) => {
+      if (epoch !== feedQuoteEpoch.current) return;
+      setFeedBody(b);
+      if (b) hydrateQuotes(b.text, epoch);
+    }).catch(() => {});
+    void api.getBlogComments(p.id).then((t) => { if (epoch === feedQuoteEpoch.current) setFeedThreads(t); }).catch(() => { if (epoch === feedQuoteEpoch.current) setFeedThreads([]); });
+  }
+
+  // Resolve each >>note: ref once per open, through the same read the open uses.
+  function hydrateQuotes(text: string | undefined, epoch: number) {
+    for (const q of extractQuoteRefs(text)) {
+      if (feedQuotesPending.current.has(q.ref)) continue;
+      feedQuotesPending.current.add(q.ref);
+      void api.getBlogPost(q.author, q.ref)
+        .then((n) => { if (epoch === feedQuoteEpoch.current) setFeedQuotes((prev) => ({ ...prev, [q.ref]: n })); })
+        .catch(() => { if (epoch === feedQuoteEpoch.current) setFeedQuotes((prev) => ({ ...prev, [q.ref]: null })); });
+    }
   }
 
   async function doPostFeedComment() {
@@ -923,13 +983,20 @@ export function SkillMarket({
 
     // ── feed post (issue #210) ─────────────────────────────────────────────
     if (stage === "feedPost" && feedPost) {
-      const total = feedPostLines(feedPost, feedBody, feedThreads, marketCols).length;
+      const total = feedPostLines(feedPost, feedBody, feedThreads, marketCols, feedQuotes).length;
       const height = subViewportH(agentRows, total);
       if (key.escape) { setStage("feed"); setFeedPost(null); setFeedBody(null); setFeedThreads(null); return; }
       if (input === "c") {
         setFeedCmtText(""); setFeedCmtGit(""); setFeedCmtSage(false); setFeedCmtField("text");
         setStage("feedComment");
         return;
+      }
+      // a number key opens the matching resolved quote card in the reader (quote-hop)
+      const hop = Number(input);
+      if (Number.isInteger(hop) && hop >= 1 && hop <= QUOTE_REFS_MAX) {
+        const q = extractQuoteRefs((feedBody ?? feedPost).text)[hop - 1];
+        const qn = q ? feedQuotes[q.ref] : undefined;
+        if (qn) { openFeedPost(qn); return; }
       }
       if (key.downArrow) { setFeedScroll((o) => clampScroll(o + 1, total, height)); return; }
       if (key.upArrow) { setFeedScroll((o) => clampScroll(o - 1, total, height)); return; }
@@ -1263,7 +1330,7 @@ export function SkillMarket({
 
   // ── feed post (issue #210) ────────────────────────────────────────────────
   if (stage === "feedPost" && feedPost) {
-    const lines = feedPostLines(feedPost, feedBody, feedThreads, marketCols);
+    const lines = feedPostLines(feedPost, feedBody, feedThreads, marketCols, feedQuotes);
     const height = subViewportH(agentRows, lines.length);
     return (
       <Box flexDirection="column" paddingX={1} borderStyle="round" borderColor={colors.iqViolet}>
@@ -1275,7 +1342,7 @@ export function SkillMarket({
           <ScrollView lines={lines} height={height} offset={feedScroll} />
         </Box>
         <Box marginTop={1}>
-          <Text dimColor>[c] comment · ↑/↓/PgUp/PgDn scroll · esc back</Text>
+          <Text dimColor>[c] comment{extractQuoteRefs((feedBody ?? feedPost).text).length ? " · [1-4] open quote" : ""} · ↑/↓/PgUp/PgDn scroll · esc back</Text>
         </Box>
       </Box>
     );


### PR DESCRIPTION
Implements the quote ref convention from #212: `>>note:<wallet>:<ms>:<nonce>` in a post or comment hydrates as an inline quote card on VS Code and the CLI. The feed's hyperlink, finishing what blockchan's `>>txSignature` quotelinks start: those resolve only inside one loaded page, a note id makes the quote portable across threads, surfaces, and databases.

## Shape

- **Pure text convention.** No contract, seed, message type, or on-chain change. A ref costs only its bytes; the write path does not know quotes exist.
- **Resolution reuses `getBlogPost` verbatim** on every surface, through the same spoof-proof read an open uses (the author's own table is the truth, the anchor is permissionless). A miss renders as a deadlink, not an error.
- **Lazy and capped** at 4 refs per note, so a pathological note cannot fan out unbounded reads.

## What each layer gets

- **Core**: `extractQuoteRefs` / `parseNoteRef` (the ref grammar, deduped, capped) plus specs. That is all core gets.
- **VS Code panel**: refs in the post body and comments become compact markers with a hydrated card under the paragraph; click opens the quoted post in the reader. Resolution rides the existing `getBlogPost` message, disambiguated from reader opens by an inflight map; quote resolutions pre-seed the reader cache so the click-through is instant.
- **CLI**: cards under the post body, `[1-4]` opens the matching quote in the reader (quote-hop). The footer hints the keys only when refs exist.

## Verified

- Core specs green; full suite 353/353; tsc clean on core, cli, vscode; builds green.
- **Devnet end to end, real writes**: posted a fixture, posted a second post quoting it, watched the real CLI hydrate the card from chain and `[1]`-hop into the quoted post; the deadlink path resolves null and renders dead.

![devnet: a post quoting another post, card hydrated from chain, then the quote-hop](https://github.com/RemilioNubilio/AgentNet/releases/download/pr-assets/quote-demo.png)

- Multi-agent adversarial review over the diff (six lenses: both surfaces' correctness, XSS, template escaping, spec quality, and the five rules) with two refuters per finding; everything that survived was fixed before this PR.

The review confirmed six findings and all six are fixed in this diff: a cross-open hydration race (late settles from a previous post could stamp a stale null over a fresh card; fixed with an open epoch fence), a permanent negative cache in the panel (a transient null read pinned a deadlink for the panel lifetime; nulls are no longer cached so the next render retries), an untitled quote printing its first line twice on the CLI (the snippet now starts at line 2, matching the panel), and a ref grammar divergence between the surfaces plus a greedy nonce with no trailing boundary (both regexes are now byte-identical, pinned to each other by comments on both sides, and a ref glued to alphanumeric text is no match rather than a corrupted id; the grammar matches what buildNote actually mints).

## The five rules, against this diff

1. **No meaningless wrappers.** None added; the only new function-shaped things parse or render.
2. **Reuse first.** Resolution is the existing `getBlogPost` on both surfaces; the CLI imports the core parser. The panel template cannot import core, so it carries its own regex; the two grammars are pinned to each other (see the review note above).
3. **No single-use type variables.** `QuoteRef` is used across core, spec, and the CLI.
4. **No non-essential parameters.** The renderer's `quotes` param is the hydration state the view owns; nothing else changed shape.
5. **Responsibilities stay separated.** Core parses, surfaces render, the read path resolves. Nothing on the write path changed.

Deadlinks stay dead links, quotes stay portable. The feed becomes a web.
