### PR TITLE
Codex: use a supported approval policy for Auto mode

### DIFF
--- a/packages/core/src/runtime/codex-approvals.spec.ts
+++ b/packages/core/src/runtime/codex-approvals.spec.ts
@@ -1,0 +1,71 @@
+import { EventEmitter } from "node:events";
+import { PassThrough, Writable } from "node:stream";
+import { afterEach, describe, expect, it, vi } from "vitest";
+import { spawn } from "node:child_process";
+import { spawnCli } from "./spawn.js";
+
+vi.mock("node:child_process", async (importOriginal) => ({
+  ...await importOriginal<typeof import("node:child_process")>(),
+  spawn: vi.fn(),
+}));
+
+afterEach(() => {
+  vi.unstubAllEnvs();
+  vi.clearAllMocks();
+});
+
+// Exercise the production engine through its JSON-RPC boundary. Only the child
+// transport is simulated; no Codex process, model request or wallet is involved.
+describe.each([undefined, "existing-thread"])("Codex approvals (session %s)", (sessionId) => {
+  it.each([
+    { mode: "auto", override: "", policy: "on-request", sandbox: "workspace-write" },
+    { mode: "readonly", override: "", policy: "on-request", sandbox: "read-only" },
+    { mode: "full", override: "", policy: "never", sandbox: "danger-full-access" },
+    { mode: undefined, override: "", policy: "on-request", sandbox: undefined },
+    { mode: "auto", override: "danger-full-access", policy: "on-request", sandbox: "danger-full-access" },
+    { mode: "readonly", override: "danger-full-access", policy: "on-request", sandbox: "danger-full-access" },
+    { mode: "full", override: "danger-full-access", policy: "never", sandbox: "danger-full-access" },
+  ])("$mode with sandbox override '$override'", async ({ mode, override, policy, sandbox }) => {
+    vi.stubEnv("AGENTNET_CODEX_SANDBOX", override);
+    const requests: { id: number; method: string; params: Record<string, unknown> }[] = [];
+    const stdout = new PassThrough();
+    const stderr = new PassThrough();
+    const child = Object.assign(new EventEmitter(), {
+      stdout,
+      stderr,
+      stdin: new Writable({
+        write(chunk, _encoding, done) {
+          const request = JSON.parse(chunk.toString());
+          requests.push(request);
+          queueMicrotask(() => stdout.write(JSON.stringify({
+            id: request.id,
+            result: { thread: { id: sessionId ?? "new-thread" } },
+          }) + "\n"));
+          done();
+        },
+      }),
+      kill: () => {
+        queueMicrotask(() => {
+          stdout.end();
+          stderr.end();
+          child.emit("exit", 0, null);
+        });
+        return true;
+      },
+    });
+    vi.mocked(spawn).mockReturnValue(child as unknown as ReturnType<typeof spawn>);
+    const engine = spawnCli({ cli: "codex", cwd: process.cwd(), mode, sessionId });
+    const opened = vi.fn();
+    engine.onSessionId(opened);
+    try {
+      await vi.waitFor(() => expect(opened).toHaveBeenCalled());
+      expect(requests.map((r) => r.method)).toEqual([
+        "initialize", sessionId ? "thread/resume" : "thread/start",
+      ]);
+      expect(requests[1].params).toMatchObject({ approvalPolicy: policy, approvalsReviewer: "user" });
+      expect(requests[1].params.sandbox).toBe(sandbox);
+    } finally {
+      engine.stop?.();
+    }
+  });
+});

--- a/packages/core/src/runtime/spawn.ts
+++ b/packages/core/src/runtime/spawn.ts
@@ -145,12 +145,11 @@ function claudePermissionMode(
 
 // Codex approval policy per UI mode. The picker sends "auto" | "readonly" | "full"; the
 // codex app-server takes an approvalPolicy. (Sandbox is a separate axis — see codexSandbox.)
-// Previously the app hardcoded "on-request" and ignored the mode, so the codex chips did
-// nothing; this makes them real.
-function codexApprovalPolicy(mode?: string): "on-request" | "on-failure" | "never" {
+// Auto permits workspace writes through its sandbox; escalation still needs approval.
+// Current app-server versions no longer accept the old "on-failure" policy.
+function codexApprovalPolicy(mode?: string): "on-request" | "never" {
   if (mode === "full") return "never"; // full access, never ask
-  if (mode === "auto") return "on-failure"; // auto-run in the workspace; ask only on failure/escalation
-  return "on-request"; // readonly + default: ask before edits, commands, network
+  return "on-request";
 }
 
 // Codex OS sandbox per UI mode. AGENTNET_CODEX_SANDBOX wins when set (Android forces


### PR DESCRIPTION
Auto mode sends `on-failure` when starting or resuming a Codex thread. Codex CLI 0.153.3's app-server protocol no longer accepts that value. Use `on-request` while retaining the existing `workspace-write` sandbox and user-reviewed approvals. Read-only, Full access and the Android sandbox override keep their existing policy/sandbox combinations.

This updates the existing helper and adds regression tests at the production engine's JSON-RPC boundary. Both Auto start/resume cases fail before the fix and pass afterward. All 442 core tests pass with Chrome required, both core/panel typechecks pass, and the VS Code extension/MCP bundles build. The installed Codex schema independently confirms the accepted policy values. Tests simulate the child transport; no model, wallet or live session is started.

Code rules:

1. No meaningless wrappers with identical input/output: correct the existing policy helper in place.
2. Scan existing functions first and reuse, never two functions with the same purpose: start and resume keep using the shared mapping.
3. No type variables that won't be reused, inline them: narrow the existing inline return type.
4. No non-essential parameters: add no production parameters.
5. Keep responsibilities separated, and say so if the design feels wrong: approval policy and OS sandbox remain separate; tests cover their outgoing combination.
