### PR TITLE
Onboarding: make the Helius key step visually optional (#219)

### DIFF
--- a/surfaces/webview/src/i18n/messages.ts
+++ b/surfaces/webview/src/i18n/messages.ts
@@ -108,6 +108,11 @@ export const M = {
         "완전 선택사항입니다. 기본은 퍼블릭 RPC로 그대로 동작해요. 더 빠른 마켓 인덱싱을 원하면 Helius 키를 붙여넣으세요.",
         "Полностью опционально. По умолчанию работает публичный RPC. Вставьте ключ Helius для более быстрой индексации маркета.",
       ),
+      skipNote: m(
+        "Skipping changes nothing. Everything works on the public RPC, and you can add a key later in Settings.",
+        "건너뛰어도 달라지는 건 없어요. 퍼블릭 RPC로 모든 기능이 그대로 동작하고, 키는 나중에 설정에서 추가할 수 있어요.",
+        "Пропуск ничего не меняет. Всё работает через публичный RPC, а ключ можно добавить позже в настройках.",
+      ),
     },
     skipForNow: m("Skip for now", "지금은 건너뛰기", "Пока пропустить"),
     fundControls: {

--- a/surfaces/webview/src/settings/HeliusKeyForm.tsx
+++ b/surfaces/webview/src/settings/HeliusKeyForm.tsx
@@ -1,11 +1,21 @@
 import { useEffect, useState } from "react";
 import { useStore } from "../state/store";
+import { useT } from "../i18n";
+import { M } from "../i18n/messages";
 
-export function HeliusKeyForm({ onDone, skipLabel = "Use Default" }: { onDone?: () => void; skipLabel?: string }) {
+// `emphasis` decides which action reads as primary. Settings > Helius and the market retry
+// prompt exist to save a key, so "key" (the default) keeps Save Key green. The unlock
+// tutorial's step 03 is optional and most users will never hold a Helius plan, so "skip"
+// puts the green button on skipping, above the key path, with one reassurance line under
+// it, and turns the link and Save Key gray (issue #219). Both variants call the same
+// handlers; the layout and copy change, not the behavior.
+export function HeliusKeyForm({ onDone, skipLabel = "Use Default", emphasis = "key" }: { onDone?: () => void; skipLabel?: string; emphasis?: "key" | "skip" }) {
   const { state, send } = useStore();
+  const t = useT();
   const [key, setKey] = useState("");
   const [saving, setSaving] = useState(false);
   const [expectedTail, setExpectedTail] = useState<string | null>(null);
+  const skipFirst = emphasis === "skip";
 
   useEffect(() => {
     if (saving && expectedTail && state.rpcStatus?.hasKey && state.rpcStatus.masked?.endsWith(expectedTail)) {
@@ -30,6 +40,14 @@ export function HeliusKeyForm({ onDone, skipLabel = "Use Default" }: { onDone?: 
 
   return (
     <div className="flex flex-col gap-3">
+      {skipFirst && (
+        <>
+          <button onClick={clear} className="an-btn an-btn-green w-full">
+            {skipLabel}
+          </button>
+          <p className="text-center text-caption leading-relaxed text-[color:var(--an-fg-mute)]">{t(M.unlock.rpc.skipNote)}</p>
+        </>
+      )}
       <p className="text-xs leading-relaxed text-zinc-500">
         Stored locally, never synced. Speeds up NFT indexing, agent lists, and skill search.
       </p>
@@ -52,23 +70,25 @@ export function HeliusKeyForm({ onDone, skipLabel = "Use Default" }: { onDone?: 
         href="https://www.helius.dev/docs/quickstart"
         target="_blank"
         rel="noreferrer"
-        className="an-term-mono text-[10px] font-bold uppercase tracking-[0.12em] text-[color:var(--an-green)] active:opacity-70"
+        className={`an-term-mono text-[10px] font-bold uppercase tracking-[0.12em] active:opacity-70 ${skipFirst ? "text-[color:var(--an-fg-dim)]" : "text-[color:var(--an-green)]"}`}
       >
         &gt; Get_your_key · helius.dev
       </a>
       <button
         onClick={save}
         disabled={saving || !key.trim()}
-        className="an-btn an-btn-green mt-1 w-full disabled:opacity-50"
+        className={`an-btn mt-1 w-full disabled:opacity-50 ${skipFirst ? "an-btn-outline" : "an-btn-green"}`}
       >
         {saving ? "Saving…" : "Save Key"}
       </button>
-      <button
-        onClick={clear}
-        className="an-term-mono min-h-11 w-full text-[11px] font-semibold uppercase tracking-[0.14em] text-[color:var(--an-fg-dim)] active:opacity-70"
-      >
-        &gt; {skipLabel}
-      </button>
+      {!skipFirst && (
+        <button
+          onClick={clear}
+          className="an-term-mono min-h-11 w-full text-[11px] font-semibold uppercase tracking-[0.14em] text-[color:var(--an-fg-dim)] active:opacity-70"
+        >
+          &gt; {skipLabel}
+        </button>
+      )}
     </div>
   );
 }

--- a/surfaces/webview/src/unlock/UnlockProvider.tsx
+++ b/surfaces/webview/src/unlock/UnlockProvider.tsx
@@ -168,7 +168,7 @@ export function UnlockProvider({ children }: { children: ReactNode }) {
               )}
               {screen === "advanced" && (
                 <StepScreen step={3} title={t(M.unlock.rpc.title)} status={t(M.unlock.rpc.status)} detail={t(M.unlock.rpc.detail)} icon={ICON_RPC}>
-                  <div className="mt-6"><HeliusKeyForm onDone={enterGranted} skipLabel={t(M.unlock.skipForNow)} /></div>
+                  <div className="mt-6"><HeliusKeyForm onDone={enterGranted} skipLabel={t(M.unlock.skipForNow)} emphasis="skip" /></div>
                 </StepScreen>
               )}
               {screen === "done" && (


### PR DESCRIPTION
Step 03 of the unlock tutorial asked for a Helius key with a green Save Key and a gray skip, so an optional step read as a required signup. This inverts the emphasis for onboarding only, as a variant on the shared component, per #219.

## What changed

- `HeliusKeyForm` takes `emphasis?: "key" | "skip"` next to the existing `skipLabel`. `"key"` is the default and renders exactly what shipped; Settings > Helius and the market retry prompt keep it.
- Under `"skip"`, passed only by the unlock step: skip is the full-width `an-btn an-btn-green`, and it sits above the key path so the green button cannot read as "submit the key". One reassurance line under it (`M.unlock.rpc.skipNote`, en, ko, ru). The key path is demoted together: the helius.dev link in `--an-fg-dim`, Save Key as `an-btn-outline`.
- Behavior is untouched: skip still calls `useDefaultRpc` then `onDone`; save still submits the key.
- The input and its label were already on the secondary palette (border `--an-line`, label `--an-fg-dim`), so only the link and Save Key needed a change there.

Three files: `HeliusKeyForm.tsx`, `UnlockProvider.tsx` (one prop), `messages.ts` (one entry).

## Proof

Before and after at phone width. The real localhost host on a throwaway home, the tutorial driven from a locked wallet through step 03 in headless Chrome, 390 px wide:

![before and after, step 03](https://github.com/RemilioNubilio/AgentNet/releases/download/pr-assets/219-before-after-step3.png)

Korean and Russian, same step, same run method:

![step 03 in Korean](https://github.com/RemilioNubilio/AgentNet/releases/download/pr-assets/219-after-ko.png)
![step 03 in Russian](https://github.com/RemilioNubilio/AgentNet/releases/download/pr-assets/219-after-ru.png)

Settings > Market RPC after the change, the default variant, unchanged:

![Settings > Market RPC, unchanged](https://github.com/RemilioNubilio/AgentNet/releases/download/pr-assets/219-settings-market-rpc-unchanged.png)

- `vite build` for surfaces/webview passes. `tsc --noEmit` on the webview reports the same five pre-existing errors as main, none in the changed files; CI does not typecheck the webview.
- Two independent adversarial reviews of the diff (correctness, React, CSS composition, accessibility; then intent versus the issue, copy in all three locales, and the code rules) found no functional defect. They asked for two edits, both applied: the component comment now says the layout and copy change rather than "only the emphasis", and the English note says "you can add a key later in Settings" to match the Cloud_Backup note next to it.

## Code rules

1. No meaningless wrappers: the variant is one conditional block and two class swaps inside the existing component; no new component.
2. Reuse existing functions: the primary is the shared `.an-btn` system, the note is the same `text-caption` line the Cloud_Backup step already renders, and copy goes through `useT` and `M` like every other string on this surface.
3. No single-use type aliases: the prop's union is inline in the props type.
4. No non-essential parameters: `emphasis` is the one thing the call sites differ on. Inferring it from whether `skipLabel` was passed would tie the layout to a label customization, so it is its own prop and says what it means.
5. Responsibilities stay separated: the form keeps its save and skip logic; the caller only states which action is primary.

## Not in this PR

- The market-side prompt text ("Add Helius key for faster results") is unchanged, as the issue notes it is triggered by an actual failure.
- No webview unit test: surfaces/webview has no test harness on main, so the proof is the driven runtime pass above.
