### PR TITLE
chat panel: reuse session and feed data types

### DIFF
--- a/packages/core/src/chat/ui/panel/feed.ts
+++ b/packages/core/src/chat/ui/panel/feed.ts
@@ -11,6 +11,7 @@ import { skId, skSd, skAc, skFd } from "./skeleton.js";
 import { panels, showView } from "./views.js";
 import { gitLinkNode } from "./agents.js";
 import { appendQuoteText } from "./quotes.js";
+import type { Note, ThreadNode, ThreadedReply } from "../../../core/types.js";
 
 // ── helper: a note/comment card (date + on-chain tx link in the footer) ──
 // __txSignature / __blockTime are attached per-row by the gateway and flow through
@@ -50,8 +51,8 @@ export function noteCard(n, withAuthor) {
 // FEED reads the global feed:blog anchor through the same messages the mobile
 // surfaces use (getBlogFeed / getBlogPost / getBlogComments / postBlogComment).
 // RANK is the pre-existing agent directory, unchanged.
-export const feedBodies = {};            // postId -> authoritative body from the author's table
-export const feedThreads = {};           // postId -> comment threads
+export const feedBodies: Record<string, Note | undefined> = {}; // postId -> authoritative body from the author's table
+export const feedThreads: Record<string, ThreadNode[] | undefined> = {}; // postId -> comment threads
 export function openAgents() {
   if (S.agentsTab === 'feed') openFeed(); else openRank();
 }
@@ -85,7 +86,7 @@ export function setFeedSort(s) {
   S.feedPosts = null; // force skeletons: the two sorts are different reads
   openFeed();
 }
-export function renderFeed(posts) {
+export function renderFeed(posts: Note[] | null | undefined) {
   S.feedPosts = posts || [];
   const list = document.getElementById('feedList');
   list.innerHTML = '';
@@ -137,7 +138,7 @@ export function renderFeed(posts) {
 // ── FEED post reader: mirrored row renders instantly; the authoritative body is
 // re-fetched once from the author's own table (trust: the anchor is permissionless),
 // and the comment thread lazy-loads — same semantics as the mobile BlogPostView.
-export function openFeedPost(p) {
+export function openFeedPost(p: Note) {
   S.currentFeedPost = p;
   S.feedReplyTo = null;
   document.getElementById('agFeedPane').style.display = 'none';
@@ -225,7 +226,7 @@ export function renderFeedPost() {
   capC.innerHTML = '<span class="gt">&gt;</span>COMMENTS' + (threads && threads.length ? ' <span class="n">(' + threads.length + ')</span>' : '');
   sec.appendChild(capC);
   const canReply = !!S.myWalletAddress;
-  function commentCard(nn, topAuthor) {
+  function commentCard(nn: ThreadedReply, topAuthor: Note['author']) {
     const el = document.createElement('div'); el.className = 'fdc';
     const top = document.createElement('div'); top.className = 'fdc-top';
     const av = document.createElement('span'); av.className = 'fdc-ava'; av.innerHTML = avatarSvg(nn.author || '');

--- a/packages/core/src/chat/ui/panel/quotes.ts
+++ b/packages/core/src/chat/ui/panel/quotes.ts
@@ -7,6 +7,7 @@ import { vscode } from "./host.js";
 import { agShort, fmtNoteDate } from "./format.js";
 import { quoteCardModel } from "./quoteCard.js";
 import { openFeedPost } from "./feed.js";
+import type { Note } from "../../../core/types.js";
 
 // ── quote refs: ">>note:<wallet>:<ts>:<rand>" in a post body or comment is an
 // on-chain quote-tweet, hydrated through the EXISTING getBlogPost/blogPost pair
@@ -14,9 +15,9 @@ import { openFeedPost } from "./feed.js";
 // and the postId (the whole "note:..." string after the ">>").
 // The grammar and the read cap (QUOTE_REFS_MAX) are core's, so every surface resolves the
 // same refs; the per-view accounting (quoteSeen/quoteSlots in S) is the panel's own.
-export const quoteCache = {};     // postId -> { post: Note|null } once resolved (null = deadlink)
-export const quoteInflight = {};  // postId -> true while its getBlogPost is out
-export function fillQuoteCard(el, id, post) {
+export const quoteCache: Record<string, { post: Note | null } | undefined> = {}; // postId -> resolved post (null = deadlink)
+export const quoteInflight: Record<string, true | undefined> = {}; // postId -> true while its getBlogPost is out
+export function fillQuoteCard(el: HTMLDivElement, id: Note['id'], post: Note | null) {
   el.textContent = '';
   el.classList.remove('fdq-loading');
   if (!post) {
@@ -41,7 +42,7 @@ export function fillQuoteCard(el, id, post) {
 // (post text is attacker-controlled, never innerHTML), each ref becomes a
 // compact inline marker, and per unique ref (capped) a quote card is appended
 // directly under the paragraph.
-export function appendQuoteText(parent, text, cls) {
+export function appendQuoteText(parent: HTMLElement, text: string, cls: string) {
   const p = document.createElement('p'); p.className = cls;
   const cards = [];
   for (const seg of splitQuoteRefs(String(text))) {

--- a/packages/core/src/chat/ui/panel/state.ts
+++ b/packages/core/src/chat/ui/panel/state.ts
@@ -1,3 +1,6 @@
+import type { CloudListState, SessionMeta } from "../../../runtime/contract.js";
+import type { Note } from "../../../core/types.js";
+
 // The panel's mutable state, one store. ESM import bindings are read-only and the message
 // listener (main.ts) plus onMessage write state owned by many modules, so every top-level
 // `let` of the legacy script lives here as S.<name>: every cross-module write is legal and a
@@ -12,9 +15,9 @@ export const S = {
   streamTimer: 0, // trailing timer that defers the next render to the cadence boundary
   lastStreamRender: 0, // when the live bubble was last re-rendered
   // ---- sessions.ts ----
-  allSessions: [] as any[], // last sessions payload from extension
-  cloudListState: 'none', // cloud health of that payload's union (ok/reauth/transient/none)
-  activeId: null as any,
+  allSessions: [] as SessionMeta[], // last sessions payload from extension
+  cloudListState: 'none' as CloudListState, // cloud health of that payload's union (ok/reauth/transient/none)
+  activeId: null as SessionMeta['sessionId'] | null | undefined,
   expanded: false, // "모두 보기" toggled?
   // ---- slash.ts ----
   slashIdx: 0,
@@ -44,14 +47,14 @@ export const S = {
   currentProfileWallet: null as any,
   agentsTab: 'feed', // persists across view switches, same as profileTab
   feedSort: 'active', // ACTIVE = lastActivityTime, LATEST = createdAt
-  feedPosts: null as any, // null = never loaded (skeletons), [] = settled empty
-  currentFeedPost: null as any, // the post open in the reader
+  feedPosts: null as Note[] | null, // null = never loaded (skeletons), [] = settled empty
+  currentFeedPost: null as Note | null, // the post open in the reader
   feedLastSage: false, // whether the comment in flight was sage (skips the fresh re-read)
-  feedReplyTo: null as any, // id of the comment being answered (mobile CommentThreadList idiom)
+  feedReplyTo: null as Note['id'] | null, // id of the comment being answered (mobile CommentThreadList idiom)
   fabModalEl: null as any,
   // ---- quotes.ts ----
-  quoteCards: {} as any, // postId -> [placeholder card elements] awaiting the reply
-  quoteSeen: {} as any, // postId -> true once carded in the current render pass
+  quoteCards: {} as Record<string, HTMLDivElement[] | undefined>, // postId -> [placeholder card elements] awaiting the reply
+  quoteSeen: {} as Record<string, true | undefined>, // postId -> true once carded in the current render pass
   quoteSlots: 0, // unique refs carded in the current render pass
   // ---- agents.ts ----
   lastAgents: [] as any[],


### PR DESCRIPTION
Replace loose session/feed/quote state and cache annotations with the existing SessionMeta, CloudListState, Note, ThreadNode and ThreadedReply types. This is a bounded three-file follow-up to the merged panel migration.

All 428 core tests pass with Chrome required, both core and panel TypeScript checks pass, and rebuilding the generated panel produces byte-for-byte identical JavaScript to current main. No runtime behavior or dependencies change. The broader panel remains non-strict; these annotations do not validate incoming JSON at runtime.

Code rules:

1. No meaningless wrappers with identical input/output.
2. Reuse existing functions; no duplicate implementations.
3. Reuse existing types; no unnecessary type variables.
4. Add no non-essential parameters.
5. Keep responsibilities separated.
