### PR TITLE
fix: keep rejected profile repository URLs non-navigable

### DIFF
--- a/surfaces/webview/src/market/AgentProfileView.tsx
+++ b/surfaces/webview/src/market/AgentProfileView.tsx
@@ -179,7 +179,7 @@ export function noteDate(timestamp?: number) {
 function VerifiedRepoRow({ repo }: { repo: VRepo }) {
   return (
     <a
-      href={safeExternalUrl(repo.url) ?? repo.url}
+      href={safeExternalUrl(repo.url) ?? undefined}
       target="_blank"
       rel="noreferrer"
       className="flex items-center justify-between rounded-xl border px-3 py-2.5 active:opacity-80"


### PR DESCRIPTION
The expanded profile repository row calls safeExternalUrl but restores the original URL when validation rejects it. Remove that fallback so rejected values have no href, consistent with the other repository cards. This addresses the repository-link item in #208 without changing the existing protocol policy.

A local check of the real component covers HTTPS, HTTP, git, data, file and malformed URLs: three cases fail on main and all six pass with this one-line fix. The Vite production build passes. The full webview typecheck reports 12 diagnostics that are identical on unchanged main and this branch. Component verification uses a simulated host; no external link was opened.

Code rules:

1. No meaningless wrappers with identical input/output.
2. Reuse existing functions; no duplicate implementations.
3. Reuse existing types; no unnecessary type variables.
4. Add no non-essential parameters.
5. Keep responsibilities separated.
